### PR TITLE
DOS function

### DIFF
--- a/amset/analytical_band_from_BZT.py
+++ b/amset/analytical_band_from_BZT.py
@@ -89,12 +89,12 @@ class Analytical_bands(object):
             dspwre /= nstv[:,np.newaxis]
     
             #maybe possible a further speed up here
-            for nw in xrange(nwave):
-                for i in xrange(nstv[nw]):
-                    ddspwre[nw] += outer(vec2[nw,i],vec2[nw,i])*(-tempc[nw,i])
-                ddspwre[nw] /= nstv[nw]
-            #out_tempc = out_vec2*(-tempc[:,:,np.newaxis,np.newaxis])
-            #ddspwre = np.sum(out_tempc,axis=1)/ nstv[:,np.newaxis,np.newaxis]
+            #for nw in xrange(nwave):
+                #for i in xrange(nstv[nw]):
+                    #ddspwre[nw] += outer(vec2[nw,i],vec2[nw,i])*(-tempc[nw,i])
+                #ddspwre[nw] /= nstv[nw]
+            out_tempc = out_vec2*(-tempc[:,:,np.newaxis,np.newaxis])
+            ddspwre = np.sum(out_tempc,axis=1)/ nstv[:,np.newaxis,np.newaxis]
         
         ene=spwre.dot(engre)
         if br_dir is not None:
@@ -224,7 +224,7 @@ if __name__ == "__main__":
     engre, latt_points, nwave, nsym, nsymop, symop, br_dir = analytical_bands.get_engre(iband=[cbm_bidx])
     #generate the star functions only one time
     nstv, vec, vec2 = analytical_bands.get_star_functions(latt_points,nsym,symop,nwave,br_dir=br_dir)
-    out_vec2 = np.zeros((nwave,nwave,3,3))
+    out_vec2 = np.zeros((nwave,max(nstv),3,3))
     for nw in xrange(nwave):
         for i in xrange(nstv[nw]):
             out_vec2[nw,i]= outer(vec2[nw,i],vec2[nw,i])

--- a/amset/vasprun.xml
+++ b/amset/vasprun.xml
@@ -1,0 +1,17723 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<modeling>
+ <generator>
+  <i name="program" type="string">vasp </i>
+  <i name="version" type="string">5.2.2  </i>
+  <i name="subversion" type="string">15Apr09 complex  parallel </i>
+  <i name="platform" type="string">unknown </i>
+  <i name="date" type="string">2013 09 23 </i>
+  <i name="time" type="string">16:15:27 </i>
+ </generator>
+ <incar>
+  <i type="string" name="PREC">accurate</i>
+  <i type="string" name="ALGO"> Fast</i>
+  <i type="int" name="ISPIN">     1</i>
+  <i type="int" name="ICHARG">    11</i>
+  <i type="int" name="NELM">   100</i>
+  <i type="int" name="IBRION">    -1</i>
+  <i name="EDIFF">      0.00010000</i>
+  <i type="int" name="NSW">     0</i>
+  <i type="int" name="ISIF">     3</i>
+  <i type="int" name="ISYM">     0</i>
+  <i name="ENCUT">    520.00000000</i>
+  <i type="int" name="NBANDS">    20</i>
+  <i type="int" name="NEDOS">   601</i>
+  <i type="string" name="LREAL"> Auto</i>
+  <i type="int" name="ISMEAR">     0</i>
+  <i name="SIGMA">      0.00100000</i>
+  <i type="logical" name="LWAVE"> F  </i>
+  <i type="logical" name="LCHARG"> F  </i>
+  <i type="logical" name="LORBIT"> F  </i>
+  <i type="int" name="NELM">   100</i>
+  <i type="logical" name="LPEAD"> F  </i>
+  <i type="logical" name="LCALCPOL"> F  </i>
+  <i type="logical" name="LCALCEPS"> F  </i>
+  <v name="EFIELD_PEAD">      0.00000000      0.00000000      0.00000000</v>
+  <i type="logical" name="LEFG"> F  </i>
+ </incar>
+ <kpoints>
+  <varray name="kpointlist" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.06666667       0.00000000       0.00000000 </v>
+   <v>       0.13333333       0.00000000       0.00000000 </v>
+   <v>       0.20000000       0.00000000       0.00000000 </v>
+   <v>       0.26666667       0.00000000       0.00000000 </v>
+   <v>       0.33333333       0.00000000       0.00000000 </v>
+   <v>       0.40000000       0.00000000       0.00000000 </v>
+   <v>       0.46666667       0.00000000       0.00000000 </v>
+   <v>       0.06666667       0.06666667       0.00000000 </v>
+   <v>       0.13333333       0.06666667       0.00000000 </v>
+   <v>       0.20000000       0.06666667       0.00000000 </v>
+   <v>       0.26666667       0.06666667       0.00000000 </v>
+   <v>       0.33333333       0.06666667       0.00000000 </v>
+   <v>       0.40000000       0.06666667       0.00000000 </v>
+   <v>       0.46666667       0.06666667       0.00000000 </v>
+   <v>      -0.46666667       0.06666667       0.00000000 </v>
+   <v>      -0.40000000       0.06666667       0.00000000 </v>
+   <v>      -0.33333333       0.06666667       0.00000000 </v>
+   <v>      -0.26666667       0.06666667       0.00000000 </v>
+   <v>      -0.20000000       0.06666667       0.00000000 </v>
+   <v>      -0.13333333       0.06666667       0.00000000 </v>
+   <v>      -0.06666667       0.06666667       0.00000000 </v>
+   <v>       0.13333333       0.13333333       0.00000000 </v>
+   <v>       0.20000000       0.13333333       0.00000000 </v>
+   <v>       0.26666667       0.13333333       0.00000000 </v>
+   <v>       0.33333333       0.13333333       0.00000000 </v>
+   <v>       0.40000000       0.13333333       0.00000000 </v>
+   <v>       0.46666667       0.13333333       0.00000000 </v>
+   <v>      -0.46666667       0.13333333       0.00000000 </v>
+   <v>      -0.40000000       0.13333333       0.00000000 </v>
+   <v>      -0.33333333       0.13333333       0.00000000 </v>
+   <v>      -0.26666667       0.13333333       0.00000000 </v>
+   <v>      -0.20000000       0.13333333       0.00000000 </v>
+   <v>      -0.13333333       0.13333333       0.00000000 </v>
+   <v>       0.20000000       0.20000000       0.00000000 </v>
+   <v>       0.26666667       0.20000000       0.00000000 </v>
+   <v>       0.33333333       0.20000000       0.00000000 </v>
+   <v>       0.40000000       0.20000000       0.00000000 </v>
+   <v>       0.46666667       0.20000000       0.00000000 </v>
+   <v>      -0.46666667       0.20000000       0.00000000 </v>
+   <v>      -0.40000000       0.20000000       0.00000000 </v>
+   <v>      -0.33333333       0.20000000       0.00000000 </v>
+   <v>      -0.26666667       0.20000000       0.00000000 </v>
+   <v>      -0.20000000       0.20000000       0.00000000 </v>
+   <v>       0.26666667       0.26666667       0.00000000 </v>
+   <v>       0.33333333       0.26666667       0.00000000 </v>
+   <v>       0.40000000       0.26666667       0.00000000 </v>
+   <v>       0.46666667       0.26666667       0.00000000 </v>
+   <v>      -0.46666667       0.26666667       0.00000000 </v>
+   <v>      -0.40000000       0.26666667       0.00000000 </v>
+   <v>      -0.33333333       0.26666667       0.00000000 </v>
+   <v>      -0.26666667       0.26666667       0.00000000 </v>
+   <v>       0.33333333       0.33333333       0.00000000 </v>
+   <v>       0.40000000       0.33333333       0.00000000 </v>
+   <v>       0.46666667       0.33333333       0.00000000 </v>
+   <v>      -0.46666667       0.33333333       0.00000000 </v>
+   <v>      -0.40000000       0.33333333       0.00000000 </v>
+   <v>      -0.33333333       0.33333333       0.00000000 </v>
+   <v>       0.40000000       0.40000000       0.00000000 </v>
+   <v>       0.46666667       0.40000000       0.00000000 </v>
+   <v>      -0.46666667       0.40000000       0.00000000 </v>
+   <v>      -0.40000000       0.40000000       0.00000000 </v>
+   <v>       0.46666667       0.46666667       0.00000000 </v>
+   <v>      -0.46666667       0.46666667       0.00000000 </v>
+   <v>       0.20000000       0.13333333       0.06666667 </v>
+   <v>       0.26666667       0.13333333       0.06666667 </v>
+   <v>       0.33333333       0.13333333       0.06666667 </v>
+   <v>       0.40000000       0.13333333       0.06666667 </v>
+   <v>       0.46666667       0.13333333       0.06666667 </v>
+   <v>      -0.46666667       0.13333333       0.06666667 </v>
+   <v>       0.26666667       0.20000000       0.06666667 </v>
+   <v>       0.33333333       0.20000000       0.06666667 </v>
+   <v>       0.40000000       0.20000000       0.06666667 </v>
+   <v>       0.46666667       0.20000000       0.06666667 </v>
+   <v>      -0.46666667       0.20000000       0.06666667 </v>
+   <v>      -0.40000000       0.20000000       0.06666667 </v>
+   <v>      -0.33333333       0.20000000       0.06666667 </v>
+   <v>      -0.26666667       0.20000000       0.06666667 </v>
+   <v>      -0.20000000       0.20000000       0.06666667 </v>
+   <v>      -0.13333333       0.20000000       0.06666667 </v>
+   <v>       0.33333333       0.26666667       0.06666667 </v>
+   <v>       0.40000000       0.26666667       0.06666667 </v>
+   <v>       0.46666667       0.26666667       0.06666667 </v>
+   <v>      -0.46666667       0.26666667       0.06666667 </v>
+   <v>      -0.40000000       0.26666667       0.06666667 </v>
+   <v>      -0.33333333       0.26666667       0.06666667 </v>
+   <v>      -0.26666667       0.26666667       0.06666667 </v>
+   <v>      -0.20000000       0.26666667       0.06666667 </v>
+   <v>       0.40000000       0.33333333       0.06666667 </v>
+   <v>       0.46666667       0.33333333       0.06666667 </v>
+   <v>      -0.46666667       0.33333333       0.06666667 </v>
+   <v>      -0.40000000       0.33333333       0.06666667 </v>
+   <v>      -0.33333333       0.33333333       0.06666667 </v>
+   <v>      -0.26666667       0.33333333       0.06666667 </v>
+   <v>       0.46666667       0.40000000       0.06666667 </v>
+   <v>      -0.46666667       0.40000000       0.06666667 </v>
+   <v>      -0.40000000       0.40000000       0.06666667 </v>
+   <v>      -0.33333333       0.40000000       0.06666667 </v>
+   <v>      -0.46666667       0.46666667       0.06666667 </v>
+   <v>      -0.40000000       0.46666667       0.06666667 </v>
+   <v>       0.40000000       0.26666667       0.13333333 </v>
+   <v>       0.46666667       0.26666667       0.13333333 </v>
+   <v>      -0.46666667       0.26666667       0.13333333 </v>
+   <v>      -0.40000000       0.26666667       0.13333333 </v>
+   <v>       0.46666667       0.33333333       0.13333333 </v>
+   <v>      -0.46666667       0.33333333       0.13333333 </v>
+   <v>      -0.40000000       0.33333333       0.13333333 </v>
+   <v>      -0.33333333       0.33333333       0.13333333 </v>
+   <v>      -0.26666667       0.33333333       0.13333333 </v>
+   <v>      -0.20000000       0.33333333       0.13333333 </v>
+   <v>      -0.46666667       0.40000000       0.13333333 </v>
+   <v>      -0.40000000       0.40000000       0.13333333 </v>
+   <v>      -0.33333333       0.40000000       0.13333333 </v>
+   <v>      -0.26666667       0.40000000       0.13333333 </v>
+   <v>      -0.40000000       0.46666667       0.13333333 </v>
+   <v>      -0.33333333       0.46666667       0.13333333 </v>
+   <v>      -0.40000000       0.40000000       0.20000000 </v>
+   <v>      -0.33333333       0.40000000       0.20000000 </v>
+   <v>      -0.33333333       0.46666667       0.20000000 </v>
+   <v>      -0.26666667       0.46666667       0.20000000 </v>
+  </varray>
+  <varray name="weights" >
+   <v>       0.00029630 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00237037 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00177778 </v>
+   <v>       0.00355556 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+   <v>       0.01422222 </v>
+   <v>       0.00711111 </v>
+   <v>       0.00711111 </v>
+  </varray>
+ </kpoints>
+ <parameters>
+  <separator name="general" >
+   <i type="string" name="SYSTEM">unknown system</i>
+   <i type="logical" name="LCOMPAT"> F  </i>
+  </separator>
+  <separator name="electronic" >
+   <i type="string" name="PREC">accura</i>
+   <i name="ENMAX">    520.00000000</i>
+   <i name="ENAUG">    391.91400000</i>
+   <i name="EDIFF">      0.00010000</i>
+   <i type="int" name="IALGO">    68</i>
+   <i type="int" name="IWAVPR">    10</i>
+   <i type="int" name="NBANDS">    20</i>
+   <i name="NELECT">     20.00000000</i>
+   <separator name="electronic smearing" >
+    <i type="int" name="ISMEAR">     0</i>
+    <i name="SIGMA">      0.00100000</i>
+   </separator>
+   <separator name="electronic projectors" >
+    <i type="logical" name="LREAL"> T  </i>
+    <v name="ROPT">     -0.00025000     -0.00025000</v>
+    <i type="int" name="LMAXPAW">  -100</i>
+    <i type="int" name="LMAXMIX">     2</i>
+   </separator>
+   <separator name="electronic startup" >
+    <i type="int" name="ISTART">     0</i>
+    <i type="int" name="ICHARG">    11</i>
+    <i type="int" name="INIWAV">     1</i>
+   </separator>
+   <separator name="electronic spin" >
+    <i type="int" name="ISPIN">     1</i>
+    <i type="logical" name="LNONCOLLINEAR"> F  </i>
+    <v name="MAGMOM">      1.00000000      1.00000000</v>
+    <i name="NUPDOWN">     -1.00000000</i>
+    <i type="logical" name="LSORBIT"> F  </i>
+    <v name="SAXIS">      0.00000000      0.00000000      1.00000000</v>
+    <i type="logical" name="LSPIRAL"> F  </i>
+    <v name="QSPIRAL">      0.00000000      0.00000000      0.00000000</v>
+    <i type="logical" name="LZEROZ"> F  </i>
+   </separator>
+   <separator name="electronic exchange-correlation" >
+    <i type="logical" name="LASPH"> F  </i>
+    <i type="logical" name="LMETAGGA"> F  </i>
+   </separator>
+   <separator name="electronic convergence" >
+    <i type="int" name="NELM">   100</i>
+    <i type="int" name="NELMDL">    -5</i>
+    <i type="int" name="NELMIN">     2</i>
+    <i name="ENINI">    520.00000000</i>
+    <separator name="electronic convergence detail" >
+     <i type="logical" name="LDIAG"> T  </i>
+     <i name="WEIMIN">      0.00000000</i>
+     <i name="EBREAK">      0.00000125</i>
+     <i name="DEPER">      0.30000000</i>
+     <i type="int" name="NRMM">     4</i>
+     <i name="TIME">      0.40000000</i>
+    </separator>
+   </separator>
+   <separator name="electronic mixer" >
+    <i name="AMIX">      0.40000000</i>
+    <i name="BMIX">      1.00000000</i>
+    <i name="AMIN">      0.10000000</i>
+    <i name="AMIX_MAG">      1.60000000</i>
+    <i name="BMIX_MAG">      1.00000000</i>
+    <separator name="electronic mixer details" >
+     <i type="int" name="IMIX">     4</i>
+     <i type="int" name="MAXMIX">   -45</i>
+     <i name="WC">    100.00000000</i>
+     <i type="int" name="INIMIX">     1</i>
+     <i type="int" name="MIXPRE">     1</i>
+     <i type="int" name="MREMOVE">     5</i>
+    </separator>
+   </separator>
+   <separator name="electronic dipolcorrection" >
+    <i type="logical" name="LDIPOL"> F  </i>
+    <i type="logical" name="LMONO"> F  </i>
+    <i type="int" name="IDIPOL">     0</i>
+    <i name="EPSILON">      1.00000000</i>
+    <v name="DIPOL">   -100.00000000   -100.00000000   -100.00000000</v>
+    <i name="EFIELD">      0.00000000</i>
+   </separator>
+  </separator>
+  <separator name="grids" >
+   <i type="int" name="NGX">    36</i>
+   <i type="int" name="NGY">    36</i>
+   <i type="int" name="NGZ">    36</i>
+   <i type="int" name="NGXF">    72</i>
+   <i type="int" name="NGYF">    72</i>
+   <i type="int" name="NGZF">    72</i>
+   <i type="logical" name="ADDGRID"> F  </i>
+  </separator>
+  <separator name="ionic" >
+   <i type="int" name="NSW">     0</i>
+   <i type="int" name="IBRION">    -1</i>
+   <i type="int" name="ISIF">     3</i>
+   <i name="PSTRESS">      0.00000000</i>
+   <i name="EDIFFG">      0.00100000</i>
+   <i type="int" name="NFREE">     0</i>
+   <i name="POTIM">      0.50000000</i>
+   <i name="SMASS">     -3.00000000</i>
+  </separator>
+  <separator name="ionic md" >
+   <i name="TEBEG">      0.00010000</i>
+   <i name="TEEND">      0.00010000</i>
+   <i type="int" name="NBLOCK">     1</i>
+   <i type="int" name="KBLOCK">     1</i>
+   <i type="int" name="NPACO">   256</i>
+   <i name="APACO">     16.00000000</i>
+  </separator>
+  <separator name="symmetry" >
+   <i type="int" name="ISYM">     0</i>
+   <i name="SYMPREC">      0.00001000</i>
+  </separator>
+  <separator name="dos" >
+   <i type="logical" name="LORBIT"> T  </i>
+   <v name="RWIGS">     -1.00000000     -1.00000000</v>
+   <i type="int" name="NEDOS">   601</i>
+   <i name="EMIN">     10.00000000</i>
+   <i name="EMAX">    -10.00000000</i>
+   <i name="EFERMI">      0.00000000</i>
+  </separator>
+  <separator name="writing" >
+   <i type="int" name="NWRITE">     2</i>
+   <i type="logical" name="LWAVE"> F  </i>
+   <i type="logical" name="LCHARG"> F  </i>
+   <i type="logical" name="LPARD"> F  </i>
+   <i type="logical" name="LVTOT"> F  </i>
+   <i type="logical" name="LELF"> F  </i>
+   <i type="logical" name="LOPTICS"> F  </i>
+   <v name="STM">      0.00000000      0.00000000      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="performance" >
+   <i type="int" name="NPAR">     2</i>
+   <i type="int" name="NSIM">     4</i>
+   <i type="int" name="NBLK">    32</i>
+   <i type="logical" name="LPLANE"> T  </i>
+   <i type="logical" name="LSCALAPACK"> F  </i>
+   <i type="logical" name="LSCAAWARE"> F  </i>
+   <i type="logical" name="LSCALU"> F  </i>
+   <i type="logical" name="LASYNC"> F  </i>
+  </separator>
+  <separator name="miscellaneous" >
+   <i type="int" name="IDIOT">     3</i>
+   <i type="logical" name="LMUSIC"> F  </i>
+   <v name="POMASS">    127.60000000    207.20000000</v>
+   <i type="logical" name="LCORR"> T  </i>
+  </separator>
+  <i type="logical" name="LREAL_COMPAT"> F  </i>
+  <i type="logical" name="GGA_COMPAT"> T  </i>
+  <i type="logical" name="LBERRY"> F  </i>
+  <i type="int" name="ICORELEVEL">     0</i>
+  <i type="logical" name="LDAU"> F  </i>
+  <i type="int" name="I_CONSTRAINED_M">     0</i>
+  <separator name="electronic exchange-correlation" >
+   <i type="string" name="GGA">--</i>
+   <i type="int" name="VOSKOWN">     0</i>
+   <i type="logical" name="LHFCALC"> F  </i>
+   <i type="logical" name="LHFONE"> F  </i>
+   <i type="logical" name="LRHFCALC"> F  </i>
+   <i type="logical" name="LTHOMAS"> F  </i>
+   <i type="logical" name="LMODELHF"> F  </i>
+   <i name="ENCUTFOCK">      0.00000000</i>
+   <i name="ENCUT4O">     -1.00000000</i>
+   <i type="int" name="EXXOEP">     0</i>
+   <i type="int" name="FOURORBIT">     0</i>
+   <i name="AEXX">      0.00000000</i>
+   <i name="HFALPHA">      0.00000000</i>
+   <i name="ALDAX">      1.00000000</i>
+   <i name="AGGAX">      1.00000000</i>
+   <i name="ALDAC">      1.00000000</i>
+   <i name="AGGAC">      1.00000000</i>
+   <i type="int" name="NKREDX">     1</i>
+   <i type="int" name="NKREDY">     1</i>
+   <i type="int" name="NKREDZ">     1</i>
+   <i type="logical" name="SHIFTRED"> F  </i>
+   <i type="logical" name="ODDONLY"> F  </i>
+   <i type="logical" name="EVENONLY"> F  </i>
+   <i type="int" name="LMAXFOCK">     0</i>
+   <i type="int" name="NMAXFOCKAE">     0</i>
+   <i name="HFSCREEN">      0.00000000</i>
+   <i name="HFSCREENC">      0.00000000</i>
+  </separator>
+  <separator name="model GW" >
+   <i type="int" name="MODEL_GW">     0</i>
+   <i name="MODEL_EPS0">     21.23304667</i>
+   <i name="MODEL_ALPHA">      1.00000000</i>
+  </separator>
+  <separator name="linear response parameters" >
+   <i type="logical" name="LEPSILON"> F  </i>
+   <i type="logical" name="LRPA"> F  </i>
+   <i type="logical" name="LNABLA"> F  </i>
+   <i type="logical" name="LVEL"> F  </i>
+   <i type="int" name="KINTER">     0</i>
+   <i name="CSHIFT">      0.10000000</i>
+   <i name="OMEGAMAX">     -1.00000000</i>
+  </separator>
+  <separator name="orbital magnetization" >
+   <i type="logical" name="ORBITALMAG"> F  </i>
+   <i type="logical" name="LMAGBLOCH"> F  </i>
+   <i type="logical" name="LCHIMAG"> F  </i>
+   <i type="logical" name="LGAUGE"> T  </i>
+   <i type="int" name="MAGATOM">     0</i>
+   <v name="MAGDIPOL">      0.00000000      0.00000000      0.00000000</v>
+   <v name="AVECCONST">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <separator name="response functions" >
+   <i type="logical" name="LRPA"> T  </i>
+   <i type="logical" name="LTCTE"> F  </i>
+   <i type="logical" name="LTETE"> F  </i>
+   <i type="logical" name="L2ORDER"> F  </i>
+   <i type="logical" name="LGWLF"> F  </i>
+   <i name="ENCUTGW">    346.66666667</i>
+   <i name="ENCUTGWSOFT">     -2.00000000</i>
+   <i name="ENCUTLF">     -1.00000000</i>
+   <i type="int" name="LMAXMP2">    -1</i>
+   <i name="SCISSOR">      0.00000000</i>
+   <i type="int" name="NOMEGA">     0</i>
+   <i type="int" name="NOMEGAR">     0</i>
+   <i type="int" name="NBANDSGW">    -1</i>
+   <i type="int" name="NBANDSLF">    -1</i>
+   <i type="int" name="NELM">   100</i>
+   <i type="int" name="DIM">     3</i>
+   <i type="int" name="ANTIRES">     0</i>
+   <i type="logical" name="LUSEW"> F  </i>
+   <i name="OMEGAMAX">    -30.00000000</i>
+   <i name="OMEGATL">   -200.00000000</i>
+   <i type="int" name="OMEGAGRID">     0</i>
+   <i name="CSHIFT">     -0.10000000</i>
+   <i type="logical" name="SELFENERGY"> F  </i>
+   <i type="logical" name="LSPECTRAL"> F  </i>
+   <i type="logical" name="ODDONLYGW"> F  </i>
+   <i type="logical" name="EVENONLYGW"> F  </i>
+   <i type="int" name="NKREDLFX">     1</i>
+   <i type="int" name="NKREDLFY">     1</i>
+   <i type="int" name="NKREDLFZ">     1</i>
+   <i type="int" name="MAXMEM">  1024</i>
+   <i type="int" name="TELESCOPE">     0</i>
+  </separator>
+ </parameters>
+ <atominfo>
+  <atoms>       2 </atoms>
+  <types>       2 </types>
+  <array name="atoms" >
+   <dimension dim="1">ion</dimension>
+   <field type="string">element</field>
+   <field type="int">atomtype</field>
+   <set>
+    <rc><c>Te</c><c>   1</c></rc>
+    <rc><c>Pb</c><c>   2</c></rc>
+   </set>
+  </array>
+  <array name="atomtypes" >
+   <dimension dim="1">type</dimension>
+   <field type="int">atomspertype</field>
+   <field type="string">element</field>
+   <field>mass</field>
+   <field>valence</field>
+   <field type="string">pseudopotential</field>
+   <set>
+    <rc><c>   1</c><c>Te</c><c>    127.60000000</c><c>      6.00000000</c><c> PAW_PBE Te 08Apr2002                   </c></rc>
+    <rc><c>   1</c><c>Pb</c><c>    207.20000000</c><c>     14.00000000</c><c> PAW_PBE Pb_d 06Sep2000                 </c></rc>
+   </set>
+  </array>
+ </atominfo>
+ <structure name="initialpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       0.00000000       3.28312200       3.28312200 </v>
+    <v>       3.28312200       0.00000000       3.28312200 </v>
+    <v>       3.28312200       3.28312200       0.00000000 </v>
+   </varray>
+   <i name="volume">     70.77682223 </i>
+   <varray name="rec_basis" >
+    <v>      -0.15229407       0.15229407       0.15229407 </v>
+    <v>       0.15229407      -0.15229407       0.15229407 </v>
+    <v>       0.15229407       0.15229407      -0.15229407 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.50000000       0.50000000       0.50000000 </v>
+  </varray>
+ </structure>
+ <calculation>
+  <scstep>
+   <time name="dav">    4.84    4.95</time>
+   <time name="total">    5.35    5.56</time>
+   <energy>
+    <i name="alphaZ">     34.23942152 </i>
+    <i name="ewald">  -1367.07711238 </i>
+    <i name="hartreedc">   -511.88782808 </i>
+    <i name="XCdc">      9.44187696 </i>
+    <i name="pawpsdc">   1333.58181230 </i>
+    <i name="pawaedc">  -1277.49825912 </i>
+    <i name="eentropy">     -0.00000126 </i>
+    <i name="bandstr">     51.25340445 </i>
+    <i name="atom">   1884.46920649 </i>
+    <i name="e_fr_energy">    156.52252089 </i>
+    <i name="e_wo_entrp">    156.52252215 </i>
+    <i name="e_0_energy">    156.52252152 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    4.72    4.74</time>
+   <time name="total">    4.75    4.76</time>
+   <energy>
+    <i name="e_fr_energy">      4.21884362 </i>
+    <i name="e_wo_entrp">      4.21884728 </i>
+    <i name="e_0_energy">      4.21884545 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    5.33    5.36</time>
+   <time name="total">    5.34    5.36</time>
+   <energy>
+    <i name="e_fr_energy">     -7.30861040 </i>
+    <i name="e_wo_entrp">     -7.30861040 </i>
+    <i name="e_0_energy">     -7.30861040 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    5.15    5.16</time>
+   <time name="total">    5.15    5.16</time>
+   <energy>
+    <i name="e_fr_energy">     -7.65087824 </i>
+    <i name="e_wo_entrp">     -7.65087824 </i>
+    <i name="e_0_energy">     -7.65087824 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="dav">    5.78    5.79</time>
+   <time name="total">    5.78    5.79</time>
+   <energy>
+    <i name="e_fr_energy">     -7.66603318 </i>
+    <i name="e_wo_entrp">     -7.66603318 </i>
+    <i name="e_0_energy">     -7.66603318 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.94    0.95</time>
+   <time name="diis">    8.36    8.42</time>
+   <time name="orth">    0.08    0.08</time>
+   <time name="total">    9.39    9.45</time>
+   <energy>
+    <i name="e_fr_energy">     -7.66643087 </i>
+    <i name="e_wo_entrp">     -7.66643087 </i>
+    <i name="e_0_energy">     -7.66643087 </i>
+   </energy>
+  </scstep>
+  <scstep>
+   <time name="diag">    0.77    0.77</time>
+   <time name="diis">    3.56    3.57</time>
+   <time name="orth">    0.08    0.08</time>
+   <time name="total">    4.41    4.42</time>
+   <energy>
+    <i name="alphaZ">     34.23942152 </i>
+    <i name="ewald">  -1367.07711238 </i>
+    <i name="hartreedc">   -511.88782808 </i>
+    <i name="XCdc">      9.44187696 </i>
+    <i name="pawpsdc">   1333.58181230 </i>
+    <i name="pawaedc">  -1277.49825912 </i>
+    <i name="eentropy">      0.00000000 </i>
+    <i name="bandstr">   -112.93558440 </i>
+    <i name="atom">   1884.46920649 </i>
+    <i name="e_fr_energy">     -7.66646670 </i>
+    <i name="e_wo_entrp">     -7.66646670 </i>
+    <i name="e_0_energy">     -7.66646670 </i>
+   </energy>
+  </scstep>
+  <structure>
+   <crystal>
+    <varray name="basis" >
+     <v>       0.00000000       3.28312200       3.28312200 </v>
+     <v>       3.28312200       0.00000000       3.28312200 </v>
+     <v>       3.28312200       3.28312200       0.00000000 </v>
+    </varray>
+    <i name="volume">     70.77682223 </i>
+    <varray name="rec_basis" >
+     <v>      -0.15229407       0.15229407       0.15229407 </v>
+     <v>       0.15229407      -0.15229407       0.15229407 </v>
+     <v>       0.15229407       0.15229407      -0.15229407 </v>
+    </varray>
+   </crystal>
+   <varray name="positions" >
+    <v>       0.00000000       0.00000000       0.00000000 </v>
+    <v>       0.50000000       0.50000000       0.50000000 </v>
+   </varray>
+  </structure>
+  <varray name="forces" >
+   <v>      -0.00008452       0.00005761       0.00008506 </v>
+   <v>       0.00008452      -0.00005761      -0.00008506 </v>
+  </varray>
+  <varray name="stress" >
+   <v>       9.46638188      76.32106238      29.16873410 </v>
+   <v>      76.32109431     102.24703475     -45.76936730 </v>
+   <v>      29.16872978     -45.76935698    -108.03653377 </v>
+  </varray>
+  <energy>
+   <i name="e_fr_energy">     -7.66646670 </i>
+   <i name="e_wo_entrp">     -7.66646670 </i>
+   <i name="e_0_energy">      0.00000000 </i>
+  </energy>
+  <time name="totalsc">   45.55   45.93</time>
+  <eigenvalues>
+   <array>
+    <dimension dim="1">band</dimension>
+    <dimension dim="2">kpoint</dimension>
+    <dimension dim="3">spin</dimension>
+    <field>eigene</field>
+    <field>occ</field>
+    <set>
+     <set comment="spin 1">
+      <set comment="kpoint 1">
+       <r>  -11.6752    1.0000 </r>
+       <r>  -11.6752    1.0000 </r>
+       <r>  -11.6668    1.0000 </r>
+       <r>  -11.6668    1.0000 </r>
+       <r>  -11.6668    1.0000 </r>
+       <r>   -6.5891    1.0000 </r>
+       <r>   -0.6273    1.0000 </r>
+       <r>    3.8650    1.0000 </r>
+       <r>    3.8650    1.0000 </r>
+       <r>    3.8650    1.0000 </r>
+       <r>    9.0634    0.0000 </r>
+       <r>    9.0634    0.0000 </r>
+       <r>    9.0634    0.0000 </r>
+       <r>   10.9300    0.0000 </r>
+       <r>   10.9300    0.0000 </r>
+       <r>   10.9300    0.0000 </r>
+       <r>   12.4676    0.0000 </r>
+       <r>   12.5580    0.0000 </r>
+       <r>   12.9992    0.0000 </r>
+       <r>   12.9992    0.0000 </r>
+      </set>
+      <set comment="kpoint 2">
+       <r>  -11.6755    1.0000 </r>
+       <r>  -11.6755    1.0000 </r>
+       <r>  -11.6667    1.0000 </r>
+       <r>  -11.6663    1.0000 </r>
+       <r>  -11.6663    1.0000 </r>
+       <r>   -6.5534    1.0000 </r>
+       <r>   -0.7398    1.0000 </r>
+       <r>    3.8755    1.0000 </r>
+       <r>    3.8755    1.0000 </r>
+       <r>    3.9272    1.0000 </r>
+       <r>    8.8082    0.0000 </r>
+       <r>    8.8818    0.0000 </r>
+       <r>    8.8818    0.0000 </r>
+       <r>   10.8561    0.0000 </r>
+       <r>   11.0134    0.0000 </r>
+       <r>   11.0134    0.0000 </r>
+       <r>   12.7707    0.0000 </r>
+       <r>   12.9045    0.0000 </r>
+       <r>   13.2469    0.0000 </r>
+       <r>   13.2469    0.0000 </r>
+      </set>
+      <set comment="kpoint 3">
+       <r>  -11.6767    1.0000 </r>
+       <r>  -11.6767    1.0000 </r>
+       <r>  -11.6664    1.0000 </r>
+       <r>  -11.6648    1.0000 </r>
+       <r>  -11.6648    1.0000 </r>
+       <r>   -6.4476    1.0000 </r>
+       <r>   -1.0485    1.0000 </r>
+       <r>    3.9076    1.0000 </r>
+       <r>    3.9076    1.0000 </r>
+       <r>    4.0876    1.0000 </r>
+       <r>    8.2493    0.0000 </r>
+       <r>    8.4476    0.0000 </r>
+       <r>    8.4476    0.0000 </r>
+       <r>   10.7812    0.0000 </r>
+       <r>   11.2488    0.0000 </r>
+       <r>   11.2488    0.0000 </r>
+       <r>   13.4897    0.0000 </r>
+       <r>   13.7682    0.0000 </r>
+       <r>   13.8916    0.0000 </r>
+       <r>   13.8916    0.0000 </r>
+      </set>
+      <set comment="kpoint 4">
+       <r>  -11.6787    1.0000 </r>
+       <r>  -11.6787    1.0000 </r>
+       <r>  -11.6660    1.0000 </r>
+       <r>  -11.6624    1.0000 </r>
+       <r>  -11.6624    1.0000 </r>
+       <r>   -6.2757    1.0000 </r>
+       <r>   -1.4886    1.0000 </r>
+       <r>    3.9622    1.0000 </r>
+       <r>    3.9622    1.0000 </r>
+       <r>    4.2933    1.0000 </r>
+       <r>    7.6301    0.0000 </r>
+       <r>    7.9263    0.0000 </r>
+       <r>    7.9263    0.0000 </r>
+       <r>   10.8679    0.0000 </r>
+       <r>   11.6206    0.0000 </r>
+       <r>   11.6206    0.0000 </r>
+       <r>   14.4083    0.0000 </r>
+       <r>   14.7757    0.0000 </r>
+       <r>   14.7757    0.0000 </r>
+       <r>   14.9063    0.0000 </r>
+      </set>
+      <set comment="kpoint 5">
+       <r>  -11.6811    1.0000 </r>
+       <r>  -11.6811    1.0000 </r>
+       <r>  -11.6654    1.0000 </r>
+       <r>  -11.6594    1.0000 </r>
+       <r>  -11.6594    1.0000 </r>
+       <r>   -6.0464    1.0000 </r>
+       <r>   -1.9929    1.0000 </r>
+       <r>    4.0386    1.0000 </r>
+       <r>    4.0386    1.0000 </r>
+       <r>    4.5038    1.0000 </r>
+       <r>    7.0507    0.0000 </r>
+       <r>    7.4160    0.0000 </r>
+       <r>    7.4160    0.0000 </r>
+       <r>   11.1692    0.0000 </r>
+       <r>   12.1202    0.0000 </r>
+       <r>   12.1202    0.0000 </r>
+       <r>   15.3527    0.0000 </r>
+       <r>   15.7941    0.0000 </r>
+       <r>   15.7941    0.0000 </r>
+       <r>   16.1596    0.0000 </r>
+      </set>
+      <set comment="kpoint 6">
+       <r>  -11.6835    1.0000 </r>
+       <r>  -11.6835    1.0000 </r>
+       <r>  -11.6650    1.0000 </r>
+       <r>  -11.6565    1.0000 </r>
+       <r>  -11.6565    1.0000 </r>
+       <r>   -5.7774    1.0000 </r>
+       <r>   -2.5002    1.0000 </r>
+       <r>    4.1305    1.0000 </r>
+       <r>    4.1305    1.0000 </r>
+       <r>    4.7035    1.0000 </r>
+       <r>    6.5490    0.0000 </r>
+       <r>    6.9714    0.0000 </r>
+       <r>    6.9714    0.0000 </r>
+       <r>   11.6822    0.0000 </r>
+       <r>   12.7353    0.0000 </r>
+       <r>   12.7353    0.0000 </r>
+       <r>   15.8003    0.0000 </r>
+       <r>   16.8147    0.0000 </r>
+       <r>   16.8210    0.0000 </r>
+       <r>   17.4373    0.0000 </r>
+      </set>
+      <set comment="kpoint 7">
+       <r>  -11.6854    1.0000 </r>
+       <r>  -11.6854    1.0000 </r>
+       <r>  -11.6647    1.0000 </r>
+       <r>  -11.6542    1.0000 </r>
+       <r>  -11.6542    1.0000 </r>
+       <r>   -5.5070    1.0000 </r>
+       <r>   -2.9435    1.0000 </r>
+       <r>    4.2210    1.0000 </r>
+       <r>    4.2210    1.0000 </r>
+       <r>    4.8883    1.0000 </r>
+       <r>    6.1482    0.0000 </r>
+       <r>    6.6347    0.0000 </r>
+       <r>    6.6347    0.0000 </r>
+       <r>   12.3733    0.0000 </r>
+       <r>   13.4410    0.0000 </r>
+       <r>   13.4409    0.0000 </r>
+       <r>   15.2625    0.0000 </r>
+       <r>   16.5149    0.0000 </r>
+       <r>   16.5149    0.0000 </r>
+       <r>   18.1998    0.0000 </r>
+      </set>
+      <set comment="kpoint 8">
+       <r>  -11.6864    1.0000 </r>
+       <r>  -11.6864    1.0000 </r>
+       <r>  -11.6645    1.0000 </r>
+       <r>  -11.6530    1.0000 </r>
+       <r>  -11.6530    1.0000 </r>
+       <r>   -5.3168    1.0000 </r>
+       <r>   -3.2243    1.0000 </r>
+       <r>    4.2806    1.0000 </r>
+       <r>    4.2806    1.0000 </r>
+       <r>    5.0281    1.0000 </r>
+       <r>    5.8955    0.0000 </r>
+       <r>    6.4490    0.0000 </r>
+       <r>    6.4490    0.0000 </r>
+       <r>   13.1470    0.0000 </r>
+       <r>   14.1299    0.0000 </r>
+       <r>   14.1299    0.0000 </r>
+       <r>   14.4047    0.0000 </r>
+       <r>   15.6705    0.0000 </r>
+       <r>   15.6706    0.0000 </r>
+       <r>   19.1836    0.0000 </r>
+      </set>
+      <set comment="kpoint 9">
+       <r>  -11.6765    1.0000 </r>
+       <r>  -11.6748    1.0000 </r>
+       <r>  -11.6671    1.0000 </r>
+       <r>  -11.6659    1.0000 </r>
+       <r>  -11.6659    1.0000 </r>
+       <r>   -6.5415    1.0000 </r>
+       <r>   -0.7705    1.0000 </r>
+       <r>    3.7914    1.0000 </r>
+       <r>    3.7914    1.0000 </r>
+       <r>    4.1141    1.0000 </r>
+       <r>    8.3553    0.0000 </r>
+       <r>    9.0644    0.0000 </r>
+       <r>    9.0644    0.0000 </r>
+       <r>   10.6264    0.0000 </r>
+       <r>   11.1635    0.0000 </r>
+       <r>   11.1635    0.0000 </r>
+       <r>   12.6556    0.0000 </r>
+       <r>   12.9774    0.0000 </r>
+       <r>   13.0446    0.0000 </r>
+       <r>   13.7169    0.0000 </r>
+      </set>
+      <set comment="kpoint 10">
+       <r>  -11.6782    1.0000 </r>
+       <r>  -11.6749    1.0000 </r>
+       <r>  -11.6672    1.0000 </r>
+       <r>  -11.6648    1.0000 </r>
+       <r>  -11.6646    1.0000 </r>
+       <r>   -6.4592    1.0000 </r>
+       <r>   -0.9971    1.0000 </r>
+       <r>    3.7352    1.0000 </r>
+       <r>    3.7591    1.0000 </r>
+       <r>    4.3519    1.0000 </r>
+       <r>    7.7514    0.0000 </r>
+       <r>    8.8585    0.0000 </r>
+       <r>    8.9046    0.0000 </r>
+       <r>   10.4728    0.0000 </r>
+       <r>   11.3735    0.0000 </r>
+       <r>   11.4485    0.0000 </r>
+       <r>   13.0167    0.0000 </r>
+       <r>   13.3398    0.0000 </r>
+       <r>   13.5856    0.0000 </r>
+       <r>   14.5253    0.0000 </r>
+      </set>
+      <set comment="kpoint 11">
+       <r>  -11.6804    1.0000 </r>
+       <r>  -11.6762    1.0000 </r>
+       <r>  -11.6668    1.0000 </r>
+       <r>  -11.6630    1.0000 </r>
+       <r>  -11.6621    1.0000 </r>
+       <r>   -6.3095    1.0000 </r>
+       <r>   -1.3740    1.0000 </r>
+       <r>    3.7150    1.0000 </r>
+       <r>    3.7912    1.0000 </r>
+       <r>    4.5700    1.0000 </r>
+       <r>    7.1749    0.0000 </r>
+       <r>    8.3956    0.0000 </r>
+       <r>    8.5125    0.0000 </r>
+       <r>   10.5036    0.0000 </r>
+       <r>   11.6399    0.0000 </r>
+       <r>   11.8441    0.0000 </r>
+       <r>   13.7694    0.0000 </r>
+       <r>   14.0323    0.0000 </r>
+       <r>   14.5626    0.0000 </r>
+       <r>   15.4855    0.0000 </r>
+      </set>
+      <set comment="kpoint 12">
+       <r>  -11.6829    1.0000 </r>
+       <r>  -11.6783    1.0000 </r>
+       <r>  -11.6661    1.0000 </r>
+       <r>  -11.6608    1.0000 </r>
+       <r>  -11.6592    1.0000 </r>
+       <r>   -6.0994    1.0000 </r>
+       <r>   -1.8400    1.0000 </r>
+       <r>    3.7371    1.0000 </r>
+       <r>    3.8640    1.0000 </r>
+       <r>    4.7177    1.0000 </r>
+       <r>    6.7099    0.0000 </r>
+       <r>    7.8790    0.0000 </r>
+       <r>    8.0339    0.0000 </r>
+       <r>   10.7229    0.0000 </r>
+       <r>   12.0424    0.0000 </r>
+       <r>   12.3524    0.0000 </r>
+       <r>   14.6913    0.0000 </r>
+       <r>   14.9524    0.0000 </r>
+       <r>   15.7631    0.0000 </r>
+       <r>   16.4724    0.0000 </r>
+      </set>
+      <set comment="kpoint 13">
+       <r>  -11.6853    1.0000 </r>
+       <r>  -11.6808    1.0000 </r>
+       <r>  -11.6653    1.0000 </r>
+       <r>  -11.6582    1.0000 </r>
+       <r>  -11.6562    1.0000 </r>
+       <r>   -5.8431    1.0000 </r>
+       <r>   -2.3344    1.0000 </r>
+       <r>    3.8043    1.0000 </r>
+       <r>    3.9550    1.0000 </r>
+       <r>    4.7485    1.0000 </r>
+       <r>    6.4238    0.0000 </r>
+       <r>    7.4019    0.0000 </r>
+       <r>    7.5568    0.0000 </r>
+       <r>   11.1423    0.0000 </r>
+       <r>   12.5871    0.0000 </r>
+       <r>   12.9670    0.0000 </r>
+       <r>   15.4721    0.0000 </r>
+       <r>   15.9549    0.0000 </r>
+       <r>   17.0117    0.0000 </r>
+       <r>   17.2114    0.0000 </r>
+      </set>
+      <set comment="kpoint 14">
+       <r>  -11.6870    1.0000 </r>
+       <r>  -11.6832    1.0000 </r>
+       <r>  -11.6646    1.0000 </r>
+       <r>  -11.6558    1.0000 </r>
+       <r>  -11.6539    1.0000 </r>
+       <r>   -5.5701    1.0000 </r>
+       <r>   -2.7942    1.0000 </r>
+       <r>    3.9135    1.0000 </r>
+       <r>    4.0273    1.0000 </r>
+       <r>    4.6845    1.0000 </r>
+       <r>    6.3199    0.0000 </r>
+       <r>    7.0260    0.0000 </r>
+       <r>    7.1289    0.0000 </r>
+       <r>   11.7468    0.0000 </r>
+       <r>   13.2571    0.0000 </r>
+       <r>   13.6602    0.0000 </r>
+       <r>   15.2933    0.0000 </r>
+       <r>   16.2823    0.0000 </r>
+       <r>   17.3380    0.0000 </r>
+       <r>   17.4828    0.0000 </r>
+      </set>
+      <set comment="kpoint 15">
+       <r>  -11.6879    1.0000 </r>
+       <r>  -11.6850    1.0000 </r>
+       <r>  -11.6642    1.0000 </r>
+       <r>  -11.6541    1.0000 </r>
+       <r>  -11.6527    1.0000 </r>
+       <r>   -5.3445    1.0000 </r>
+       <r>   -3.1340    1.0000 </r>
+       <r>    4.0043    1.0000 </r>
+       <r>    4.0530    1.0000 </r>
+       <r>    4.6662    1.0000 </r>
+       <r>    6.2580    0.0000 </r>
+       <r>    6.7837    0.0000 </r>
+       <r>    6.8630    0.0000 </r>
+       <r>   12.4882    0.0000 </r>
+       <r>   14.0080    0.0000 </r>
+       <r>   14.2788    0.0000 </r>
+       <r>   14.4445    0.0000 </r>
+       <r>   15.5969    0.0000 </r>
+       <r>   16.6375    0.0000 </r>
+       <r>   18.5008    0.0000 </r>
+      </set>
+      <set comment="kpoint 16">
+       <r>  -11.6876    1.0000 </r>
+       <r>  -11.6859    1.0000 </r>
+       <r>  -11.6641    1.0000 </r>
+       <r>  -11.6533    1.0000 </r>
+       <r>  -11.6528    1.0000 </r>
+       <r>   -5.2737    1.0000 </r>
+       <r>   -3.2349    1.0000 </r>
+       <r>    3.8726    1.0000 </r>
+       <r>    4.1966    1.0000 </r>
+       <r>    4.7647    1.0000 </r>
+       <r>    6.1296    0.0000 </r>
+       <r>    6.5564    0.0000 </r>
+       <r>    6.9863    0.0000 </r>
+       <r>   13.0355    0.0000 </r>
+       <r>   13.8228    0.0000 </r>
+       <r>   14.0551    0.0000 </r>
+       <r>   14.6774    0.0000 </r>
+       <r>   15.8210    0.0000 </r>
+       <r>   15.9033    0.0000 </r>
+       <r>   19.0375    0.0000 </r>
+      </set>
+      <set comment="kpoint 17">
+       <r>  -11.6863    1.0000 </r>
+       <r>  -11.6859    1.0000 </r>
+       <r>  -11.6642    1.0000 </r>
+       <r>  -11.6541    1.0000 </r>
+       <r>  -11.6536    1.0000 </r>
+       <r>   -5.4081    1.0000 </r>
+       <r>   -3.0439    1.0000 </r>
+       <r>    3.7209    1.0000 </r>
+       <r>    4.3029    1.0000 </r>
+       <r>    4.8777    1.0000 </r>
+       <r>    6.0749    0.0000 </r>
+       <r>    6.4893    0.0000 </r>
+       <r>    7.2755    0.0000 </r>
+       <r>   12.4274    0.0000 </r>
+       <r>   13.3210    0.0000 </r>
+       <r>   14.3012    0.0000 </r>
+       <r>   14.6436    0.0000 </r>
+       <r>   16.1056    0.0000 </r>
+       <r>   16.7288    0.0000 </r>
+       <r>   17.9921    0.0000 </r>
+      </set>
+      <set comment="kpoint 18">
+       <r>  -11.6848    1.0000 </r>
+       <r>  -11.6841    1.0000 </r>
+       <r>  -11.6646    1.0000 </r>
+       <r>  -11.6564    1.0000 </r>
+       <r>  -11.6551    1.0000 </r>
+       <r>   -5.6597    1.0000 </r>
+       <r>   -2.6545    1.0000 </r>
+       <r>    3.6035    1.0000 </r>
+       <r>    4.3350    1.0000 </r>
+       <r>    4.8863    1.0000 </r>
+       <r>    6.2248    0.0000 </r>
+       <r>    6.6144    0.0000 </r>
+       <r>    7.6519    0.0000 </r>
+       <r>   11.7247    0.0000 </r>
+       <r>   12.6146    0.0000 </r>
+       <r>   13.6462    0.0000 </r>
+       <r>   15.3698    0.0000 </r>
+       <r>   16.2054    0.0000 </r>
+       <r>   17.6474    0.0000 </r>
+       <r>   17.7234    0.0000 </r>
+      </set>
+      <set comment="kpoint 19">
+       <r>  -11.6830    1.0000 </r>
+       <r>  -11.6814    1.0000 </r>
+       <r>  -11.6652    1.0000 </r>
+       <r>  -11.6592    1.0000 </r>
+       <r>  -11.6574    1.0000 </r>
+       <r>   -5.9321    1.0000 </r>
+       <r>   -2.1778    1.0000 </r>
+       <r>    3.5401    1.0000 </r>
+       <r>    4.2918    1.0000 </r>
+       <r>    4.7699    1.0000 </r>
+       <r>    6.5858    0.0000 </r>
+       <r>    6.9223    0.0000 </r>
+       <r>    8.0784    0.0000 </r>
+       <r>   11.1839    0.0000 </r>
+       <r>   12.0134    0.0000 </r>
+       <r>   12.9436    0.0000 </r>
+       <r>   14.9452    0.0000 </r>
+       <r>   16.1435    0.0000 </r>
+       <r>   16.6359    0.0000 </r>
+       <r>   16.7432    0.0000 </r>
+      </set>
+      <set comment="kpoint 20">
+       <r>  -11.6808    1.0000 </r>
+       <r>  -11.6788    1.0000 </r>
+       <r>  -11.6659    1.0000 </r>
+       <r>  -11.6621    1.0000 </r>
+       <r>  -11.6601    1.0000 </r>
+       <r>   -6.1754    1.0000 </r>
+       <r>   -1.6885    1.0000 </r>
+       <r>    3.5373    1.0000 </r>
+       <r>    4.2014    1.0000 </r>
+       <r>    4.5753    1.0000 </r>
+       <r>    7.0914    0.0000 </r>
+       <r>    7.3677    0.0000 </r>
+       <r>    8.5136    0.0000 </r>
+       <r>   10.8484    0.0000 </r>
+       <r>   11.5407    0.0000 </r>
+       <r>   12.3217    0.0000 </r>
+       <r>   14.0209    0.0000 </r>
+       <r>   15.2816    0.0000 </r>
+       <r>   15.5593    0.0000 </r>
+       <r>   15.6700    0.0000 </r>
+      </set>
+      <set comment="kpoint 21">
+       <r>  -11.6787    1.0000 </r>
+       <r>  -11.6766    1.0000 </r>
+       <r>  -11.6664    1.0000 </r>
+       <r>  -11.6644    1.0000 </r>
+       <r>  -11.6628    1.0000 </r>
+       <r>   -6.3666    1.0000 </r>
+       <r>   -1.2463    1.0000 </r>
+       <r>    3.5963    1.0000 </r>
+       <r>    4.0911    1.0000 </r>
+       <r>    4.3411    1.0000 </r>
+       <r>    7.6844    0.0000 </r>
+       <r>    7.8955    0.0000 </r>
+       <r>    8.8849    0.0000 </r>
+       <r>   10.7160    0.0000 </r>
+       <r>   11.2095    0.0000 </r>
+       <r>   11.7936    0.0000 </r>
+       <r>   13.2586    0.0000 </r>
+       <r>   14.2136    0.0000 </r>
+       <r>   14.5447    0.0000 </r>
+       <r>   14.6841    0.0000 </r>
+      </set>
+      <set comment="kpoint 22">
+       <r>  -11.6768    1.0000 </r>
+       <r>  -11.6755    1.0000 </r>
+       <r>  -11.6667    1.0000 </r>
+       <r>  -11.6658    1.0000 </r>
+       <r>  -11.6650    1.0000 </r>
+       <r>   -6.4944    1.0000 </r>
+       <r>   -0.9108    1.0000 </r>
+       <r>    3.7154    1.0000 </r>
+       <r>    3.9786    1.0000 </r>
+       <r>    4.1056    1.0000 </r>
+       <r>    8.3025    0.0000 </r>
+       <r>    8.4373    0.0000 </r>
+       <r>    9.0545    0.0000 </r>
+       <r>   10.7359    0.0000 </r>
+       <r>   11.0301    0.0000 </r>
+       <r>   11.3562    0.0000 </r>
+       <r>   12.8658    0.0000 </r>
+       <r>   13.3638    0.0000 </r>
+       <r>   13.6612    0.0000 </r>
+       <r>   13.8445    0.0000 </r>
+      </set>
+      <set comment="kpoint 23">
+       <r>  -11.6807    1.0000 </r>
+       <r>  -11.6737    1.0000 </r>
+       <r>  -11.6681    1.0000 </r>
+       <r>  -11.6635    1.0000 </r>
+       <r>  -11.6635    1.0000 </r>
+       <r>   -6.4011    1.0000 </r>
+       <r>   -1.1068    1.0000 </r>
+       <r>    3.5929    1.0000 </r>
+       <r>    3.5929    1.0000 </r>
+       <r>    4.6509    1.0000 </r>
+       <r>    7.1836    0.0000 </r>
+       <r>    9.1175    0.0000 </r>
+       <r>    9.1175    0.0000 </r>
+       <r>   10.0936    0.0000 </r>
+       <r>   11.7858    0.0000 </r>
+       <r>   11.7858    0.0000 </r>
+       <r>   12.8440    0.0000 </r>
+       <r>   13.1809    0.0000 </r>
+       <r>   13.8574    0.0000 </r>
+       <r>   15.4026    0.0000 </r>
+      </set>
+      <set comment="kpoint 24">
+       <r>  -11.6837    1.0000 </r>
+       <r>  -11.6737    1.0000 </r>
+       <r>  -11.6684    1.0000 </r>
+       <r>  -11.6618    1.0000 </r>
+       <r>  -11.6614    1.0000 </r>
+       <r>   -6.2756    1.0000 </r>
+       <r>   -1.3670    1.0000 </r>
+       <r>    3.4950    1.0000 </r>
+       <r>    3.5154    1.0000 </r>
+       <r>    4.7690    1.0000 </r>
+       <r>    6.8181    0.0000 </r>
+       <r>    8.9545    0.0000 </r>
+       <r>    9.0110    0.0000 </r>
+       <r>    9.9726    0.0000 </r>
+       <r>   12.1198    0.0000 </r>
+       <r>   12.2045    0.0000 </r>
+       <r>   13.2444    0.0000 </r>
+       <r>   13.5263    0.0000 </r>
+       <r>   14.5626    0.0000 </r>
+       <r>   16.3788    0.0000 </r>
+      </set>
+      <set comment="kpoint 25">
+       <r>  -11.6867    1.0000 </r>
+       <r>  -11.6750    1.0000 </r>
+       <r>  -11.6679    1.0000 </r>
+       <r>  -11.6599    1.0000 </r>
+       <r>  -11.6585    1.0000 </r>
+       <r>   -6.0886    1.0000 </r>
+       <r>   -1.7410    1.0000 </r>
+       <r>    3.4512    1.0000 </r>
+       <r>    3.5146    1.0000 </r>
+       <r>    4.6204    1.0000 </r>
+       <r>    6.7498    0.0000 </r>
+       <r>    8.5512    0.0000 </r>
+       <r>    8.6746    0.0000 </r>
+       <r>   10.0769    0.0000 </r>
+       <r>   12.4749    0.0000 </r>
+       <r>   12.7022    0.0000 </r>
+       <r>   14.0251    0.0000 </r>
+       <r>   14.2646    0.0000 </r>
+       <r>   15.5995    0.0000 </r>
+       <r>   17.3183    0.0000 </r>
+      </set>
+      <set comment="kpoint 26">
+       <r>  -11.6894    1.0000 </r>
+       <r>  -11.6771    1.0000 </r>
+       <r>  -11.6668    1.0000 </r>
+       <r>  -11.6581    1.0000 </r>
+       <r>  -11.6556    1.0000 </r>
+       <r>   -5.8521    1.0000 </r>
+       <r>   -2.1766    1.0000 </r>
+       <r>    3.4680    1.0000 </r>
+       <r>    3.5586    1.0000 </r>
+       <r>    4.3160    1.0000 </r>
+       <r>    6.8791    0.0000 </r>
+       <r>    8.1139    0.0000 </r>
+       <r>    8.2417    0.0000 </r>
+       <r>   10.3694    0.0000 </r>
+       <r>   12.9584    0.0000 </r>
+       <r>   13.2994    0.0000 </r>
+       <r>   14.8714    0.0000 </r>
+       <r>   15.1902    0.0000 </r>
+       <r>   16.8125    0.0000 </r>
+       <r>   17.5032    0.0000 </r>
+      </set>
+      <set comment="kpoint 27">
+       <r>  -11.6912    1.0000 </r>
+       <r>  -11.6796    1.0000 </r>
+       <r>  -11.6654    1.0000 </r>
+       <r>  -11.6566    1.0000 </r>
+       <r>  -11.6533    1.0000 </r>
+       <r>   -5.5896    1.0000 </r>
+       <r>   -2.6139    1.0000 </r>
+       <r>    3.5472    1.0000 </r>
+       <r>    3.5660    1.0000 </r>
+       <r>    4.0678    1.0000 </r>
+       <r>    7.0315    0.0000 </r>
+       <r>    7.7602    0.0000 </r>
+       <r>    7.7967    0.0000 </r>
+       <r>   10.8539    0.0000 </r>
+       <r>   13.5764    0.0000 </r>
+       <r>   13.9699    0.0000 </r>
+       <r>   15.1200    0.0000 </r>
+       <r>   15.9043    0.0000 </r>
+       <r>   17.0515    0.0000 </r>
+       <r>   17.2033    0.0000 </r>
+      </set>
+      <set comment="kpoint 28">
+       <r>  -11.6919    1.0000 </r>
+       <r>  -11.6819    1.0000 </r>
+       <r>  -11.6641    1.0000 </r>
+       <r>  -11.6554    1.0000 </r>
+       <r>  -11.6521    1.0000 </r>
+       <r>   -5.3500    1.0000 </r>
+       <r>   -2.9774    1.0000 </r>
+       <r>    3.4006    1.0000 </r>
+       <r>    3.6861    1.0000 </r>
+       <r>    4.0801    1.0000 </r>
+       <r>    6.9813    0.0000 </r>
+       <r>    7.3836    0.0000 </r>
+       <r>    7.6917    0.0000 </r>
+       <r>   11.5110    0.0000 </r>
+       <r>   14.2559    0.0000 </r>
+       <r>   14.4473    0.0000 </r>
+       <r>   14.4907    0.0000 </r>
+       <r>   15.5947    0.0000 </r>
+       <r>   17.6491    0.0000 </r>
+       <r>   17.7688    0.0000 </r>
+      </set>
+      <set comment="kpoint 29">
+       <r>  -11.6913    1.0000 </r>
+       <r>  -11.6837    1.0000 </r>
+       <r>  -11.6632    1.0000 </r>
+       <r>  -11.6547    1.0000 </r>
+       <r>  -11.6521    1.0000 </r>
+       <r>   -5.2229    1.0000 </r>
+       <r>   -3.1617    1.0000 </r>
+       <r>    3.1806    1.0000 </r>
+       <r>    3.8739    1.0000 </r>
+       <r>    4.2631    1.0000 </r>
+       <r>    6.7350    0.0000 </r>
+       <r>    7.0303    0.0000 </r>
+       <r>    7.9022    0.0000 </r>
+       <r>   12.2750    0.0000 </r>
+       <r>   13.5145    0.0000 </r>
+       <r>   14.0657    0.0000 </r>
+       <r>   15.0567    0.0000 </r>
+       <r>   16.0374    0.0000 </r>
+       <r>   16.9849    0.0000 </r>
+       <r>   18.6173    0.0000 </r>
+      </set>
+      <set comment="kpoint 30">
+       <r>  -11.6895    1.0000 </r>
+       <r>  -11.6846    1.0000 </r>
+       <r>  -11.6629    1.0000 </r>
+       <r>  -11.6545    1.0000 </r>
+       <r>  -11.6534    1.0000 </r>
+       <r>   -5.2876    1.0000 </r>
+       <r>   -3.0816    1.0000 </r>
+       <r>    3.0164    1.0000 </r>
+       <r>    4.0865    1.0000 </r>
+       <r>    4.5112    1.0000 </r>
+       <r>    6.4895    0.0000 </r>
+       <r>    6.7645    0.0000 </r>
+       <r>    8.2000    0.0000 </r>
+       <r>   12.4192    0.0000 </r>
+       <r>   13.3090    0.0000 </r>
+       <r>   13.4476    0.0000 </r>
+       <r>   15.3959    0.0000 </r>
+       <r>   16.2731    0.0000 </r>
+       <r>   16.9710    0.0000 </r>
+       <r>   17.8648    0.0000 </r>
+      </set>
+      <set comment="kpoint 31">
+       <r>  -11.6868    1.0000 </r>
+       <r>  -11.6847    1.0000 </r>
+       <r>  -11.6634    1.0000 </r>
+       <r>  -11.6557    1.0000 </r>
+       <r>  -11.6550    1.0000 </r>
+       <r>   -5.5011    1.0000 </r>
+       <r>   -2.7838    1.0000 </r>
+       <r>    2.9380    1.0000 </r>
+       <r>    4.2785    1.0000 </r>
+       <r>    4.7655    1.0000 </r>
+       <r>    6.3227    0.0000 </r>
+       <r>    6.6280    0.0000 </r>
+       <r>    8.5209    0.0000 </r>
+       <r>   11.7890    0.0000 </r>
+       <r>   12.6149    0.0000 </r>
+       <r>   14.3148    0.0000 </r>
+       <r>   14.8367    0.0000 </r>
+       <r>   15.6190    0.0000 </r>
+       <r>   18.0395    0.0000 </r>
+       <r>   18.0471    0.0000 </r>
+      </set>
+      <set comment="kpoint 32">
+       <r>  -11.6838    1.0000 </r>
+       <r>  -11.6836    1.0000 </r>
+       <r>  -11.6642    1.0000 </r>
+       <r>  -11.6584    1.0000 </r>
+       <r>  -11.6561    1.0000 </r>
+       <r>   -5.7640    1.0000 </r>
+       <r>   -2.3800    1.0000 </r>
+       <r>    2.9567    1.0000 </r>
+       <r>    4.3870    1.0000 </r>
+       <r>    4.9191    1.0000 </r>
+       <r>    6.3297    0.0000 </r>
+       <r>    6.6752    0.0000 </r>
+       <r>    8.8193    0.0000 </r>
+       <r>   11.2917    0.0000 </r>
+       <r>   12.0416    0.0000 </r>
+       <r>   13.9797    0.0000 </r>
+       <r>   14.4236    0.0000 </r>
+       <r>   15.6199    0.0000 </r>
+       <r>   17.3368    0.0000 </r>
+       <r>   17.7676    0.0000 </r>
+      </set>
+      <set comment="kpoint 33">
+       <r>  -11.6824    1.0000 </r>
+       <r>  -11.6804    1.0000 </r>
+       <r>  -11.6653    1.0000 </r>
+       <r>  -11.6610    1.0000 </r>
+       <r>  -11.6580    1.0000 </r>
+       <r>   -6.0136    1.0000 </r>
+       <r>   -1.9532    1.0000 </r>
+       <r>    3.0769    1.0000 </r>
+       <r>    4.3733    1.0000 </r>
+       <r>    4.8624    1.0000 </r>
+       <r>    6.6031    0.0000 </r>
+       <r>    6.9326    0.0000 </r>
+       <r>    9.0328    0.0000 </r>
+       <r>   10.9890    0.0000 </r>
+       <r>   11.6101    0.0000 </r>
+       <r>   13.1994    0.0000 </r>
+       <r>   13.6584    0.0000 </r>
+       <r>   16.0445    0.0000 </r>
+       <r>   16.1238    0.0000 </r>
+       <r>   16.6667    0.0000 </r>
+      </set>
+      <set comment="kpoint 34">
+       <r>  -11.6806    1.0000 </r>
+       <r>  -11.6780    1.0000 </r>
+       <r>  -11.6661    1.0000 </r>
+       <r>  -11.6631    1.0000 </r>
+       <r>  -11.6603    1.0000 </r>
+       <r>   -6.2194    1.0000 </r>
+       <r>   -1.5604    1.0000 </r>
+       <r>    3.2955    1.0000 </r>
+       <r>    4.2591    1.0000 </r>
+       <r>    4.6372    1.0000 </r>
+       <r>    7.0892    0.0000 </r>
+       <r>    7.3629    0.0000 </r>
+       <r>    9.0878    0.0000 </r>
+       <r>   10.8061    0.0000 </r>
+       <r>   11.3309    0.0000 </r>
+       <r>   12.4681    0.0000 </r>
+       <r>   13.2072    0.0000 </r>
+       <r>   15.0255    0.0000 </r>
+       <r>   15.4620    0.0000 </r>
+       <r>   15.6261    0.0000 </r>
+      </set>
+      <set comment="kpoint 35">
+       <r>  -11.6878    1.0000 </r>
+       <r>  -11.6720    1.0000 </r>
+       <r>  -11.6695    1.0000 </r>
+       <r>  -11.6599    1.0000 </r>
+       <r>  -11.6599    1.0000 </r>
+       <r>   -6.1757    1.0000 </r>
+       <r>   -1.4842    1.0000 </r>
+       <r>    3.3233    1.0000 </r>
+       <r>    3.3233    1.0000 </r>
+       <r>    4.5549    1.0000 </r>
+       <r>    6.9085    0.0000 </r>
+       <r>    9.2757    0.0000 </r>
+       <r>    9.2757    0.0000 </r>
+       <r>    9.5907    0.0000 </r>
+       <r>   12.6719    0.0000 </r>
+       <r>   12.6719    0.0000 </r>
+       <r>   13.1079    0.0000 </r>
+       <r>   13.4071    0.0000 </r>
+       <r>   14.9373    0.0000 </r>
+       <r>   17.3516    0.0000 </r>
+      </set>
+      <set comment="kpoint 36">
+       <r>  -11.6918    1.0000 </r>
+       <r>  -11.6720    1.0000 </r>
+       <r>  -11.6699    1.0000 </r>
+       <r>  -11.6578    1.0000 </r>
+       <r>  -11.6574    1.0000 </r>
+       <r>   -6.0152    1.0000 </r>
+       <r>   -1.7225    1.0000 </r>
+       <r>    3.2133    1.0000 </r>
+       <r>    3.2283    1.0000 </r>
+       <r>    4.1054    1.0000 </r>
+       <r>    7.2604    0.0000 </r>
+       <r>    9.1120    0.0000 </r>
+       <r>    9.2235    0.0000 </r>
+       <r>    9.5787    0.0000 </r>
+       <r>   13.0533    0.0000 </r>
+       <r>   13.1635    0.0000 </r>
+       <r>   13.5960    0.0000 </r>
+       <r>   13.8138    0.0000 </r>
+       <r>   15.7058    0.0000 </r>
+       <r>   18.2095    0.0000 </r>
+      </set>
+      <set comment="kpoint 37">
+       <r>  -11.6952    1.0000 </r>
+       <r>  -11.6732    1.0000 </r>
+       <r>  -11.6693    1.0000 </r>
+       <r>  -11.6561    1.0000 </r>
+       <r>  -11.6546    1.0000 </r>
+       <r>   -5.8046    1.0000 </r>
+       <r>   -2.0529    1.0000 </r>
+       <r>    3.1732    1.0000 </r>
+       <r>    3.1990    1.0000 </r>
+       <r>    3.6538    1.0000 </r>
+       <r>    7.6477    0.0000 </r>
+       <r>    8.7871    0.0000 </r>
+       <r>    8.9324    0.0000 </r>
+       <r>    9.7401    0.0000 </r>
+       <r>   13.4812    0.0000 </r>
+       <r>   13.7154    0.0000 </r>
+       <r>   14.3650    0.0000 </r>
+       <r>   14.5864    0.0000 </r>
+       <r>   16.7669    0.0000 </r>
+       <r>   17.7967    0.0000 </r>
+      </set>
+      <set comment="kpoint 38">
+       <r>  -11.6974    1.0000 </r>
+       <r>  -11.6753    1.0000 </r>
+       <r>  -11.6678    1.0000 </r>
+       <r>  -11.6550    1.0000 </r>
+       <r>  -11.6523    1.0000 </r>
+       <r>   -5.5637    1.0000 </r>
+       <r>   -2.4259    1.0000 </r>
+       <r>    3.0447    1.0000 </r>
+       <r>    3.2069    1.0000 </r>
+       <r>    3.4574    1.0000 </r>
+       <r>    7.9108    0.0000 </r>
+       <r>    8.5237    0.0000 </r>
+       <r>    8.5306    0.0000 </r>
+       <r>   10.0738    0.0000 </r>
+       <r>   14.0420    0.0000 </r>
+       <r>   14.3558    0.0000 </r>
+       <r>   14.8900    0.0000 </r>
+       <r>   15.3867    0.0000 </r>
+       <r>   16.9522    0.0000 </r>
+       <r>   16.9919    0.0000 </r>
+      </set>
+      <set comment="kpoint 39">
+       <r>  -11.6981    1.0000 </r>
+       <r>  -11.6778    1.0000 </r>
+       <r>  -11.6658    1.0000 </r>
+       <r>  -11.6547    1.0000 </r>
+       <r>  -11.6511    1.0000 </r>
+       <r>   -5.3298    1.0000 </r>
+       <r>   -2.7749    1.0000 </r>
+       <r>    2.7369    1.0000 </r>
+       <r>    3.3149    1.0000 </r>
+       <r>    3.5653    1.0000 </r>
+       <r>    7.7817    0.0000 </r>
+       <r>    8.0996    0.0000 </r>
+       <r>    8.6102    0.0000 </r>
+       <r>   10.6049    0.0000 </r>
+       <r>   14.3917    0.0000 </r>
+       <r>   14.7550    0.0000 </r>
+       <r>   14.7654    0.0000 </r>
+       <r>   15.6184    0.0000 </r>
+       <r>   17.1703    0.0000 </r>
+       <r>   17.4867    0.0000 </r>
+      </set>
+      <set comment="kpoint 40">
+       <r>  -11.6972    1.0000 </r>
+       <r>  -11.6801    1.0000 </r>
+       <r>  -11.6635    1.0000 </r>
+       <r>  -11.6551    1.0000 </r>
+       <r>  -11.6511    1.0000 </r>
+       <r>   -5.1707    1.0000 </r>
+       <r>   -3.0117    1.0000 </r>
+       <r>    2.4913    1.0000 </r>
+       <r>    3.4928    1.0000 </r>
+       <r>    3.7731    1.0000 </r>
+       <r>    7.4564    0.0000 </r>
+       <r>    7.6797    0.0000 </r>
+       <r>    8.8747    0.0000 </r>
+       <r>   11.3100    0.0000 </r>
+       <r>   13.5756    0.0000 </r>
+       <r>   14.1732    0.0000 </r>
+       <r>   15.4113    0.0000 </r>
+       <r>   16.2857    0.0000 </r>
+       <r>   18.1688    0.0000 </r>
+       <r>   18.2049    0.0000 </r>
+      </set>
+      <set comment="kpoint 41">
+       <r>  -11.6948    1.0000 </r>
+       <r>  -11.6820    1.0000 </r>
+       <r>  -11.6617    1.0000 </r>
+       <r>  -11.6559    1.0000 </r>
+       <r>  -11.6523    1.0000 </r>
+       <r>   -5.1663    1.0000 </r>
+       <r>   -3.0470    1.0000 </r>
+       <r>    2.3525    1.0000 </r>
+       <r>    3.7292    1.0000 </r>
+       <r>    4.0448    1.0000 </r>
+       <r>    7.1189    0.0000 </r>
+       <r>    7.2943    0.0000 </r>
+       <r>    9.1346    0.0000 </r>
+       <r>   12.1051    0.0000 </r>
+       <r>   12.8398    0.0000 </r>
+       <r>   13.4156    0.0000 </r>
+       <r>   15.7028    0.0000 </r>
+       <r>   17.0380    0.0000 </r>
+       <r>   17.2303    0.0000 </r>
+       <r>   18.0436    0.0000 </r>
+      </set>
+      <set comment="kpoint 42">
+       <r>  -11.6913    1.0000 </r>
+       <r>  -11.6832    1.0000 </r>
+       <r>  -11.6613    1.0000 </r>
+       <r>  -11.6563    1.0000 </r>
+       <r>  -11.6544    1.0000 </r>
+       <r>   -5.3212    1.0000 </r>
+       <r>   -2.8764    1.0000 </r>
+       <r>    2.3369    1.0000 </r>
+       <r>    3.9992    1.0000 </r>
+       <r>    4.3650    1.0000 </r>
+       <r>    6.7985    0.0000 </r>
+       <r>    6.9682    0.0000 </r>
+       <r>    9.3317    0.0000 </r>
+       <r>   12.0444    0.0000 </r>
+       <r>   12.7475    0.0000 </r>
+       <r>   13.2344    0.0000 </r>
+       <r>   15.1175    0.0000 </r>
+       <r>   16.1253    0.0000 </r>
+       <r>   18.2705    0.0000 </r>
+       <r>   18.4264    0.0000 </r>
+      </set>
+      <set comment="kpoint 43">
+       <r>  -11.6873    1.0000 </r>
+       <r>  -11.6836    1.0000 </r>
+       <r>  -11.6625    1.0000 </r>
+       <r>  -11.6569    1.0000 </r>
+       <r>  -11.6562    1.0000 </r>
+       <r>   -5.5566    1.0000 </r>
+       <r>   -2.5871    1.0000 </r>
+       <r>    2.4537    1.0000 </r>
+       <r>    4.2515    1.0000 </r>
+       <r>    4.6960    1.0000 </r>
+       <r>    6.5227    0.0000 </r>
+       <r>    6.7479    0.0000 </r>
+       <r>    9.4066    0.0000 </r>
+       <r>   11.6357    0.0000 </r>
+       <r>   12.2149    0.0000 </r>
+       <r>   13.9682    0.0000 </r>
+       <r>   14.5411    0.0000 </r>
+       <r>   15.2411    0.0000 </r>
+       <r>   18.2378    0.0000 </r>
+       <r>   18.8690    0.0000 </r>
+      </set>
+      <set comment="kpoint 44">
+       <r>  -11.6835    1.0000 </r>
+       <r>  -11.6833    1.0000 </r>
+       <r>  -11.6641    1.0000 </r>
+       <r>  -11.6592    1.0000 </r>
+       <r>  -11.6566    1.0000 </r>
+       <r>   -5.8006    1.0000 </r>
+       <r>   -2.2625    1.0000 </r>
+       <r>    2.7045    1.0000 </r>
+       <r>    4.3996    1.0000 </r>
+       <r>    4.9217    1.0000 </r>
+       <r>    6.3977    0.0000 </r>
+       <r>    6.7143    0.0000 </r>
+       <r>    9.3179    0.0000 </r>
+       <r>   11.3046    0.0000 </r>
+       <r>   11.8341    0.0000 </r>
+       <r>   13.6282    0.0000 </r>
+       <r>   14.1622    0.0000 </r>
+       <r>   15.5417    0.0000 </r>
+       <r>   17.0723    0.0000 </r>
+       <r>   17.7508    0.0000 </r>
+      </set>
+      <set comment="kpoint 45">
+       <r>  -11.6972    1.0000 </r>
+       <r>  -11.6711    1.0000 </r>
+       <r>  -11.6702    1.0000 </r>
+       <r>  -11.6555    1.0000 </r>
+       <r>  -11.6555    1.0000 </r>
+       <r>   -5.8841    1.0000 </r>
+       <r>   -1.8060    1.0000 </r>
+       <r>    3.0409    1.0000 </r>
+       <r>    3.0409    1.0000 </r>
+       <r>    3.5126    1.0000 </r>
+       <r>    7.8771    0.0000 </r>
+       <r>    9.1733    0.0000 </r>
+       <r>    9.5331    0.0000 </r>
+       <r>    9.5331    0.0000 </r>
+       <r>   13.4775    0.0000 </r>
+       <r>   13.7211    0.0000 </r>
+       <r>   13.7314    0.0000 </r>
+       <r>   13.7314    0.0000 </r>
+       <r>   16.1590    0.0000 </r>
+       <r>   18.9503    0.0000 </r>
+      </set>
+      <set comment="kpoint 46">
+       <r>  -11.7017    1.0000 </r>
+       <r>  -11.6714    1.0000 </r>
+       <r>  -11.6700    1.0000 </r>
+       <r>  -11.6536    1.0000 </r>
+       <r>  -11.6531    1.0000 </r>
+       <r>   -5.7053    1.0000 </r>
+       <r>   -1.9937    1.0000 </r>
+       <r>    2.8958    1.0000 </r>
+       <r>    2.9439    1.0000 </r>
+       <r>    3.0336    1.0000 </r>
+       <r>    8.4491    0.0000 </r>
+       <r>    9.0378    0.0000 </r>
+       <r>    9.5160    0.0000 </r>
+       <r>    9.5963    0.0000 </r>
+       <r>   13.8307    0.0000 </r>
+       <r>   14.0502    0.0000 </r>
+       <r>   14.3384    0.0000 </r>
+       <r>   14.3861    0.0000 </r>
+       <r>   16.9764    0.0000 </r>
+       <r>   17.9364    0.0000 </r>
+      </set>
+      <set comment="kpoint 47">
+       <r>  -11.7047    1.0000 </r>
+       <r>  -11.6713    1.0000 </r>
+       <r>  -11.6706    1.0000 </r>
+       <r>  -11.6524    1.0000 </r>
+       <r>  -11.6510    1.0000 </r>
+       <r>   -5.4960    1.0000 </r>
+       <r>   -2.2597    1.0000 </r>
+       <r>    2.4726    1.0000 </r>
+       <r>    2.9278    1.0000 </r>
+       <r>    3.0241    1.0000 </r>
+       <r>    8.7533    0.0000 </r>
+       <r>    9.1107    0.0000 </r>
+       <r>    9.2460    0.0000 </r>
+       <r>    9.6376    0.0000 </r>
+       <r>   14.3793    0.0000 </r>
+       <r>   14.6909    0.0000 </r>
+       <r>   14.8956    0.0000 </r>
+       <r>   15.0335    0.0000 </r>
+       <r>   16.9790    0.0000 </r>
+       <r>   17.0468    0.0000 </r>
+      </set>
+      <set comment="kpoint 48">
+       <r>  -11.7056    1.0000 </r>
+       <r>  -11.6734    1.0000 </r>
+       <r>  -11.6688    1.0000 </r>
+       <r>  -11.6522    1.0000 </r>
+       <r>  -11.6498    1.0000 </r>
+       <r>   -5.2857    1.0000 </r>
+       <r>   -2.5531    1.0000 </r>
+       <r>    2.1175    1.0000 </r>
+       <r>    2.9944    1.0000 </r>
+       <r>    3.1448    1.0000 </r>
+       <r>    8.5420    0.0000 </r>
+       <r>    8.8468    0.0000 </r>
+       <r>    9.4872    0.0000 </r>
+       <r>    9.9111    0.0000 </r>
+       <r>   14.5174    0.0000 </r>
+       <r>   15.0593    0.0000 </r>
+       <r>   15.2477    0.0000 </r>
+       <r>   15.5395    0.0000 </r>
+       <r>   16.8801    0.0000 </r>
+       <r>   17.0673    0.0000 </r>
+      </set>
+      <set comment="kpoint 49">
+       <r>  -11.7044    1.0000 </r>
+       <r>  -11.6759    1.0000 </r>
+       <r>  -11.6661    1.0000 </r>
+       <r>  -11.6531    1.0000 </r>
+       <r>  -11.6497    1.0000 </r>
+       <r>   -5.1225    1.0000 </r>
+       <r>   -2.8042    1.0000 </r>
+       <r>    1.8861    1.0000 </r>
+       <r>    3.1422    1.0000 </r>
+       <r>    3.3437    1.0000 </r>
+       <r>    8.1893    0.0000 </r>
+       <r>    8.3952    0.0000 </r>
+       <r>    9.7933    0.0000 </r>
+       <r>   10.4552    0.0000 </r>
+       <r>   13.8335    0.0000 </r>
+       <r>   14.3906    0.0000 </r>
+       <r>   15.7699    0.0000 </r>
+       <r>   16.4392    0.0000 </r>
+       <r>   17.6641    0.0000 </r>
+       <r>   18.0184    0.0000 </r>
+      </set>
+      <set comment="kpoint 50">
+       <r>  -11.7013    1.0000 </r>
+       <r>  -11.6784    1.0000 </r>
+       <r>  -11.6631    1.0000 </r>
+       <r>  -11.6549    1.0000 </r>
+       <r>  -11.6508    1.0000 </r>
+       <r>   -5.0678    1.0000 </r>
+       <r>   -2.9377    1.0000 </r>
+       <r>    1.7953    1.0000 </r>
+       <r>    3.3651    1.0000 </r>
+       <r>    3.6106    1.0000 </r>
+       <r>    7.7912    0.0000 </r>
+       <r>    7.9285    0.0000 </r>
+       <r>    9.9687    0.0000 </r>
+       <r>   11.2052    0.0000 </r>
+       <r>   13.1258    0.0000 </r>
+       <r>   13.6531    0.0000 </r>
+       <r>   15.7227    0.0000 </r>
+       <r>   17.4031    0.0000 </r>
+       <r>   17.6896    0.0000 </r>
+       <r>   18.6514    0.0000 </r>
+      </set>
+      <set comment="kpoint 51">
+       <r>  -11.6970    1.0000 </r>
+       <r>  -11.6808    1.0000 </r>
+       <r>  -11.6602    1.0000 </r>
+       <r>  -11.6573    1.0000 </r>
+       <r>  -11.6527    1.0000 </r>
+       <r>   -5.1523    1.0000 </r>
+       <r>   -2.9171    1.0000 </r>
+       <r>    1.8579    1.0000 </r>
+       <r>    3.6497    1.0000 </r>
+       <r>    3.9388    1.0000 </r>
+       <r>    7.3668    0.0000 </r>
+       <r>    7.4704    0.0000 </r>
+       <r>    9.9751    0.0000 </r>
+       <r>   12.0986    0.0000 </r>
+       <r>   12.5861    0.0000 </r>
+       <r>   13.0242    0.0000 </r>
+       <r>   15.0102    0.0000 </r>
+       <r>   17.2574    0.0000 </r>
+       <r>   18.3742    0.0000 </r>
+       <r>   18.7543    0.0000 </r>
+      </set>
+      <set comment="kpoint 52">
+       <r>  -11.6920    1.0000 </r>
+       <r>  -11.6826    1.0000 </r>
+       <r>  -11.6601    1.0000 </r>
+       <r>  -11.6575    1.0000 </r>
+       <r>  -11.6548    1.0000 </r>
+       <r>   -5.3369    1.0000 </r>
+       <r>   -2.7796    1.0000 </r>
+       <r>    2.0796    1.0000 </r>
+       <r>    3.9667    1.0000 </r>
+       <r>    4.3155    1.0000 </r>
+       <r>    6.9276    0.0000 </r>
+       <r>    7.0540    0.0000 </r>
+       <r>    9.7871    0.0000 </r>
+       <r>   12.1038    0.0000 </r>
+       <r>   12.5416    0.0000 </r>
+       <r>   13.1194    0.0000 </r>
+       <r>   14.4567    0.0000 </r>
+       <r>   16.2755    0.0000 </r>
+       <r>   19.0910    0.0000 </r>
+       <r>   19.1005    0.0000 </r>
+      </set>
+      <set comment="kpoint 53">
+       <r>  -11.7075    1.0000 </r>
+       <r>  -11.6727    1.0000 </r>
+       <r>  -11.6684    1.0000 </r>
+       <r>  -11.6513    1.0000 </r>
+       <r>  -11.6513    1.0000 </r>
+       <r>   -5.5637    1.0000 </r>
+       <r>   -2.0239    1.0000 </r>
+       <r>    2.4009    1.0000 </r>
+       <r>    2.7928    1.0000 </r>
+       <r>    2.7928    1.0000 </r>
+       <r>    8.8557    0.0000 </r>
+       <r>    9.1814    0.0000 </r>
+       <r>    9.8443    0.0000 </r>
+       <r>    9.8443    0.0000 </r>
+       <r>   13.9686    0.0000 </r>
+       <r>   14.1150    0.0000 </r>
+       <r>   14.8827    0.0000 </r>
+       <r>   14.8827    0.0000 </r>
+       <r>   17.5155    0.0000 </r>
+       <r>   18.1249    0.0000 </r>
+      </set>
+      <set comment="kpoint 54">
+       <r>  -11.7114    1.0000 </r>
+       <r>  -11.6728    1.0000 </r>
+       <r>  -11.6683    1.0000 </r>
+       <r>  -11.6498    1.0000 </r>
+       <r>  -11.6494    1.0000 </r>
+       <r>   -5.3958    1.0000 </r>
+       <r>   -2.1487    1.0000 </r>
+       <r>    1.9351    1.0000 </r>
+       <r>    2.7264    1.0000 </r>
+       <r>    2.7490    1.0000 </r>
+       <r>    8.8095    0.0000 </r>
+       <r>    9.7058    0.0000 </r>
+       <r>    9.8305    0.0000 </r>
+       <r>    9.9550    0.0000 </r>
+       <r>   14.3922    0.0000 </r>
+       <r>   14.5243    0.0000 </r>
+       <r>   15.4141    0.0000 </r>
+       <r>   15.4339    0.0000 </r>
+       <r>   17.1299    0.0000 </r>
+       <r>   17.2544    0.0000 </r>
+      </set>
+      <set comment="kpoint 55">
+       <r>  -11.7128    1.0000 </r>
+       <r>  -11.6717    1.0000 </r>
+       <r>  -11.6696    1.0000 </r>
+       <r>  -11.6494    1.0000 </r>
+       <r>  -11.6483    1.0000 </r>
+       <r>   -5.2252    1.0000 </r>
+       <r>   -2.3458    1.0000 </r>
+       <r>    1.5953    1.0000 </r>
+       <r>    2.7479    1.0000 </r>
+       <r>    2.8208    1.0000 </r>
+       <r>    8.8792    0.0000 </r>
+       <r>    9.5452    0.0000 </r>
+       <r>    9.6993    0.0000 </r>
+       <r>   10.3185    0.0000 </r>
+       <r>   14.7251    0.0000 </r>
+       <r>   15.1723    0.0000 </r>
+       <r>   15.5379    0.0000 </r>
+       <r>   15.7143    0.0000 </r>
+       <r>   16.8533    0.0000 </r>
+       <r>   16.9712    0.0000 </r>
+      </set>
+      <set comment="kpoint 56">
+       <r>  -11.7116    1.0000 </r>
+       <r>  -11.6719    1.0000 </r>
+       <r>  -11.6694    1.0000 </r>
+       <r>  -11.6502    1.0000 </r>
+       <r>  -11.6482    1.0000 </r>
+       <r>   -5.0848    1.0000 </r>
+       <r>   -2.5696    1.0000 </r>
+       <r>    1.4050    1.0000 </r>
+       <r>    2.8571    1.0000 </r>
+       <r>    2.9888    1.0000 </r>
+       <r>    8.7855    0.0000 </r>
+       <r>    9.1057    0.0000 </r>
+       <r>    9.8554    0.0000 </r>
+       <r>   10.5802    0.0000 </r>
+       <r>   14.2738    0.0000 </r>
+       <r>   14.7326    0.0000 </r>
+       <r>   16.0973    0.0000 </r>
+       <r>   16.2028    0.0000 </r>
+       <r>   17.4368    0.0000 </r>
+       <r>   17.6078    0.0000 </r>
+      </set>
+      <set comment="kpoint 57">
+       <r>  -11.7081    1.0000 </r>
+       <r>  -11.6747    1.0000 </r>
+       <r>  -11.6664    1.0000 </r>
+       <r>  -11.6522    1.0000 </r>
+       <r>  -11.6491    1.0000 </r>
+       <r>   -5.0128    1.0000 </r>
+       <r>   -2.7644    1.0000 </r>
+       <r>    1.3813    1.0000 </r>
+       <r>    3.0508    1.0000 </r>
+       <r>    3.2375    1.0000 </r>
+       <r>    8.4188    0.0000 </r>
+       <r>    8.5860    0.0000 </r>
+       <r>   10.3978    0.0000 </r>
+       <r>   10.6188    0.0000 </r>
+       <r>   13.6643    0.0000 </r>
+       <r>   14.0341    0.0000 </r>
+       <r>   15.8377    0.0000 </r>
+       <r>   17.1398    0.0000 </r>
+       <r>   17.9341    0.0000 </r>
+       <r>   18.4406    0.0000 </r>
+      </set>
+      <set comment="kpoint 58">
+       <r>  -11.7029    1.0000 </r>
+       <r>  -11.6778    1.0000 </r>
+       <r>  -11.6629    1.0000 </r>
+       <r>  -11.6548    1.0000 </r>
+       <r>  -11.6508    1.0000 </r>
+       <r>   -5.0371    1.0000 </r>
+       <r>   -2.8849    1.0000 </r>
+       <r>    1.5334    1.0000 </r>
+       <r>    3.3207    1.0000 </r>
+       <r>    3.5569    1.0000 </r>
+       <r>    7.9243    0.0000 </r>
+       <r>    8.0283    0.0000 </r>
+       <r>   10.4095    0.0000 </r>
+       <r>   11.1807    0.0000 </r>
+       <r>   13.1150    0.0000 </r>
+       <r>   13.4536    0.0000 </r>
+       <r>   15.2549    0.0000 </r>
+       <r>   17.9770    0.0000 </r>
+       <r>   18.1343    0.0000 </r>
+       <r>   18.7364    0.0000 </r>
+      </set>
+      <set comment="kpoint 59">
+       <r>  -11.7163    1.0000 </r>
+       <r>  -11.6739    1.0000 </r>
+       <r>  -11.6669    1.0000 </r>
+       <r>  -11.6479    1.0000 </r>
+       <r>  -11.6479    1.0000 </r>
+       <r>   -5.2775    1.0000 </r>
+       <r>   -2.1222    1.0000 </r>
+       <r>    1.4996    1.0000 </r>
+       <r>    2.6112    1.0000 </r>
+       <r>    2.6112    1.0000 </r>
+       <r>    8.6427    0.0000 </r>
+       <r>   10.1369    0.0000 </r>
+       <r>   10.1369    0.0000 </r>
+       <r>   10.4622    0.0000 </r>
+       <r>   14.5618    0.0000 </r>
+       <r>   14.6023    0.0000 </r>
+       <r>   15.9558    0.0000 </r>
+       <r>   15.9558    0.0000 </r>
+       <r>   17.0915    0.0000 </r>
+       <r>   17.3307    0.0000 </r>
+      </set>
+      <set comment="kpoint 60">
+       <r>  -11.7185    1.0000 </r>
+       <r>  -11.6737    1.0000 </r>
+       <r>  -11.6672    1.0000 </r>
+       <r>  -11.6472    1.0000 </r>
+       <r>  -11.6469    1.0000 </r>
+       <r>   -5.1602    1.0000 </r>
+       <r>   -2.1932    1.0000 </r>
+       <r>    1.2044    1.0000 </r>
+       <r>    2.5865    1.0000 </r>
+       <r>    2.6060    1.0000 </r>
+       <r>    8.6609    0.0000 </r>
+       <r>   10.0829    0.0000 </r>
+       <r>   10.1066    0.0000 </r>
+       <r>   10.9429    0.0000 </r>
+       <r>   14.9633    0.0000 </r>
+       <r>   15.0150    0.0000 </r>
+       <r>   15.9741    0.0000 </r>
+       <r>   16.0452    0.0000 </r>
+       <r>   16.8565    0.0000 </r>
+       <r>   17.1422    0.0000 </r>
+      </set>
+      <set comment="kpoint 61">
+       <r>  -11.7176    1.0000 </r>
+       <r>  -11.6722    1.0000 </r>
+       <r>  -11.6687    1.0000 </r>
+       <r>  -11.6477    1.0000 </r>
+       <r>  -11.6468    1.0000 </r>
+       <r>   -5.0654    1.0000 </r>
+       <r>   -2.3490    1.0000 </r>
+       <r>    1.0780    1.0000 </r>
+       <r>    2.6532    1.0000 </r>
+       <r>    2.7209    1.0000 </r>
+       <r>    8.8318    0.0000 </r>
+       <r>    9.7354    0.0000 </r>
+       <r>    9.8955    0.0000 </r>
+       <r>   11.1436    0.0000 </r>
+       <r>   14.8619    0.0000 </r>
+       <r>   15.2101    0.0000 </r>
+       <r>   15.7058    0.0000 </r>
+       <r>   16.2105    0.0000 </r>
+       <r>   17.1044    0.0000 </r>
+       <r>   17.7098    0.0000 </r>
+      </set>
+      <set comment="kpoint 62">
+       <r>  -11.7139    1.0000 </r>
+       <r>  -11.6713    1.0000 </r>
+       <r>  -11.6697    1.0000 </r>
+       <r>  -11.6495    1.0000 </r>
+       <r>  -11.6476    1.0000 </r>
+       <r>   -5.0123    1.0000 </r>
+       <r>   -2.5545    1.0000 </r>
+       <r>    1.1371    1.0000 </r>
+       <r>    2.8098    1.0000 </r>
+       <r>    2.9370    1.0000 </r>
+       <r>    8.8538    0.0000 </r>
+       <r>    9.2085    0.0000 </r>
+       <r>    9.8796    0.0000 </r>
+       <r>   11.0254    0.0000 </r>
+       <r>   14.2751    0.0000 </r>
+       <r>   14.5655    0.0000 </r>
+       <r>   16.1795    0.0000 </r>
+       <r>   16.4501    0.0000 </r>
+       <r>   17.4298    0.0000 </r>
+       <r>   18.0722    0.0000 </r>
+      </set>
+      <set comment="kpoint 63">
+       <r>  -11.7214    1.0000 </r>
+       <r>  -11.6745    1.0000 </r>
+       <r>  -11.6662    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -5.1050    1.0000 </r>
+       <r>   -2.1342    1.0000 </r>
+       <r>    0.9746    1.0000 </r>
+       <r>    2.5159    1.0000 </r>
+       <r>    2.5159    1.0000 </r>
+       <r>    8.5359    0.0000 </r>
+       <r>   10.3198    0.0000 </r>
+       <r>   10.3198    0.0000 </r>
+       <r>   11.3457    0.0000 </r>
+       <r>   14.9497    0.0000 </r>
+       <r>   15.3810    0.0000 </r>
+       <r>   16.2715    0.0000 </r>
+       <r>   16.4648    0.0000 </r>
+       <r>   16.4651    0.0000 </r>
+       <r>   16.7284    0.0000 </r>
+      </set>
+      <set comment="kpoint 64">
+       <r>  -11.7211    1.0000 </r>
+       <r>  -11.6740    1.0000 </r>
+       <r>  -11.6667    1.0000 </r>
+       <r>  -11.6462    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -5.0715    1.0000 </r>
+       <r>   -2.1903    1.0000 </r>
+       <r>    0.9301    1.0000 </r>
+       <r>    2.5383    1.0000 </r>
+       <r>    2.5572    1.0000 </r>
+       <r>    8.6101    0.0000 </r>
+       <r>   10.1816    0.0000 </r>
+       <r>   10.2138    0.0000 </r>
+       <r>   11.4212    0.0000 </r>
+       <r>   15.2172    0.0000 </r>
+       <r>   15.5248    0.0000 </r>
+       <r>   15.8587    0.0000 </r>
+       <r>   15.8727    0.0000 </r>
+       <r>   16.9569    0.0000 </r>
+       <r>   17.3906    0.0000 </r>
+      </set>
+      <set comment="kpoint 65">
+       <r>  -11.6805    1.0000 </r>
+       <r>  -11.6750    1.0000 </r>
+       <r>  -11.6674    1.0000 </r>
+       <r>  -11.6636    1.0000 </r>
+       <r>  -11.6625    1.0000 </r>
+       <r>   -6.3551    1.0000 </r>
+       <r>   -1.2415    1.0000 </r>
+       <r>    3.5117    1.0000 </r>
+       <r>    3.8323    1.0000 </r>
+       <r>    4.6140    1.0000 </r>
+       <r>    7.1782    0.0000 </r>
+       <r>    8.4491    0.0000 </r>
+       <r>    9.0831    0.0000 </r>
+       <r>   10.3484    0.0000 </r>
+       <r>   11.5679    0.0000 </r>
+       <r>   11.9307    0.0000 </r>
+       <r>   13.0405    0.0000 </r>
+       <r>   13.8929    0.0000 </r>
+       <r>   14.2123    0.0000 </r>
+       <r>   15.4431    0.0000 </r>
+      </set>
+      <set comment="kpoint 66">
+       <r>  -11.6830    1.0000 </r>
+       <r>  -11.6764    1.0000 </r>
+       <r>  -11.6669    1.0000 </r>
+       <r>  -11.6618    1.0000 </r>
+       <r>  -11.6599    1.0000 </r>
+       <r>   -6.1863    1.0000 </r>
+       <r>   -1.6066    1.0000 </r>
+       <r>    3.3441    1.0000 </r>
+       <r>    3.9500    1.0000 </r>
+       <r>    4.7612    1.0000 </r>
+       <r>    6.7550    0.0000 </r>
+       <r>    7.9202    0.0000 </r>
+       <r>    8.9604    0.0000 </r>
+       <r>   10.4262    0.0000 </r>
+       <r>   11.8140    0.0000 </r>
+       <r>   12.5066    0.0000 </r>
+       <r>   13.4623    0.0000 </r>
+       <r>   14.7698    0.0000 </r>
+       <r>   15.1763    0.0000 </r>
+       <r>   16.4199    0.0000 </r>
+      </set>
+      <set comment="kpoint 67">
+       <r>  -11.6855    1.0000 </r>
+       <r>  -11.6785    1.0000 </r>
+       <r>  -11.6660    1.0000 </r>
+       <r>  -11.6596    1.0000 </r>
+       <r>  -11.6573    1.0000 </r>
+       <r>   -5.9622    1.0000 </r>
+       <r>   -2.0431    1.0000 </r>
+       <r>    3.2545    1.0000 </r>
+       <r>    4.0691    1.0000 </r>
+       <r>    4.7251    1.0000 </r>
+       <r>    6.5665    0.0000 </r>
+       <r>    7.4105    0.0000 </r>
+       <r>    8.6638    0.0000 </r>
+       <r>   10.6590    0.0000 </r>
+       <r>   12.1869    0.0000 </r>
+       <r>   13.1583    0.0000 </r>
+       <r>   14.2452    0.0000 </r>
+       <r>   15.6321    0.0000 </r>
+       <r>   16.3624    0.0000 </r>
+       <r>   17.0976    0.0000 </r>
+      </set>
+      <set comment="kpoint 68">
+       <r>  -11.6877    1.0000 </r>
+       <r>  -11.6810    1.0000 </r>
+       <r>  -11.6649    1.0000 </r>
+       <r>  -11.6574    1.0000 </r>
+       <r>  -11.6549    1.0000 </r>
+       <r>   -5.7012    1.0000 </r>
+       <r>   -2.4962    1.0000 </r>
+       <r>    3.2451    1.0000 </r>
+       <r>    4.1141    1.0000 </r>
+       <r>    4.5978    1.0000 </r>
+       <r>    6.5490    0.0000 </r>
+       <r>    7.0201    0.0000 </r>
+       <r>    8.2974    0.0000 </r>
+       <r>   11.0813    0.0000 </r>
+       <r>   12.7103    0.0000 </r>
+       <r>   13.8721    0.0000 </r>
+       <r>   15.0217    0.0000 </r>
+       <r>   15.7441    0.0000 </r>
+       <r>   17.4032    0.0000 </r>
+       <r>   17.6762    0.0000 </r>
+      </set>
+      <set comment="kpoint 69">
+       <r>  -11.6891    1.0000 </r>
+       <r>  -11.6831    1.0000 </r>
+       <r>  -11.6640    1.0000 </r>
+       <r>  -11.6556    1.0000 </r>
+       <r>  -11.6533    1.0000 </r>
+       <r>   -5.4420    1.0000 </r>
+       <r>   -2.8989    1.0000 </r>
+       <r>    3.3108    1.0000 </r>
+       <r>    3.9722    1.0000 </r>
+       <r>    4.5914    1.0000 </r>
+       <r>    6.4292    0.0000 </r>
+       <r>    6.9600    0.0000 </r>
+       <r>    7.9302    0.0000 </r>
+       <r>   11.6885    0.0000 </r>
+       <r>   13.3587    0.0000 </r>
+       <r>   14.3880    0.0000 </r>
+       <r>   14.7215    0.0000 </r>
+       <r>   15.9641    0.0000 </r>
+       <r>   17.2321    0.0000 </r>
+       <r>   17.9996    0.0000 </r>
+      </set>
+      <set comment="kpoint 70">
+       <r>  -11.6898    1.0000 </r>
+       <r>  -11.6844    1.0000 </r>
+       <r>  -11.6634    1.0000 </r>
+       <r>  -11.6545    1.0000 </r>
+       <r>  -11.6525    1.0000 </r>
+       <r>   -5.2624    1.0000 </r>
+       <r>   -3.1548    1.0000 </r>
+       <r>    3.4240    1.0000 </r>
+       <r>    3.7703    1.0000 </r>
+       <r>    4.6457    1.0000 </r>
+       <r>    6.2710    0.0000 </r>
+       <r>    7.1210    0.0000 </r>
+       <r>    7.6318    0.0000 </r>
+       <r>   12.4087    0.0000 </r>
+       <r>   13.4971    0.0000 </r>
+       <r>   14.1643    0.0000 </r>
+       <r>   14.8872    0.0000 </r>
+       <r>   15.9751    0.0000 </r>
+       <r>   16.8108    0.0000 </r>
+       <r>   18.3264    0.0000 </r>
+      </set>
+      <set comment="kpoint 71">
+       <r>  -11.6872    1.0000 </r>
+       <r>  -11.6736    1.0000 </r>
+       <r>  -11.6687    1.0000 </r>
+       <r>  -11.6599    1.0000 </r>
+       <r>  -11.6591    1.0000 </r>
+       <r>   -6.1318    1.0000 </r>
+       <r>   -1.6135    1.0000 </r>
+       <r>    3.2363    1.0000 </r>
+       <r>    3.5678    1.0000 </r>
+       <r>    4.5908    1.0000 </r>
+       <r>    6.8287    0.0000 </r>
+       <r>    8.6188    0.0000 </r>
+       <r>    9.1814    0.0000 </r>
+       <r>    9.9255    0.0000 </r>
+       <r>   12.4580    0.0000 </r>
+       <r>   12.7661    0.0000 </r>
+       <r>   13.2974    0.0000 </r>
+       <r>   14.1361    0.0000 </r>
+       <r>   15.2732    0.0000 </r>
+       <r>   17.3302    0.0000 </r>
+      </set>
+      <set comment="kpoint 72">
+       <r>  -11.6904    1.0000 </r>
+       <r>  -11.6749    1.0000 </r>
+       <r>  -11.6682    1.0000 </r>
+       <r>  -11.6580    1.0000 </r>
+       <r>  -11.6566    1.0000 </r>
+       <r>   -5.9319    1.0000 </r>
+       <r>   -1.9527    1.0000 </r>
+       <r>    3.0511    1.0000 </r>
+       <r>    3.6650    1.0000 </r>
+       <r>    4.2275    1.0000 </r>
+       <r>    7.0685    0.0000 </r>
+       <r>    8.1464    0.0000 </r>
+       <r>    9.1037    0.0000 </r>
+       <r>   10.0792    0.0000 </r>
+       <r>   12.7782    0.0000 </r>
+       <r>   13.4319    0.0000 </r>
+       <r>   13.7672    0.0000 </r>
+       <r>   14.9852    0.0000 </r>
+       <r>   16.2881    0.0000 </r>
+       <r>   17.4661    0.0000 </r>
+      </set>
+      <set comment="kpoint 73">
+       <r>  -11.6929    1.0000 </r>
+       <r>  -11.6769    1.0000 </r>
+       <r>  -11.6669    1.0000 </r>
+       <r>  -11.6565    1.0000 </r>
+       <r>  -11.6542    1.0000 </r>
+       <r>   -5.6913    1.0000 </r>
+       <r>   -2.3405    1.0000 </r>
+       <r>    2.9578    1.0000 </r>
+       <r>    3.6187    1.0000 </r>
+       <r>    4.0178    1.0000 </r>
+       <r>    7.2893    0.0000 </r>
+       <r>    7.7539    0.0000 </r>
+       <r>    8.8959    0.0000 </r>
+       <r>   10.3519    0.0000 </r>
+       <r>   13.2094    0.0000 </r>
+       <r>   14.1673    0.0000 </r>
+       <r>   14.5124    0.0000 </r>
+       <r>   15.4113    0.0000 </r>
+       <r>   17.0437    0.0000 </r>
+       <r>   17.5197    0.0000 </r>
+      </set>
+      <set comment="kpoint 74">
+       <r>  -11.6943    1.0000 </r>
+       <r>  -11.6792    1.0000 </r>
+       <r>  -11.6651    1.0000 </r>
+       <r>  -11.6557    1.0000 </r>
+       <r>  -11.6524    1.0000 </r>
+       <r>   -5.4405    1.0000 </r>
+       <r>   -2.7186    1.0000 </r>
+       <r>    2.9478    1.0000 </r>
+       <r>    3.3219    1.0000 </r>
+       <r>    4.1440    1.0000 </r>
+       <r>    7.0836    0.0000 </r>
+       <r>    7.8224    0.0000 </r>
+       <r>    8.6105    0.0000 </r>
+       <r>   10.8183    0.0000 </r>
+       <r>   13.7674    0.0000 </r>
+       <r>   14.4455    0.0000 </r>
+       <r>   14.9008    0.0000 </r>
+       <r>   15.5880    0.0000 </r>
+       <r>   17.0793    0.0000 </r>
+       <r>   17.8385    0.0000 </r>
+      </set>
+      <set comment="kpoint 75">
+       <r>  -11.6946    1.0000 </r>
+       <r>  -11.6812    1.0000 </r>
+       <r>  -11.6633    1.0000 </r>
+       <r>  -11.6556    1.0000 </r>
+       <r>  -11.6515    1.0000 </r>
+       <r>   -5.2388    1.0000 </r>
+       <r>   -3.0055    1.0000 </r>
+       <r>    2.9121    1.0000 </r>
+       <r>    3.1644    1.0000 </r>
+       <r>    4.3397    1.0000 </r>
+       <r>    6.7438    0.0000 </r>
+       <r>    7.9770    0.0000 </r>
+       <r>    8.4030    0.0000 </r>
+       <r>   11.4700    0.0000 </r>
+       <r>   13.4808    0.0000 </r>
+       <r>   14.5149    0.0000 </r>
+       <r>   14.9819    0.0000 </r>
+       <r>   16.1268    0.0000 </r>
+       <r>   17.3400    0.0000 </r>
+       <r>   18.3436    0.0000 </r>
+      </set>
+      <set comment="kpoint 76">
+       <r>  -11.6938    1.0000 </r>
+       <r>  -11.6825    1.0000 </r>
+       <r>  -11.6622    1.0000 </r>
+       <r>  -11.6558    1.0000 </r>
+       <r>  -11.6517    1.0000 </r>
+       <r>   -5.1759    1.0000 </r>
+       <r>   -3.0990    1.0000 </r>
+       <r>    2.7476    1.0000 </r>
+       <r>    3.3070    1.0000 </r>
+       <r>    4.5294    1.0000 </r>
+       <r>    6.4904    0.0000 </r>
+       <r>    7.7825    0.0000 </r>
+       <r>    8.5585    0.0000 </r>
+       <r>   12.1680    0.0000 </r>
+       <r>   12.7314    0.0000 </r>
+       <r>   14.2163    0.0000 </r>
+       <r>   15.2706    0.0000 </r>
+       <r>   16.8594    0.0000 </r>
+       <r>   17.0939    0.0000 </r>
+       <r>   18.1220    0.0000 </r>
+      </set>
+      <set comment="kpoint 77">
+       <r>  -11.6922    1.0000 </r>
+       <r>  -11.6826    1.0000 </r>
+       <r>  -11.6624    1.0000 </r>
+       <r>  -11.6560    1.0000 </r>
+       <r>  -11.6529    1.0000 </r>
+       <r>   -5.2922    1.0000 </r>
+       <r>   -2.9558    1.0000 </r>
+       <r>    2.6461    1.0000 </r>
+       <r>    3.5636    1.0000 </r>
+       <r>    4.6527    1.0000 </r>
+       <r>    6.3947    0.0000 </r>
+       <r>    7.4762    0.0000 </r>
+       <r>    8.8282    0.0000 </r>
+       <r>   11.7751    0.0000 </r>
+       <r>   13.2384    0.0000 </r>
+       <r>   13.5672    0.0000 </r>
+       <r>   15.4499    0.0000 </r>
+       <r>   16.1194    0.0000 </r>
+       <r>   17.3107    0.0000 </r>
+       <r>   18.3783    0.0000 </r>
+      </set>
+      <set comment="kpoint 78">
+       <r>  -11.6902    1.0000 </r>
+       <r>  -11.6816    1.0000 </r>
+       <r>  -11.6637    1.0000 </r>
+       <r>  -11.6564    1.0000 </r>
+       <r>  -11.6546    1.0000 </r>
+       <r>   -5.5194    1.0000 </r>
+       <r>   -2.6509    1.0000 </r>
+       <r>    2.6506    1.0000 </r>
+       <r>    3.8738    1.0000 </r>
+       <r>    4.6603    1.0000 </r>
+       <r>    6.5018    0.0000 </r>
+       <r>    7.1851    0.0000 </r>
+       <r>    9.0650    0.0000 </r>
+       <r>   11.2261    0.0000 </r>
+       <r>   12.8393    0.0000 </r>
+       <r>   14.2375    0.0000 </r>
+       <r>   14.8104    0.0000 </r>
+       <r>   15.2458    0.0000 </r>
+       <r>   18.0294    0.0000 </r>
+       <r>   18.3348    0.0000 </r>
+      </set>
+      <set comment="kpoint 79">
+       <r>  -11.6880    1.0000 </r>
+       <r>  -11.6797    1.0000 </r>
+       <r>  -11.6652    1.0000 </r>
+       <r>  -11.6580    1.0000 </r>
+       <r>  -11.6560    1.0000 </r>
+       <r>   -5.7727    1.0000 </r>
+       <r>   -2.2830    1.0000 </r>
+       <r>    2.7710    1.0000 </r>
+       <r>    4.1386    1.0000 </r>
+       <r>    4.6188    1.0000 </r>
+       <r>    6.6831    0.0000 </r>
+       <r>    7.0556    0.0000 </r>
+       <r>    9.1989    0.0000 </r>
+       <r>   10.8551    0.0000 </r>
+       <r>   12.3762    0.0000 </r>
+       <r>   13.8776    0.0000 </r>
+       <r>   14.1703    0.0000 </r>
+       <r>   15.5110    0.0000 </r>
+       <r>   17.1674    0.0000 </r>
+       <r>   17.4373    0.0000 </r>
+      </set>
+      <set comment="kpoint 80">
+       <r>  -11.6856    1.0000 </r>
+       <r>  -11.6777    1.0000 </r>
+       <r>  -11.6664    1.0000 </r>
+       <r>  -11.6601    1.0000 </r>
+       <r>  -11.6577    1.0000 </r>
+       <r>   -6.0032    1.0000 </r>
+       <r>   -1.9200    1.0000 </r>
+       <r>    3.0069    1.0000 </r>
+       <r>    4.1302    1.0000 </r>
+       <r>    4.7221    1.0000 </r>
+       <r>    6.6362    0.0000 </r>
+       <r>    7.4025    0.0000 </r>
+       <r>    9.1846    0.0000 </r>
+       <r>   10.5958    0.0000 </r>
+       <r>   12.0455    0.0000 </r>
+       <r>   13.2572    0.0000 </r>
+       <r>   13.4907    0.0000 </r>
+       <r>   15.6009    0.0000 </r>
+       <r>   16.0607    0.0000 </r>
+       <r>   17.0588    0.0000 </r>
+      </set>
+      <set comment="kpoint 81">
+       <r>  -11.6961    1.0000 </r>
+       <r>  -11.6718    1.0000 </r>
+       <r>  -11.6702    1.0000 </r>
+       <r>  -11.6556    1.0000 </r>
+       <r>  -11.6553    1.0000 </r>
+       <r>   -5.8438    1.0000 </r>
+       <r>   -1.9305    1.0000 </r>
+       <r>    2.9493    1.0000 </r>
+       <r>    3.2665    1.0000 </r>
+       <r>    3.5944    1.0000 </r>
+       <r>    7.7632    0.0000 </r>
+       <r>    8.8943    0.0000 </r>
+       <r>    9.1873    0.0000 </r>
+       <r>    9.7695    0.0000 </r>
+       <r>   13.5278    0.0000 </r>
+       <r>   13.5786    0.0000 </r>
+       <r>   13.8087    0.0000 </r>
+       <r>   14.4835    0.0000 </r>
+       <r>   16.4760    0.0000 </r>
+       <r>   17.7178    0.0000 </r>
+      </set>
+      <set comment="kpoint 82">
+       <r>  -11.6994    1.0000 </r>
+       <r>  -11.6730    1.0000 </r>
+       <r>  -11.6695    1.0000 </r>
+       <r>  -11.6541    1.0000 </r>
+       <r>  -11.6530    1.0000 </r>
+       <r>   -5.6316    1.0000 </r>
+       <r>   -2.2138    1.0000 </r>
+       <r>    2.7693    1.0000 </r>
+       <r>    3.0248    1.0000 </r>
+       <r>    3.4956    1.0000 </r>
+       <r>    8.1342    0.0000 </r>
+       <r>    8.5537    0.0000 </r>
+       <r>    9.1874    0.0000 </r>
+       <r>    9.9502    0.0000 </r>
+       <r>   13.8285    0.0000 </r>
+       <r>   14.1759    0.0000 </r>
+       <r>   14.5064    0.0000 </r>
+       <r>   15.0889    0.0000 </r>
+       <r>   16.9292    0.0000 </r>
+       <r>   17.5133    0.0000 </r>
+      </set>
+      <set comment="kpoint 83">
+       <r>  -11.7012    1.0000 </r>
+       <r>  -11.6749    1.0000 </r>
+       <r>  -11.6678    1.0000 </r>
+       <r>  -11.6537    1.0000 </r>
+       <r>  -11.6511    1.0000 </r>
+       <r>   -5.4034    1.0000 </r>
+       <r>   -2.5279    1.0000 </r>
+       <r>    2.5840    1.0000 </r>
+       <r>    2.7498    1.0000 </r>
+       <r>    3.6808    1.0000 </r>
+       <r>    7.8696    0.0000 </r>
+       <r>    8.7388    0.0000 </r>
+       <r>    9.1579    0.0000 </r>
+       <r>   10.1672    0.0000 </r>
+       <r>   14.2302    0.0000 </r>
+       <r>   14.5891    0.0000 </r>
+       <r>   15.0163    0.0000 </r>
+       <r>   15.3496    0.0000 </r>
+       <r>   17.0762    0.0000 </r>
+       <r>   17.3566    0.0000 </r>
+      </set>
+      <set comment="kpoint 84">
+       <r>  -11.7012    1.0000 </r>
+       <r>  -11.6772    1.0000 </r>
+       <r>  -11.6654    1.0000 </r>
+       <r>  -11.6544    1.0000 </r>
+       <r>  -11.6502    1.0000 </r>
+       <r>   -5.2033    1.0000 </r>
+       <r>   -2.8077    1.0000 </r>
+       <r>    2.3007    1.0000 </r>
+       <r>    2.7724    1.0000 </r>
+       <r>    3.9176    1.0000 </r>
+       <r>    7.4432    0.0000 </r>
+       <r>    8.7693    0.0000 </r>
+       <r>    9.2306    0.0000 </r>
+       <r>   10.6332    0.0000 </r>
+       <r>   13.6310    0.0000 </r>
+       <r>   14.9481    0.0000 </r>
+       <r>   15.1076    0.0000 </r>
+       <r>   16.2089    0.0000 </r>
+       <r>   17.0207    0.0000 </r>
+       <r>   18.3691    0.0000 </r>
+      </set>
+      <set comment="kpoint 85">
+       <r>  -11.6997    1.0000 </r>
+       <r>  -11.6793    1.0000 </r>
+       <r>  -11.6628    1.0000 </r>
+       <r>  -11.6559    1.0000 </r>
+       <r>  -11.6503    1.0000 </r>
+       <r>   -5.0995    1.0000 </r>
+       <r>   -2.9702    1.0000 </r>
+       <r>    2.1188    1.0000 </r>
+       <r>    2.9137    1.0000 </r>
+       <r>    4.1815    1.0000 </r>
+       <r>    7.0475    0.0000 </r>
+       <r>    8.4696    0.0000 </r>
+       <r>    9.4696    0.0000 </r>
+       <r>   11.3218    0.0000 </r>
+       <r>   12.8124    0.0000 </r>
+       <r>   14.3885    0.0000 </r>
+       <r>   15.5943    0.0000 </r>
+       <r>   16.9329    0.0000 </r>
+       <r>   17.7211    0.0000 </r>
+       <r>   17.9039    0.0000 </r>
+      </set>
+      <set comment="kpoint 86">
+       <r>  -11.6970    1.0000 </r>
+       <r>  -11.6808    1.0000 </r>
+       <r>  -11.6607    1.0000 </r>
+       <r>  -11.6575    1.0000 </r>
+       <r>  -11.6516    1.0000 </r>
+       <r>   -5.1466    1.0000 </r>
+       <r>   -2.9543    1.0000 </r>
+       <r>    2.0674    1.0000 </r>
+       <r>    3.1507    1.0000 </r>
+       <r>    4.4446    1.0000 </r>
+       <r>    6.7194    0.0000 </r>
+       <r>    8.0941    0.0000 </r>
+       <r>    9.6380    0.0000 </r>
+       <r>   11.9914    0.0000 </r>
+       <r>   12.3238    0.0000 </r>
+       <r>   13.7066    0.0000 </r>
+       <r>   15.4205    0.0000 </r>
+       <r>   16.9866    0.0000 </r>
+       <r>   17.7000    0.0000 </r>
+       <r>   18.5168    0.0000 </r>
+      </set>
+      <set comment="kpoint 87">
+       <r>  -11.6937    1.0000 </r>
+       <r>  -11.6814    1.0000 </r>
+       <r>  -11.6616    1.0000 </r>
+       <r>  -11.6569    1.0000 </r>
+       <r>  -11.6535    1.0000 </r>
+       <r>   -5.3203    1.0000 </r>
+       <r>   -2.7854    1.0000 </r>
+       <r>    2.1586    1.0000 </r>
+       <r>    3.4680    1.0000 </r>
+       <r>    4.6439    1.0000 </r>
+       <r>    6.5207    0.0000 </r>
+       <r>    7.6896    0.0000 </r>
+       <r>    9.6602    0.0000 </r>
+       <r>   11.6005    0.0000 </r>
+       <r>   13.0803    0.0000 </r>
+       <r>   13.2481    0.0000 </r>
+       <r>   14.6763    0.0000 </r>
+       <r>   16.2363    0.0000 </r>
+       <r>   18.3763    0.0000 </r>
+       <r>   19.1092    0.0000 </r>
+      </set>
+      <set comment="kpoint 88">
+       <r>  -11.6906    1.0000 </r>
+       <r>  -11.6809    1.0000 </r>
+       <r>  -11.6636    1.0000 </r>
+       <r>  -11.6560    1.0000 </r>
+       <r>  -11.6558    1.0000 </r>
+       <r>   -5.5481    1.0000 </r>
+       <r>   -2.5414    1.0000 </r>
+       <r>    2.3962    1.0000 </r>
+       <r>    3.8354    1.0000 </r>
+       <r>    4.6867    1.0000 </r>
+       <r>    6.5425    0.0000 </r>
+       <r>    7.2857    0.0000 </r>
+       <r>    9.5141    0.0000 </r>
+       <r>   11.2167    0.0000 </r>
+       <r>   12.7032    0.0000 </r>
+       <r>   13.8369    0.0000 </r>
+       <r>   14.5053    0.0000 </r>
+       <r>   15.2882    0.0000 </r>
+       <r>   18.1921    0.0000 </r>
+       <r>   18.3762    0.0000 </r>
+      </set>
+      <set comment="kpoint 89">
+       <r>  -11.7060    1.0000 </r>
+       <r>  -11.6716    1.0000 </r>
+       <r>  -11.6699    1.0000 </r>
+       <r>  -11.6517    1.0000 </r>
+       <r>  -11.6513    1.0000 </r>
+       <r>   -5.5291    1.0000 </r>
+       <r>   -2.1430    1.0000 </r>
+       <r>    2.4382    1.0000 </r>
+       <r>    2.6980    1.0000 </r>
+       <r>    3.0693    1.0000 </r>
+       <r>    8.9746    0.0000 </r>
+       <r>    8.9893    0.0000 </r>
+       <r>    9.3074    0.0000 </r>
+       <r>    9.9671    0.0000 </r>
+       <r>   14.0535    0.0000 </r>
+       <r>   14.5837    0.0000 </r>
+       <r>   14.6994    0.0000 </r>
+       <r>   15.0684    0.0000 </r>
+       <r>   17.0002    0.0000 </r>
+       <r>   18.0030    0.0000 </r>
+      </set>
+      <set comment="kpoint 90">
+       <r>  -11.7084    1.0000 </r>
+       <r>  -11.6711    1.0000 </r>
+       <r>  -11.6707    1.0000 </r>
+       <r>  -11.6511    1.0000 </r>
+       <r>  -11.6495    1.0000 </r>
+       <r>   -5.3362    1.0000 </r>
+       <r>   -2.3564    1.0000 </r>
+       <r>    2.0269    1.0000 </r>
+       <r>    2.5555    1.0000 </r>
+       <r>    3.2507    1.0000 </r>
+       <r>    8.6843    0.0000 </r>
+       <r>    9.1225    0.0000 </r>
+       <r>    9.6349    0.0000 </r>
+       <r>   10.1064    0.0000 </r>
+       <r>   14.3968    0.0000 </r>
+       <r>   14.9168    0.0000 </r>
+       <r>   15.1599    0.0000 </r>
+       <r>   15.4830    0.0000 </r>
+       <r>   17.0115    0.0000 </r>
+       <r>   17.2586    0.0000 </r>
+      </set>
+      <set comment="kpoint 91">
+       <r>  -11.7085    1.0000 </r>
+       <r>  -11.6731    1.0000 </r>
+       <r>  -11.6686    1.0000 </r>
+       <r>  -11.6519    1.0000 </r>
+       <r>  -11.6485    1.0000 </r>
+       <r>   -5.1597    1.0000 </r>
+       <r>   -2.5902    1.0000 </r>
+       <r>    1.7409    1.0000 </r>
+       <r>    2.5299    1.0000 </r>
+       <r>    3.4934    1.0000 </r>
+       <r>    8.2157    0.0000 </r>
+       <r>    9.2328    0.0000 </r>
+       <r>    9.9910    0.0000 </r>
+       <r>   10.2034    0.0000 </r>
+       <r>   13.9307    0.0000 </r>
+       <r>   15.1597    0.0000 </r>
+       <r>   15.4796    0.0000 </r>
+       <r>   16.1374    0.0000 </r>
+       <r>   16.9747    0.0000 </r>
+       <r>   17.8468    0.0000 </r>
+      </set>
+      <set comment="kpoint 92">
+       <r>  -11.7064    1.0000 </r>
+       <r>  -11.6755    1.0000 </r>
+       <r>  -11.6657    1.0000 </r>
+       <r>  -11.6537    1.0000 </r>
+       <r>  -11.6486    1.0000 </r>
+       <r>   -5.0451    1.0000 </r>
+       <r>   -2.7853    1.0000 </r>
+       <r>    1.6006    1.0000 </r>
+       <r>    2.6173    1.0000 </r>
+       <r>    3.7809    1.0000 </r>
+       <r>    7.7306    0.0000 </r>
+       <r>    9.0680    0.0000 </r>
+       <r>   10.2571    0.0000 </r>
+       <r>   10.5607    0.0000 </r>
+       <r>   13.1880    0.0000 </r>
+       <r>   14.7008    0.0000 </r>
+       <r>   15.8870    0.0000 </r>
+       <r>   16.6958    0.0000 </r>
+       <r>   17.5100    0.0000 </r>
+       <r>   18.0860    0.0000 </r>
+      </set>
+      <set comment="kpoint 93">
+       <r>  -11.7028    1.0000 </r>
+       <r>  -11.6780    1.0000 </r>
+       <r>  -11.6624    1.0000 </r>
+       <r>  -11.6562    1.0000 </r>
+       <r>  -11.6498    1.0000 </r>
+       <r>   -5.0369    1.0000 </r>
+       <r>   -2.8862    1.0000 </r>
+       <r>    1.6207    1.0000 </r>
+       <r>    2.8109    1.0000 </r>
+       <r>    4.0976    1.0000 </r>
+       <r>    7.2537    0.0000 </r>
+       <r>    8.6901    0.0000 </r>
+       <r>   10.2689    0.0000 </r>
+       <r>   11.2701    0.0000 </r>
+       <r>   12.5819    0.0000 </r>
+       <r>   14.0805    0.0000 </r>
+       <r>   15.4346    0.0000 </r>
+       <r>   17.3322    0.0000 </r>
+       <r>   18.2066    0.0000 </r>
+       <r>   18.4441    0.0000 </r>
+      </set>
+      <set comment="kpoint 94">
+       <r>  -11.6982    1.0000 </r>
+       <r>  -11.6801    1.0000 </r>
+       <r>  -11.6593    1.0000 </r>
+       <r>  -11.6590    1.0000 </r>
+       <r>  -11.6516    1.0000 </r>
+       <r>   -5.1422    1.0000 </r>
+       <r>   -2.8764    1.0000 </r>
+       <r>    1.8084    1.0000 </r>
+       <r>    3.1000    1.0000 </r>
+       <r>    4.4125    1.0000 </r>
+       <r>    6.8199    0.0000 </r>
+       <r>    8.2131    0.0000 </r>
+       <r>   10.0582    0.0000 </r>
+       <r>   12.0814    0.0000 </r>
+       <r>   12.1731    0.0000 </r>
+       <r>   13.5570    0.0000 </r>
+       <r>   14.8464    0.0000 </r>
+       <r>   17.2431    0.0000 </r>
+       <r>   18.5357    0.0000 </r>
+       <r>   18.7135    0.0000 </r>
+      </set>
+      <set comment="kpoint 95">
+       <r>  -11.7145    1.0000 </r>
+       <r>  -11.6728    1.0000 </r>
+       <r>  -11.6684    1.0000 </r>
+       <r>  -11.6488    1.0000 </r>
+       <r>  -11.6479    1.0000 </r>
+       <r>   -5.2501    1.0000 </r>
+       <r>   -2.2357    1.0000 </r>
+       <r>    1.5476    1.0000 </r>
+       <r>    2.5147    1.0000 </r>
+       <r>    2.8811    1.0000 </r>
+       <r>    8.8072    0.0000 </r>
+       <r>    9.4868    0.0000 </r>
+       <r>   10.2323    0.0000 </r>
+       <r>   10.3849    0.0000 </r>
+       <r>   14.5836    0.0000 </r>
+       <r>   14.9333    0.0000 </r>
+       <r>   15.6887    0.0000 </r>
+       <r>   15.8298    0.0000 </r>
+       <r>   16.9508    0.0000 </r>
+       <r>   17.3761    0.0000 </r>
+      </set>
+      <set comment="kpoint 96">
+       <r>  -11.7150    1.0000 </r>
+       <r>  -11.6715    1.0000 </r>
+       <r>  -11.6697    1.0000 </r>
+       <r>  -11.6493    1.0000 </r>
+       <r>  -11.6470    1.0000 </r>
+       <r>   -5.1162    1.0000 </r>
+       <r>   -2.3888    1.0000 </r>
+       <r>    1.3048    1.0000 </r>
+       <r>    2.4115    1.0000 </r>
+       <r>    3.1078    1.0000 </r>
+       <r>    8.8859    0.0000 </r>
+       <r>    9.1238    0.0000 </r>
+       <r>   10.2906    0.0000 </r>
+       <r>   10.7585    0.0000 </r>
+       <r>   14.3803    0.0000 </r>
+       <r>   15.1610    0.0000 </r>
+       <r>   15.8882    0.0000 </r>
+       <r>   16.2082    0.0000 </r>
+       <r>   17.0097    0.0000 </r>
+       <r>   17.5089    0.0000 </r>
+      </set>
+      <set comment="kpoint 97">
+       <r>  -11.7128    1.0000 </r>
+       <r>  -11.6720    1.0000 </r>
+       <r>  -11.6690    1.0000 </r>
+       <r>  -11.6510    1.0000 </r>
+       <r>  -11.6470    1.0000 </r>
+       <r>   -5.0218    1.0000 </r>
+       <r>   -2.5752    1.0000 </r>
+       <r>    1.2300    1.0000 </r>
+       <r>    2.4303    1.0000 </r>
+       <r>    3.3979    1.0000 </r>
+       <r>    8.4284    0.0000 </r>
+       <r>    9.2768    0.0000 </r>
+       <r>   10.2325    0.0000 </r>
+       <r>   10.8676    0.0000 </r>
+       <r>   13.7208    0.0000 </r>
+       <r>   15.1688    0.0000 </r>
+       <r>   15.9959    0.0000 </r>
+       <r>   16.3611    0.0000 </r>
+       <r>   17.5216    0.0000 </r>
+       <r>   17.7682    0.0000 </r>
+      </set>
+      <set comment="kpoint 98">
+       <r>  -11.7084    1.0000 </r>
+       <r>  -11.6749    1.0000 </r>
+       <r>  -11.6658    1.0000 </r>
+       <r>  -11.6535    1.0000 </r>
+       <r>  -11.6481    1.0000 </r>
+       <r>   -4.9917    1.0000 </r>
+       <r>   -2.7533    1.0000 </r>
+       <r>    1.3360    1.0000 </r>
+       <r>    2.5665    1.0000 </r>
+       <r>    3.7343    1.0000 </r>
+       <r>    7.8469    0.0000 </r>
+       <r>    9.1606    0.0000 </r>
+       <r>   10.5444    0.0000 </r>
+       <r>   10.6902    0.0000 </r>
+       <r>   13.1296    0.0000 </r>
+       <r>   14.5939    0.0000 </r>
+       <r>   15.7418    0.0000 </r>
+       <r>   16.8587    0.0000 </r>
+       <r>   18.1120    0.0000 </r>
+       <r>   18.3156    0.0000 </r>
+      </set>
+      <set comment="kpoint 99">
+       <r>  -11.7195    1.0000 </r>
+       <r>  -11.6734    1.0000 </r>
+       <r>  -11.6675    1.0000 </r>
+       <r>  -11.6473    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -5.0836    1.0000 </r>
+       <r>   -2.2437    1.0000 </r>
+       <r>    1.0263    1.0000 </r>
+       <r>    2.4185    1.0000 </r>
+       <r>    2.7849    1.0000 </r>
+       <r>    8.7102    0.0000 </r>
+       <r>    9.7025    0.0000 </r>
+       <r>   10.4071    0.0000 </r>
+       <r>   11.2425    0.0000 </r>
+       <r>   14.9611    0.0000 </r>
+       <r>   15.1638    0.0000 </r>
+       <r>   15.9984    0.0000 </r>
+       <r>   16.4567    0.0000 </r>
+       <r>   16.5499    0.0000 </r>
+       <r>   17.4167    0.0000 </r>
+      </set>
+      <set comment="kpoint 100">
+       <r>  -11.7174    1.0000 </r>
+       <r>  -11.6717    1.0000 </r>
+       <r>  -11.6691    1.0000 </r>
+       <r>  -11.6487    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -5.0348    1.0000 </r>
+       <r>   -2.3807    1.0000 </r>
+       <r>    1.0338    1.0000 </r>
+       <r>    2.3623    1.0000 </r>
+       <r>    3.0592    1.0000 </r>
+       <r>    8.8911    0.0000 </r>
+       <r>    9.1980    0.0000 </r>
+       <r>   10.3865    0.0000 </r>
+       <r>   11.2147    0.0000 </r>
+       <r>   14.3331    0.0000 </r>
+       <r>   15.5351    0.0000 </r>
+       <r>   15.7824    0.0000 </r>
+       <r>   16.5187    0.0000 </r>
+       <r>   17.1038    0.0000 </r>
+       <r>   17.2667    0.0000 </r>
+      </set>
+      <set comment="kpoint 101">
+       <r>  -11.6935    1.0000 </r>
+       <r>  -11.6759    1.0000 </r>
+       <r>  -11.6675    1.0000 </r>
+       <r>  -11.6558    1.0000 </r>
+       <r>  -11.6552    1.0000 </r>
+       <r>   -5.7271    1.0000 </r>
+       <r>   -2.2231    1.0000 </r>
+       <r>    2.7094    1.0000 </r>
+       <r>    3.6013    1.0000 </r>
+       <r>    4.0630    1.0000 </r>
+       <r>    7.3690    0.0000 </r>
+       <r>    7.7765    0.0000 </r>
+       <r>    9.2995    0.0000 </r>
+       <r>   10.3662    0.0000 </r>
+       <r>   13.1115    0.0000 </r>
+       <r>   13.7349    0.0000 </r>
+       <r>   14.3381    0.0000 </r>
+       <r>   15.3299    0.0000 </r>
+       <r>   17.0654    0.0000 </r>
+       <r>   17.2309    0.0000 </r>
+      </set>
+      <set comment="kpoint 102">
+       <r>  -11.6959    1.0000 </r>
+       <r>  -11.6776    1.0000 </r>
+       <r>  -11.6659    1.0000 </r>
+       <r>  -11.6551    1.0000 </r>
+       <r>  -11.6533    1.0000 </r>
+       <r>   -5.4948    1.0000 </r>
+       <r>   -2.5218    1.0000 </r>
+       <r>    2.4834    1.0000 </r>
+       <r>    3.2115    1.0000 </r>
+       <r>    4.2764    1.0000 </r>
+       <r>    7.0834    0.0000 </r>
+       <r>    8.0303    0.0000 </r>
+       <r>    9.3830    0.0000 </r>
+       <r>   10.6592    0.0000 </r>
+       <r>   13.4820    0.0000 </r>
+       <r>   14.1054    0.0000 </r>
+       <r>   14.6572    0.0000 </r>
+       <r>   15.3088    0.0000 </r>
+       <r>   17.7838    0.0000 </r>
+       <r>   18.1261    0.0000 </r>
+      </set>
+      <set comment="kpoint 103">
+       <r>  -11.6974    1.0000 </r>
+       <r>  -11.6792    1.0000 </r>
+       <r>  -11.6638    1.0000 </r>
+       <r>  -11.6558    1.0000 </r>
+       <r>  -11.6515    1.0000 </r>
+       <r>   -5.2732    1.0000 </r>
+       <r>   -2.7983    1.0000 </r>
+       <r>    2.3827    1.0000 </r>
+       <r>    2.8638    1.0000 </r>
+       <r>    4.5007    1.0000 </r>
+       <r>    6.7279    0.0000 </r>
+       <r>    8.4025    0.0000 </r>
+       <r>    9.3462    0.0000 </r>
+       <r>   11.0366    0.0000 </r>
+       <r>   13.3496    0.0000 </r>
+       <r>   14.0453    0.0000 </r>
+       <r>   15.1500    0.0000 </r>
+       <r>   16.1435    0.0000 </r>
+       <r>   17.3285    0.0000 </r>
+       <r>   18.9342    0.0000 </r>
+      </set>
+      <set comment="kpoint 104">
+       <r>  -11.6981    1.0000 </r>
+       <r>  -11.6802    1.0000 </r>
+       <r>  -11.6617    1.0000 </r>
+       <r>  -11.6572    1.0000 </r>
+       <r>  -11.6504    1.0000 </r>
+       <r>   -5.1274    1.0000 </r>
+       <r>   -2.9753    1.0000 </r>
+       <r>    2.3930    1.0000 </r>
+       <r>    2.6244    1.0000 </r>
+       <r>    4.6466    1.0000 </r>
+       <r>    6.5123    0.0000 </r>
+       <r>    8.7014    0.0000 </r>
+       <r>    9.1993    0.0000 </r>
+       <r>   11.6053    0.0000 </r>
+       <r>   12.4745    0.0000 </r>
+       <r>   14.6594    0.0000 </r>
+       <r>   15.3090    0.0000 </r>
+       <r>   16.8722    0.0000 </r>
+       <r>   17.3048    0.0000 </r>
+       <r>   18.2581    0.0000 </r>
+      </set>
+      <set comment="kpoint 105">
+       <r>  -11.7023    1.0000 </r>
+       <r>  -11.6739    1.0000 </r>
+       <r>  -11.6686    1.0000 </r>
+       <r>  -11.6531    1.0000 </r>
+       <r>  -11.6514    1.0000 </r>
+       <r>   -5.4308    1.0000 </r>
+       <r>   -2.4181    1.0000 </r>
+       <r>    2.4511    1.0000 </r>
+       <r>    2.5759    1.0000 </r>
+       <r>    3.7658    1.0000 </r>
+       <r>    7.8742    0.0000 </r>
+       <r>    8.8770    0.0000 </r>
+       <r>    9.3106    0.0000 </r>
+       <r>   10.3718    0.0000 </r>
+       <r>   14.0815    0.0000 </r>
+       <r>   14.3066    0.0000 </r>
+       <r>   14.7234    0.0000 </r>
+       <r>   15.4142    0.0000 </r>
+       <r>   17.3281    0.0000 </r>
+       <r>   18.2917    0.0000 </r>
+      </set>
+      <set comment="kpoint 106">
+       <r>  -11.7037    1.0000 </r>
+       <r>  -11.6754    1.0000 </r>
+       <r>  -11.6667    1.0000 </r>
+       <r>  -11.6539    1.0000 </r>
+       <r>  -11.6496    1.0000 </r>
+       <r>   -5.2322    1.0000 </r>
+       <r>   -2.6342    1.0000 </r>
+       <r>    2.2012    1.0000 </r>
+       <r>    2.2755    1.0000 </r>
+       <r>    4.0757    1.0000 </r>
+       <r>    7.4160    0.0000 </r>
+       <r>    9.2980    0.0000 </r>
+       <r>    9.5040    0.0000 </r>
+       <r>   10.6413    0.0000 </r>
+       <r>   13.5585    0.0000 </r>
+       <r>   14.6836    0.0000 </r>
+       <r>   14.9107    0.0000 </r>
+       <r>   16.2351    0.0000 </r>
+       <r>   17.4376    0.0000 </r>
+       <r>   18.3580    0.0000 </r>
+      </set>
+      <set comment="kpoint 107">
+       <r>  -11.7037    1.0000 </r>
+       <r>  -11.6771    1.0000 </r>
+       <r>  -11.6641    1.0000 </r>
+       <r>  -11.6559    1.0000 </r>
+       <r>  -11.6486    1.0000 </r>
+       <r>   -5.0825    1.0000 </r>
+       <r>   -2.8109    1.0000 </r>
+       <r>    1.9707    1.0000 </r>
+       <r>    2.2135    1.0000 </r>
+       <r>    4.3770    1.0000 </r>
+       <r>    7.0011    0.0000 </r>
+       <r>    9.4585    0.0000 </r>
+       <r>    9.7517    0.0000 </r>
+       <r>   10.9576    0.0000 </r>
+       <r>   12.7112    0.0000 </r>
+       <r>   15.2126    0.0000 </r>
+       <r>   15.3359    0.0000 </r>
+       <r>   16.5174    0.0000 </r>
+       <r>   17.2794    0.0000 </r>
+       <r>   18.4153    0.0000 </r>
+      </set>
+      <set comment="kpoint 108">
+       <r>  -11.7026    1.0000 </r>
+       <r>  -11.6783    1.0000 </r>
+       <r>  -11.6612    1.0000 </r>
+       <r>  -11.6584    1.0000 </r>
+       <r>  -11.6487    1.0000 </r>
+       <r>   -5.0367    1.0000 </r>
+       <r>   -2.8884    1.0000 </r>
+       <r>    1.8729    1.0000 </r>
+       <r>    2.2905    1.0000 </r>
+       <r>    4.6145    1.0000 </r>
+       <r>    6.6931    0.0000 </r>
+       <r>    9.3115    0.0000 </r>
+       <r>    9.9136    0.0000 </r>
+       <r>   11.5290    0.0000 </r>
+       <r>   12.0205    0.0000 </r>
+       <r>   14.9257    0.0000 </r>
+       <r>   15.6013    0.0000 </r>
+       <r>   16.7193    0.0000 </r>
+       <r>   17.4018    0.0000 </r>
+       <r>   18.6757    0.0000 </r>
+      </set>
+      <set comment="kpoint 109">
+       <r>  -11.7007    1.0000 </r>
+       <r>  -11.6788    1.0000 </r>
+       <r>  -11.6617    1.0000 </r>
+       <r>  -11.6578    1.0000 </r>
+       <r>  -11.6498    1.0000 </r>
+       <r>   -5.1173    1.0000 </r>
+       <r>   -2.8406    1.0000 </r>
+       <r>    1.9246    1.0000 </r>
+       <r>    2.4926    1.0000 </r>
+       <r>    4.6956    1.0000 </r>
+       <r>    6.5850    0.0000 </r>
+       <r>    8.9754    0.0000 </r>
+       <r>    9.8836    0.0000 </r>
+       <r>   11.4924    0.0000 </r>
+       <r>   12.3720    0.0000 </r>
+       <r>   14.3644    0.0000 </r>
+       <r>   15.0985    0.0000 </r>
+       <r>   16.9278    0.0000 </r>
+       <r>   17.8061    0.0000 </r>
+       <r>   18.9671    0.0000 </r>
+      </set>
+      <set comment="kpoint 110">
+       <r>  -11.6984    1.0000 </r>
+       <r>  -11.6784    1.0000 </r>
+       <r>  -11.6641    1.0000 </r>
+       <r>  -11.6557    1.0000 </r>
+       <r>  -11.6516    1.0000 </r>
+       <r>   -5.2890    1.0000 </r>
+       <r>   -2.7007    1.0000 </r>
+       <r>    2.1307    1.0000 </r>
+       <r>    2.8064    1.0000 </r>
+       <r>    4.5585    1.0000 </r>
+       <r>    6.7398    0.0000 </r>
+       <r>    8.5293    0.0000 </r>
+       <r>    9.6841    0.0000 </r>
+       <r>   11.0963    0.0000 </r>
+       <r>   13.3049    0.0000 </r>
+       <r>   13.8959    0.0000 </r>
+       <r>   14.5569    0.0000 </r>
+       <r>   16.2889    0.0000 </r>
+       <r>   18.4304    0.0000 </r>
+       <r>   18.5343    0.0000 </r>
+      </set>
+      <set comment="kpoint 111">
+       <r>  -11.7100    1.0000 </r>
+       <r>  -11.6720    1.0000 </r>
+       <r>  -11.6695    1.0000 </r>
+       <r>  -11.6516    1.0000 </r>
+       <r>  -11.6480    1.0000 </r>
+       <r>   -5.1761    1.0000 </r>
+       <r>   -2.4899    1.0000 </r>
+       <r>    1.6939    1.0000 </r>
+       <r>    2.2637    1.0000 </r>
+       <r>    3.5846    1.0000 </r>
+       <r>    8.2203    0.0000 </r>
+       <r>    9.2344    0.0000 </r>
+       <r>   10.1201    0.0000 </r>
+       <r>   10.5406    0.0000 </r>
+       <r>   13.9006    0.0000 </r>
+       <r>   14.8459    0.0000 </r>
+       <r>   15.5226    0.0000 </r>
+       <r>   16.2449    0.0000 </r>
+       <r>   17.5435    0.0000 </r>
+       <r>   17.7606    0.0000 </r>
+      </set>
+      <set comment="kpoint 112">
+       <r>  -11.7096    1.0000 </r>
+       <r>  -11.6737    1.0000 </r>
+       <r>  -11.6673    1.0000 </r>
+       <r>  -11.6534    1.0000 </r>
+       <r>  -11.6470    1.0000 </r>
+       <r>   -5.0474    1.0000 </r>
+       <r>   -2.6353    1.0000 </r>
+       <r>    1.5012    1.0000 </r>
+       <r>    2.1123    1.0000 </r>
+       <r>    3.9483    1.0000 </r>
+       <r>    7.6991    0.0000 </r>
+       <r>    9.4885    0.0000 </r>
+       <r>   10.4147    0.0000 </r>
+       <r>   10.7478    0.0000 </r>
+       <r>   13.1390    0.0000 </r>
+       <r>   15.3146    0.0000 </r>
+       <r>   15.8356    0.0000 </r>
+       <r>   16.4050    0.0000 </r>
+       <r>   17.1818    0.0000 </r>
+       <r>   17.9348    0.0000 </r>
+      </set>
+      <set comment="kpoint 113">
+       <r>  -11.7075    1.0000 </r>
+       <r>  -11.6758    1.0000 </r>
+       <r>  -11.6643    1.0000 </r>
+       <r>  -11.6561    1.0000 </r>
+       <r>  -11.6471    1.0000 </r>
+       <r>   -4.9848    1.0000 </r>
+       <r>   -2.7590    1.0000 </r>
+       <r>    1.4707    1.0000 </r>
+       <r>    2.1049    1.0000 </r>
+       <r>    4.3060    1.0000 </r>
+       <r>    7.1977    0.0000 </r>
+       <r>    9.6341    0.0000 </r>
+       <r>   10.4699    0.0000 </r>
+       <r>   10.9633    0.0000 </r>
+       <r>   12.5170    0.0000 </r>
+       <r>   15.3466    0.0000 </r>
+       <r>   15.8657    0.0000 </r>
+       <r>   16.3382    0.0000 </r>
+       <r>   17.2949    0.0000 </r>
+       <r>   18.1090    0.0000 </r>
+      </set>
+      <set comment="kpoint 114">
+       <r>  -11.7042    1.0000 </r>
+       <r>  -11.6776    1.0000 </r>
+       <r>  -11.6609    1.0000 </r>
+       <r>  -11.6590    1.0000 </r>
+       <r>  -11.6481    1.0000 </r>
+       <r>   -5.0104    1.0000 </r>
+       <r>   -2.8307    1.0000 </r>
+       <r>    1.6133    1.0000 </r>
+       <r>    2.2353    1.0000 </r>
+       <r>    4.5976    1.0000 </r>
+       <r>    6.7805    0.0000 </r>
+       <r>    9.4313    0.0000 </r>
+       <r>   10.2610    0.0000 </r>
+       <r>   11.5260    0.0000 </r>
+       <r>   12.0111    0.0000 </r>
+       <r>   14.8376    0.0000 </r>
+       <r>   15.3480    0.0000 </r>
+       <r>   16.9428    0.0000 </r>
+       <r>   17.9705    0.0000 </r>
+       <r>   18.0703    0.0000 </r>
+      </set>
+      <set comment="kpoint 115">
+       <r>  -11.7146    1.0000 </r>
+       <r>  -11.6709    1.0000 </r>
+       <r>  -11.6700    1.0000 </r>
+       <r>  -11.6509    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -5.0294    1.0000 </r>
+       <r>   -2.4821    1.0000 </r>
+       <r>    1.1786    1.0000 </r>
+       <r>    2.1657    1.0000 </r>
+       <r>    3.4911    1.0000 </r>
+       <r>    8.4426    0.0000 </r>
+       <r>    9.1740    0.0000 </r>
+       <r>   10.6835    0.0000 </r>
+       <r>   10.9543    0.0000 </r>
+       <r>   13.6980    0.0000 </r>
+       <r>   15.3477    0.0000 </r>
+       <r>   16.3995    0.0000 </r>
+       <r>   16.4138    0.0000 </r>
+       <r>   16.8654    0.0000 </r>
+       <r>   17.6532    0.0000 </r>
+      </set>
+      <set comment="kpoint 116">
+       <r>  -11.7118    1.0000 </r>
+       <r>  -11.6731    1.0000 </r>
+       <r>  -11.6675    1.0000 </r>
+       <r>  -11.6533    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -4.9822    1.0000 </r>
+       <r>   -2.6134    1.0000 </r>
+       <r>    1.2333    1.0000 </r>
+       <r>    2.0619    1.0000 </r>
+       <r>    3.9041    1.0000 </r>
+       <r>    7.8158    0.0000 </r>
+       <r>    9.4824    0.0000 </r>
+       <r>   10.8004    0.0000 </r>
+       <r>   10.8460    0.0000 </r>
+       <r>   13.0867    0.0000 </r>
+       <r>   15.7389    0.0000 </r>
+       <r>   15.9173    0.0000 </r>
+       <r>   16.2758    0.0000 </r>
+       <r>   17.1442    0.0000 </r>
+       <r>   17.5650    0.0000 </r>
+      </set>
+      <set comment="kpoint 117">
+       <r>  -11.7052    1.0000 </r>
+       <r>  -11.6763    1.0000 </r>
+       <r>  -11.6647    1.0000 </r>
+       <r>  -11.6559    1.0000 </r>
+       <r>  -11.6480    1.0000 </r>
+       <r>   -5.0821    1.0000 </r>
+       <r>   -2.7280    1.0000 </r>
+       <r>    1.9309    1.0000 </r>
+       <r>    1.9390    1.0000 </r>
+       <r>    4.4492    1.0000 </r>
+       <r>    7.0012    0.0000 </r>
+       <r>    9.7638    0.0000 </r>
+       <r>    9.7728    0.0000 </r>
+       <r>   11.1242    0.0000 </r>
+       <r>   12.6776    0.0000 </r>
+       <r>   15.0408    0.0000 </r>
+       <r>   15.1626    0.0000 </r>
+       <r>   16.7601    0.0000 </r>
+       <r>   17.8416    0.0000 </r>
+       <r>   17.8668    0.0000 </r>
+      </set>
+      <set comment="kpoint 118">
+       <r>  -11.7059    1.0000 </r>
+       <r>  -11.6768    1.0000 </r>
+       <r>  -11.6619    1.0000 </r>
+       <r>  -11.6587    1.0000 </r>
+       <r>  -11.6470    1.0000 </r>
+       <r>   -4.9918    1.0000 </r>
+       <r>   -2.7854    1.0000 </r>
+       <r>    1.7602    1.0000 </r>
+       <r>    1.7962    1.0000 </r>
+       <r>    4.6987    1.0000 </r>
+       <r>    6.7341    0.0000 </r>
+       <r>    9.9670    0.0000 </r>
+       <r>   10.0685    0.0000 </r>
+       <r>   11.4897    0.0000 </r>
+       <r>   11.9630    0.0000 </r>
+       <r>   15.5165    0.0000 </r>
+       <r>   15.6496    0.0000 </r>
+       <r>   16.4180    0.0000 </r>
+       <r>   17.1564    0.0000 </r>
+       <r>   18.0180    0.0000 </r>
+      </set>
+      <set comment="kpoint 119">
+       <r>  -11.7093    1.0000 </r>
+       <r>  -11.6749    1.0000 </r>
+       <r>  -11.6650    1.0000 </r>
+       <r>  -11.6561    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -4.9722    1.0000 </r>
+       <r>   -2.6866    1.0000 </r>
+       <r>    1.4199    1.0000 </r>
+       <r>    1.8391    1.0000 </r>
+       <r>    4.3840    1.0000 </r>
+       <r>    7.1941    0.0000 </r>
+       <r>    9.7783    0.0000 </r>
+       <r>   10.5408    0.0000 </r>
+       <r>   11.1987    0.0000 </r>
+       <r>   12.5039    0.0000 </r>
+       <r>   15.5719    0.0000 </r>
+       <r>   16.2836    0.0000 </r>
+       <r>   16.2972    0.0000 </r>
+       <r>   16.9004    0.0000 </r>
+       <r>   17.3423    0.0000 </r>
+      </set>
+      <set comment="kpoint 120">
+       <r>  -11.7078    1.0000 </r>
+       <r>  -11.6761    1.0000 </r>
+       <r>  -11.6619    1.0000 </r>
+       <r>  -11.6591    1.0000 </r>
+       <r>  -11.6460    1.0000 </r>
+       <r>   -4.9519    1.0000 </r>
+       <r>   -2.7399    1.0000 </r>
+       <r>    1.5118    1.0000 </r>
+       <r>    1.7273    1.0000 </r>
+       <r>    4.6928    1.0000 </r>
+       <r>    6.8122    0.0000 </r>
+       <r>   10.0427    0.0000 </r>
+       <r>   10.3599    0.0000 </r>
+       <r>   11.5079    0.0000 </r>
+       <r>   12.0103    0.0000 </r>
+       <r>   15.8509    0.0000 </r>
+       <r>   16.0318    0.0000 </r>
+       <r>   16.1092    0.0000 </r>
+       <r>   17.1866    0.0000 </r>
+       <r>   17.2120    0.0000 </r>
+      </set>
+     </set>
+    </set>
+   </array>
+  </eigenvalues>
+  <separator name="orbital magnetization" >
+   <v name="MAGDIPOLOUT">      0.00000000      0.00000000      0.00000000</v>
+  </separator>
+  <dos>
+   <i name="efermi">      5.04135922 </i>
+   <total>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <field>energy</field>
+     <field>total</field>
+     <field>integrated</field>
+     <set>
+      <set comment="spin 1">
+       <r> -13.2667   0.0000   0.0000 </r>
+       <r> -13.2100   0.0000   0.0000 </r>
+       <r> -13.1534   0.0000   0.0000 </r>
+       <r> -13.0967   0.0000   0.0000 </r>
+       <r> -13.0400   0.0000   0.0000 </r>
+       <r> -12.9834   0.0000   0.0000 </r>
+       <r> -12.9267   0.0000   0.0000 </r>
+       <r> -12.8701   0.0000   0.0000 </r>
+       <r> -12.8134   0.0000   0.0000 </r>
+       <r> -12.7567   0.0000   0.0000 </r>
+       <r> -12.7001   0.0000   0.0000 </r>
+       <r> -12.6434   0.0000   0.0000 </r>
+       <r> -12.5868   0.0000   0.0000 </r>
+       <r> -12.5301   0.0000   0.0000 </r>
+       <r> -12.4734   0.0000   0.0000 </r>
+       <r> -12.4168   0.0000   0.0000 </r>
+       <r> -12.3601   0.0000   0.0000 </r>
+       <r> -12.3035   0.0000   0.0000 </r>
+       <r> -12.2468   0.0000   0.0000 </r>
+       <r> -12.1901   0.0000   0.0000 </r>
+       <r> -12.1335   0.0000   0.0000 </r>
+       <r> -12.0768   0.0000   0.0000 </r>
+       <r> -12.0202   0.0000   0.0000 </r>
+       <r> -11.9635   0.0000   0.0000 </r>
+       <r> -11.9068   0.0000   0.0000 </r>
+       <r> -11.8502   0.0000   0.0000 </r>
+       <r> -11.7935   0.0000   0.0000 </r>
+       <r> -11.7369   0.0000   0.0000 </r>
+       <r> -11.6802  17.1220   2.4919 </r>
+       <r> -11.6236   0.0000  10.0000 </r>
+       <r> -11.5669   0.0000  10.0000 </r>
+       <r> -11.5102   0.0000  10.0000 </r>
+       <r> -11.4536   0.0000  10.0000 </r>
+       <r> -11.3969   0.0000  10.0000 </r>
+       <r> -11.3403   0.0000  10.0000 </r>
+       <r> -11.2836   0.0000  10.0000 </r>
+       <r> -11.2269   0.0000  10.0000 </r>
+       <r> -11.1703   0.0000  10.0000 </r>
+       <r> -11.1136   0.0000  10.0000 </r>
+       <r> -11.0570   0.0000  10.0000 </r>
+       <r> -11.0003   0.0000  10.0000 </r>
+       <r> -10.9436   0.0000  10.0000 </r>
+       <r> -10.8870   0.0000  10.0000 </r>
+       <r> -10.8303   0.0000  10.0000 </r>
+       <r> -10.7737   0.0000  10.0000 </r>
+       <r> -10.7170   0.0000  10.0000 </r>
+       <r> -10.6603   0.0000  10.0000 </r>
+       <r> -10.6037   0.0000  10.0000 </r>
+       <r> -10.5470   0.0000  10.0000 </r>
+       <r> -10.4904   0.0000  10.0000 </r>
+       <r> -10.4337   0.0000  10.0000 </r>
+       <r> -10.3770   0.0000  10.0000 </r>
+       <r> -10.3204   0.0000  10.0000 </r>
+       <r> -10.2637   0.0000  10.0000 </r>
+       <r> -10.2071   0.0000  10.0000 </r>
+       <r> -10.1504   0.0000  10.0000 </r>
+       <r> -10.0937   0.0000  10.0000 </r>
+       <r> -10.0371   0.0000  10.0000 </r>
+       <r>  -9.9804   0.0000  10.0000 </r>
+       <r>  -9.9238   0.0000  10.0000 </r>
+       <r>  -9.8671   0.0000  10.0000 </r>
+       <r>  -9.8105   0.0000  10.0000 </r>
+       <r>  -9.7538   0.0000  10.0000 </r>
+       <r>  -9.6971   0.0000  10.0000 </r>
+       <r>  -9.6405   0.0000  10.0000 </r>
+       <r>  -9.5838   0.0000  10.0000 </r>
+       <r>  -9.5272   0.0000  10.0000 </r>
+       <r>  -9.4705   0.0000  10.0000 </r>
+       <r>  -9.4138   0.0000  10.0000 </r>
+       <r>  -9.3572   0.0000  10.0000 </r>
+       <r>  -9.3005   0.0000  10.0000 </r>
+       <r>  -9.2439   0.0000  10.0000 </r>
+       <r>  -9.1872   0.0000  10.0000 </r>
+       <r>  -9.1305   0.0000  10.0000 </r>
+       <r>  -9.0739   0.0000  10.0000 </r>
+       <r>  -9.0172   0.0000  10.0000 </r>
+       <r>  -8.9606   0.0000  10.0000 </r>
+       <r>  -8.9039   0.0000  10.0000 </r>
+       <r>  -8.8472   0.0000  10.0000 </r>
+       <r>  -8.7906   0.0000  10.0000 </r>
+       <r>  -8.7339   0.0000  10.0000 </r>
+       <r>  -8.6773   0.0000  10.0000 </r>
+       <r>  -8.6206   0.0000  10.0000 </r>
+       <r>  -8.5639   0.0000  10.0000 </r>
+       <r>  -8.5073   0.0000  10.0000 </r>
+       <r>  -8.4506   0.0000  10.0000 </r>
+       <r>  -8.3940   0.0000  10.0000 </r>
+       <r>  -8.3373   0.0000  10.0000 </r>
+       <r>  -8.2807   0.0000  10.0000 </r>
+       <r>  -8.2240   0.0000  10.0000 </r>
+       <r>  -8.1673   0.0000  10.0000 </r>
+       <r>  -8.1107   0.0000  10.0000 </r>
+       <r>  -8.0540   0.0000  10.0000 </r>
+       <r>  -7.9974   0.0000  10.0000 </r>
+       <r>  -7.9407   0.0000  10.0000 </r>
+       <r>  -7.8840   0.0000  10.0000 </r>
+       <r>  -7.8274   0.0000  10.0000 </r>
+       <r>  -7.7707   0.0000  10.0000 </r>
+       <r>  -7.7141   0.0000  10.0000 </r>
+       <r>  -7.6574   0.0000  10.0000 </r>
+       <r>  -7.6007   0.0000  10.0000 </r>
+       <r>  -7.5441   0.0000  10.0000 </r>
+       <r>  -7.4874   0.0000  10.0000 </r>
+       <r>  -7.4308   0.0000  10.0000 </r>
+       <r>  -7.3741   0.0000  10.0000 </r>
+       <r>  -7.3174   0.0000  10.0000 </r>
+       <r>  -7.2608   0.0000  10.0000 </r>
+       <r>  -7.2041   0.0000  10.0000 </r>
+       <r>  -7.1475   0.0000  10.0000 </r>
+       <r>  -7.0908   0.0000  10.0000 </r>
+       <r>  -7.0341   0.0000  10.0000 </r>
+       <r>  -6.9775   0.0000  10.0000 </r>
+       <r>  -6.9208   0.0000  10.0000 </r>
+       <r>  -6.8642   0.0000  10.0000 </r>
+       <r>  -6.8075   0.0000  10.0000 </r>
+       <r>  -6.7509   0.0000  10.0000 </r>
+       <r>  -6.6942   0.0000  10.0000 </r>
+       <r>  -6.6375   0.0000  10.0000 </r>
+       <r>  -6.5809   0.0000  10.0006 </r>
+       <r>  -6.5242   0.0000  10.0089 </r>
+       <r>  -6.4676   0.0000  10.0160 </r>
+       <r>  -6.4109   0.0000  10.0350 </r>
+       <r>  -6.3542   0.2204  10.0652 </r>
+       <r>  -6.2976   0.0000  10.0812 </r>
+       <r>  -6.2409   0.0000  10.1001 </r>
+       <r>  -6.1843   0.5011  10.1357 </r>
+       <r>  -6.1276   0.2510  10.1677 </r>
+       <r>  -6.0709   0.0000  10.1961 </r>
+       <r>  -6.0143   0.2707  10.2162 </r>
+       <r>  -5.9576   0.5020  10.2720 </r>
+       <r>  -5.9010   0.0000  10.3147 </r>
+       <r>  -5.8443   0.3264  10.3367 </r>
+       <r>  -5.7876   0.0000  10.3822 </r>
+       <r>  -5.7310   0.0000  10.4296 </r>
+       <r>  -5.6743   0.0000  10.5150 </r>
+       <r>  -5.6177   0.0000  10.5576 </r>
+       <r>  -5.5610   0.3137  10.6039 </r>
+       <r>  -5.5043   0.0837  10.6797 </r>
+       <r>  -5.4477   0.0000  10.7366 </r>
+       <r>  -5.3910   0.2510  10.8646 </r>
+       <r>  -5.3344   0.6255  10.9285 </r>
+       <r>  -5.2777   0.0240  11.0627 </r>
+       <r>  -5.2211   0.5007  11.2355 </r>
+       <r>  -5.1644   0.5011  11.3351 </r>
+       <r>  -5.1077   0.0000  11.5342 </r>
+       <r>  -5.0511   0.0000  11.6729 </r>
+       <r>  -4.9944   0.0001  11.8862 </r>
+       <r>  -4.9378   0.0000  12.0000 </r>
+       <r>  -4.8811   0.0000  12.0000 </r>
+       <r>  -4.8244   0.0000  12.0000 </r>
+       <r>  -4.7678   0.0000  12.0000 </r>
+       <r>  -4.7111   0.0000  12.0000 </r>
+       <r>  -4.6545   0.0000  12.0000 </r>
+       <r>  -4.5978   0.0000  12.0000 </r>
+       <r>  -4.5411   0.0000  12.0000 </r>
+       <r>  -4.4845   0.0000  12.0000 </r>
+       <r>  -4.4278   0.0000  12.0000 </r>
+       <r>  -4.3712   0.0000  12.0000 </r>
+       <r>  -4.3145   0.0000  12.0000 </r>
+       <r>  -4.2578   0.0000  12.0000 </r>
+       <r>  -4.2012   0.0000  12.0000 </r>
+       <r>  -4.1445   0.0000  12.0000 </r>
+       <r>  -4.0879   0.0000  12.0000 </r>
+       <r>  -4.0312   0.0000  12.0000 </r>
+       <r>  -3.9745   0.0000  12.0000 </r>
+       <r>  -3.9179   0.0000  12.0000 </r>
+       <r>  -3.8612   0.0000  12.0000 </r>
+       <r>  -3.8046   0.0000  12.0000 </r>
+       <r>  -3.7479   0.0000  12.0000 </r>
+       <r>  -3.6913   0.0000  12.0000 </r>
+       <r>  -3.6346   0.0000  12.0000 </r>
+       <r>  -3.5779   0.0000  12.0000 </r>
+       <r>  -3.5213   0.0000  12.0000 </r>
+       <r>  -3.4646   0.0000  12.0000 </r>
+       <r>  -3.4080   0.0000  12.0000 </r>
+       <r>  -3.3513   0.0000  12.0000 </r>
+       <r>  -3.2946   0.0000  12.0000 </r>
+       <r>  -3.2380   0.0000  12.0000 </r>
+       <r>  -3.1813   0.0000  12.0190 </r>
+       <r>  -3.1247   0.0000  12.0759 </r>
+       <r>  -3.0680   0.0000  12.1185 </r>
+       <r>  -3.0113   0.1797  12.1571 </r>
+       <r>  -2.9547   0.6154  12.2956 </r>
+       <r>  -2.8980   0.4477  12.3762 </r>
+       <r>  -2.8414   0.0629  12.4753 </r>
+       <r>  -2.7847   1.2869  12.7011 </r>
+       <r>  -2.7280   0.1145  12.8266 </r>
+       <r>  -2.6714   0.0000  12.8913 </r>
+       <r>  -2.6147   0.0377  12.9930 </r>
+       <r>  -2.5581   0.0000  13.1046 </r>
+       <r>  -2.5014   0.0036  13.1972 </r>
+       <r>  -2.4447   0.0000  13.2587 </r>
+       <r>  -2.3881   0.4276  13.3113 </r>
+       <r>  -2.3314   0.2510  13.4436 </r>
+       <r>  -2.2748   0.0000  13.4720 </r>
+       <r>  -2.2181   0.2510  13.5360 </r>
+       <r>  -2.1615   0.0000  13.6142 </r>
+       <r>  -2.1048   0.0000  13.6498 </r>
+       <r>  -2.0481   0.2510  13.6640 </r>
+       <r>  -1.9915   0.3326  13.7148 </r>
+       <r>  -1.9348   0.0000  13.7576 </r>
+       <r>  -1.8782   0.0000  13.7861 </r>
+       <r>  -1.8215   0.0000  13.8003 </r>
+       <r>  -1.7648   0.0000  13.8039 </r>
+       <r>  -1.7082   0.0000  13.8323 </r>
+       <r>  -1.6515   0.0000  13.8465 </r>
+       <r>  -1.5949   0.0000  13.8892 </r>
+       <r>  -1.5382   0.0000  13.8963 </r>
+       <r>  -1.4815   0.1464  13.9046 </r>
+       <r>  -1.4249   0.0000  13.9046 </r>
+       <r>  -1.3682   0.2627  13.9195 </r>
+       <r>  -1.3116   0.0000  13.9330 </r>
+       <r>  -1.2549   0.0000  13.9330 </r>
+       <r>  -1.1982   0.0000  13.9615 </r>
+       <r>  -1.1416   0.0000  13.9615 </r>
+       <r>  -1.0849   0.0000  13.9650 </r>
+       <r>  -1.0283   0.0000  13.9698 </r>
+       <r>  -0.9716   0.0000  13.9840 </r>
+       <r>  -0.9149   0.0000  13.9840 </r>
+       <r>  -0.8583   0.0000  13.9911 </r>
+       <r>  -0.8016   0.0000  13.9911 </r>
+       <r>  -0.7450   0.0000  13.9947 </r>
+       <r>  -0.6883   0.0000  13.9994 </r>
+       <r>  -0.6317   0.0000  13.9994 </r>
+       <r>  -0.5750   0.0000  14.0000 </r>
+       <r>  -0.5183   0.0000  14.0000 </r>
+       <r>  -0.4617   0.0000  14.0000 </r>
+       <r>  -0.4050   0.0000  14.0000 </r>
+       <r>  -0.3484   0.0000  14.0000 </r>
+       <r>  -0.2917   0.0000  14.0000 </r>
+       <r>  -0.2350   0.0000  14.0000 </r>
+       <r>  -0.1784   0.0000  14.0000 </r>
+       <r>  -0.1217   0.0000  14.0000 </r>
+       <r>  -0.0651   0.0000  14.0000 </r>
+       <r>  -0.0084   0.0000  14.0000 </r>
+       <r>   0.0483   0.0000  14.0000 </r>
+       <r>   0.1049   0.0000  14.0000 </r>
+       <r>   0.1616   0.0000  14.0000 </r>
+       <r>   0.2182   0.0000  14.0000 </r>
+       <r>   0.2749   0.0000  14.0000 </r>
+       <r>   0.3316   0.0000  14.0000 </r>
+       <r>   0.3882   0.0000  14.0000 </r>
+       <r>   0.4449   0.0000  14.0000 </r>
+       <r>   0.5015   0.0000  14.0000 </r>
+       <r>   0.5582   0.0000  14.0000 </r>
+       <r>   0.6149   0.0000  14.0000 </r>
+       <r>   0.6715   0.0000  14.0000 </r>
+       <r>   0.7282   0.0000  14.0000 </r>
+       <r>   0.7848   0.0000  14.0000 </r>
+       <r>   0.8415   0.0000  14.0000 </r>
+       <r>   0.8981   0.0000  14.0000 </r>
+       <r>   0.9548   0.0000  14.0071 </r>
+       <r>   1.0115   0.0000  14.0107 </r>
+       <r>   1.0681   0.0000  14.0391 </r>
+       <r>   1.1248   0.0000  14.0533 </r>
+       <r>   1.1814   0.2510  14.0747 </r>
+       <r>   1.2381   0.2510  14.1316 </r>
+       <r>   1.2948   0.0000  14.1316 </r>
+       <r>   1.3514   0.0000  14.1742 </r>
+       <r>   1.4081   0.2510  14.2027 </r>
+       <r>   1.4647   0.0000  14.2169 </r>
+       <r>   1.5214   0.0000  14.2916 </r>
+       <r>   1.5781   0.0000  14.3129 </r>
+       <r>   1.6347   0.0000  14.3982 </r>
+       <r>   1.6914   0.0000  14.3982 </r>
+       <r>   1.7480   0.5020  14.4551 </r>
+       <r>   1.8047   0.0000  14.5262 </r>
+       <r>   1.8614   0.2510  14.5689 </r>
+       <r>   1.9180   0.0000  14.6116 </r>
+       <r>   1.9747   0.5020  14.7111 </r>
+       <r>   2.0313   0.5020  14.7396 </r>
+       <r>   2.0880   0.0000  14.7893 </r>
+       <r>   2.1447   0.0000  14.9031 </r>
+       <r>   2.2013   0.2791  14.9616 </r>
+       <r>   2.2580   0.0000  15.0169 </r>
+       <r>   2.3146   0.0000  15.1164 </r>
+       <r>   2.3713   0.0000  15.1591 </r>
+       <r>   2.4280   0.0002  15.2765 </r>
+       <r>   2.4846   0.4820  15.3891 </r>
+       <r>   2.5413   0.1255  15.4898 </r>
+       <r>   2.5979   0.0000  15.5964 </r>
+       <r>   2.6546   0.7459  15.7454 </r>
+       <r>   2.7112   0.3754  15.7813 </r>
+       <r>   2.7679   0.0126  15.9100 </r>
+       <r>   2.8246   0.2510  16.0800 </r>
+       <r>   2.8812   0.1380  16.1305 </r>
+       <r>   2.9379   0.2250  16.2350 </r>
+       <r>   2.9945   0.3991  16.3657 </r>
+       <r>   3.0512   0.7220  16.5049 </r>
+       <r>   3.1079   0.5300  16.5936 </r>
+       <r>   3.1645   0.2923  16.6797 </r>
+       <r>   3.2212   0.2510  16.7911 </r>
+       <r>   3.2778   0.0000  16.9333 </r>
+       <r>   3.3345   0.0000  17.0542 </r>
+       <r>   3.3912   0.0000  17.1111 </r>
+       <r>   3.4478   0.0000  17.1822 </r>
+       <r>   3.5045   0.0000  17.3529 </r>
+       <r>   3.5611   0.3766  17.4631 </r>
+       <r>   3.6178   0.3041  17.6297 </r>
+       <r>   3.6745   0.0000  17.7120 </r>
+       <r>   3.7311   0.2501  17.8044 </r>
+       <r>   3.7878   0.5020  17.9467 </r>
+       <r>   3.8444   0.0000  18.0107 </r>
+       <r>   3.9011   0.0000  18.0930 </r>
+       <r>   3.9578   0.7530  18.2495 </r>
+       <r>   4.0144   0.0000  18.3301 </r>
+       <r>   4.0711   0.7516  18.4675 </r>
+       <r>   4.1277   0.0001  18.6252 </r>
+       <r>   4.1844   0.5020  18.7342 </r>
+       <r>   4.2410   0.0000  18.8006 </r>
+       <r>   4.2977   0.3347  18.9073 </r>
+       <r>   4.3544   0.2510  19.0424 </r>
+       <r>   4.4110   0.0050  19.1351 </r>
+       <r>   4.4677   0.0000  19.1917 </r>
+       <r>   4.5243   0.0000  19.2391 </r>
+       <r>   4.5810   0.2510  19.3138 </r>
+       <r>   4.6377   0.0959  19.4899 </r>
+       <r>   4.6943   0.5199  19.6952 </r>
+       <r>   4.7510   0.2510  19.8412 </r>
+       <r>   4.8076   0.0000  19.9265 </r>
+       <r>   4.8643   0.2499  19.9407 </r>
+       <r>   4.9210   0.2668  19.9890 </r>
+       <r>   4.9776   0.0000  19.9953 </r>
+       <r>   5.0343   0.0837  20.0000 </r>
+       <r>   5.0909   0.0000  20.0000 </r>
+       <r>   5.1476   0.0000  20.0000 </r>
+       <r>   5.2043   0.0000  20.0000 </r>
+       <r>   5.2609   0.0000  20.0000 </r>
+       <r>   5.3176   0.0000  20.0000 </r>
+       <r>   5.3742   0.0000  20.0000 </r>
+       <r>   5.4309   0.0000  20.0000 </r>
+       <r>   5.4876   0.0000  20.0000 </r>
+       <r>   5.5442   0.0000  20.0000 </r>
+       <r>   5.6009   0.0000  20.0000 </r>
+       <r>   5.6575   0.0000  20.0000 </r>
+       <r>   5.7142   0.0000  20.0000 </r>
+       <r>   5.7708   0.0000  20.0000 </r>
+       <r>   5.8275   0.0000  20.0000 </r>
+       <r>   5.8842   0.0000  20.0000 </r>
+       <r>   5.9408   0.0000  20.0047 </r>
+       <r>   5.9975   0.0000  20.0047 </r>
+       <r>   6.0541   0.0000  20.0047 </r>
+       <r>   6.1108   0.0000  20.0190 </r>
+       <r>   6.1675   0.0000  20.0379 </r>
+       <r>   6.2241   0.0415  20.0403 </r>
+       <r>   6.2808   0.0000  20.0948 </r>
+       <r>   6.3374   0.2510  20.1375 </r>
+       <r>   6.3941   0.1054  20.1435 </r>
+       <r>   6.4508   0.1661  20.2251 </r>
+       <r>   6.5074   0.5020  20.3105 </r>
+       <r>   6.5641   0.2511  20.4433 </r>
+       <r>   6.6207   0.2510  20.5428 </r>
+       <r>   6.6774   0.2507  20.5949 </r>
+       <r>   6.7341   0.7523  20.7443 </r>
+       <r>   6.7907   0.2510  20.9150 </r>
+       <r>   6.8474   0.0000  20.9861 </r>
+       <r>   6.9040   0.0000  21.0145 </r>
+       <r>   6.9607   0.4178  21.0773 </r>
+       <r>   7.0174   0.0000  21.1769 </r>
+       <r>   7.0740   0.5020  21.3452 </r>
+       <r>   7.1307   0.2497  21.4802 </r>
+       <r>   7.1873   0.5643  21.5407 </r>
+       <r>   7.2440   0.0000  21.5834 </r>
+       <r>   7.3006   0.2510  21.6972 </r>
+       <r>   7.3573   0.0000  21.6972 </r>
+       <r>   7.4140   0.5034  21.8181 </r>
+       <r>   7.4706   0.1613  21.9078 </r>
+       <r>   7.5273   0.0000  21.9413 </r>
+       <r>   7.5839   0.0000  21.9556 </r>
+       <r>   7.6406   0.0000  21.9887 </r>
+       <r>   7.6973   0.7551  22.0884 </r>
+       <r>   7.7539   0.5127  22.1742 </r>
+       <r>   7.8106   0.0000  22.3016 </r>
+       <r>   7.8672   0.0002  22.3585 </r>
+       <r>   7.9239   0.5368  22.4920 </r>
+       <r>   7.9806   0.5020  22.5778 </r>
+       <r>   8.0372   0.7530  22.6276 </r>
+       <r>   8.0939   0.1829  22.6521 </r>
+       <r>   8.1505   0.5020  22.7556 </r>
+       <r>   8.2072   0.2510  22.7840 </r>
+       <r>   8.2639   0.0000  22.8599 </r>
+       <r>   8.3205   0.0000  22.8954 </r>
+       <r>   8.3772   0.0000  22.8990 </r>
+       <r>   8.4338   0.5020  23.0270 </r>
+       <r>   8.4905   0.0000  23.1147 </r>
+       <r>   8.5472   0.2510  23.2178 </r>
+       <r>   8.6038   0.0000  23.3031 </r>
+       <r>   8.6605   0.0679  23.3745 </r>
+       <r>   8.7171   0.2510  23.5271 </r>
+       <r>   8.7738   0.5020  23.5982 </r>
+       <r>   8.8304   0.5077  23.7028 </r>
+       <r>   8.8871   1.1487  23.8494 </r>
+       <r>   8.9438   0.0000  23.9360 </r>
+       <r>   9.0004   0.0000  24.0356 </r>
+       <r>   9.0571   0.1255  24.0853 </r>
+       <r>   9.1137   0.5000  24.2434 </r>
+       <r>   9.1704   0.0000  24.3644 </r>
+       <r>   9.2271   0.2510  24.5493 </r>
+       <r>   9.2837   0.5020  24.6702 </r>
+       <r>   9.3404   0.0000  24.7911 </r>
+       <r>   9.3970   0.0000  24.8480 </r>
+       <r>   9.4537   0.0000  24.8764 </r>
+       <r>   9.5104   0.5020  25.0329 </r>
+       <r>   9.5670   0.0000  25.0827 </r>
+       <r>   9.6237   0.0000  25.1147 </r>
+       <r>   9.6803   0.0000  25.2427 </r>
+       <r>   9.7370   0.2485  25.3136 </r>
+       <r>   9.7937   0.2979  25.4302 </r>
+       <r>   9.8503   0.1255  25.4560 </r>
+       <r>   9.9070   0.0000  25.5200 </r>
+       <r>   9.9636   0.0000  25.6196 </r>
+       <r>  10.0203   0.0000  25.7333 </r>
+       <r>  10.0770   0.3882  25.8122 </r>
+       <r>  10.1336   0.0000  25.9218 </r>
+       <r>  10.1903   0.0000  25.9644 </r>
+       <r>  10.2469   0.0000  26.0427 </r>
+       <r>  10.3036   0.0000  26.1422 </r>
+       <r>  10.3602   0.1686  26.2158 </r>
+       <r>  10.4169   0.6272  26.3555 </r>
+       <r>  10.4736   0.7193  26.4425 </r>
+       <r>  10.5302   0.0000  26.4587 </r>
+       <r>  10.5869   0.2510  26.5440 </r>
+       <r>  10.6435   0.5016  26.6471 </r>
+       <r>  10.7002   0.0000  26.7324 </r>
+       <r>  10.7569   0.0060  26.7968 </r>
+       <r>  10.8135   0.1255  26.8510 </r>
+       <r>  10.8702   0.5856  26.9884 </r>
+       <r>  10.9268   0.0000  26.9884 </r>
+       <r>  10.9835   0.0000  27.0756 </r>
+       <r>  11.0402   0.5020  27.1419 </r>
+       <r>  11.0968   0.1950  27.1814 </r>
+       <r>  11.1535   0.0000  27.2273 </r>
+       <r>  11.2101   0.4530  27.3003 </r>
+       <r>  11.2668   0.0000  27.3837 </r>
+       <r>  11.3235   0.4971  27.4759 </r>
+       <r>  11.3801   0.2510  27.5081 </r>
+       <r>  11.4368   0.0000  27.5153 </r>
+       <r>  11.4934   0.9686  27.6128 </r>
+       <r>  11.5501   0.0000  27.7001 </r>
+       <r>  11.6068   0.9936  27.7707 </r>
+       <r>  11.6634   0.0000  27.8234 </r>
+       <r>  11.7201   0.0000  27.8566 </r>
+       <r>  11.7767   0.4963  27.9132 </r>
+       <r>  11.8334   0.0182  27.9785 </r>
+       <r>  11.8900   0.0000  27.9988 </r>
+       <r>  11.9467   0.0000  28.0130 </r>
+       <r>  12.0034   0.0000  28.0699 </r>
+       <r>  12.0600   0.0000  28.1979 </r>
+       <r>  12.1167   0.0000  28.2477 </r>
+       <r>  12.1733   0.6674  28.3092 </r>
+       <r>  12.2300   0.0000  28.3710 </r>
+       <r>  12.2867   0.0000  28.3852 </r>
+       <r>  12.3433   0.0000  28.4279 </r>
+       <r>  12.4000   0.0000  28.5037 </r>
+       <r>  12.4566   0.0076  28.5610 </r>
+       <r>  12.5133   0.5020  28.6821 </r>
+       <r>  12.5700   0.0000  28.7182 </r>
+       <r>  12.6266   0.0000  28.8036 </r>
+       <r>  12.6833   0.2510  28.8284 </r>
+       <r>  12.7399   0.1673  28.9517 </r>
+       <r>  12.7966   0.0000  29.0133 </r>
+       <r>  12.8533   0.0000  29.0880 </r>
+       <r>  12.9099   0.0837  29.0999 </r>
+       <r>  12.9666   0.0741  29.1325 </r>
+       <r>  13.0232   0.2730  29.1627 </r>
+       <r>  13.0799   0.1400  29.2299 </r>
+       <r>  13.1366   0.2512  29.3250 </r>
+       <r>  13.1932   0.5020  29.4329 </r>
+       <r>  13.2499   0.9178  29.5773 </r>
+       <r>  13.3065   0.4995  29.6627 </r>
+       <r>  13.3632   0.5274  29.7638 </r>
+       <r>  13.4198   0.2510  29.7873 </r>
+       <r>  13.4765   0.0045  29.8752 </r>
+       <r>  13.5332   0.5020  30.0397 </r>
+       <r>  13.5898   0.2510  30.1677 </r>
+       <r>  13.6465   0.1654  30.2269 </r>
+       <r>  13.7031   0.2510  30.3099 </r>
+       <r>  13.7598   0.0000  30.4095 </r>
+       <r>  13.8165   0.5020  30.5138 </r>
+       <r>  13.8731   0.4604  30.6359 </r>
+       <r>  13.9298   0.0536  30.7219 </r>
+       <r>  13.9864   0.2510  30.7935 </r>
+       <r>  14.0431   0.2352  30.8779 </r>
+       <r>  14.0998   0.0000  31.0068 </r>
+       <r>  14.1564   0.0000  31.0625 </r>
+       <r>  14.2131   0.2683  31.2128 </r>
+       <r>  14.2697   0.2510  31.3683 </r>
+       <r>  14.3264   0.0000  31.4465 </r>
+       <r>  14.3831   0.7530  31.5887 </r>
+       <r>  14.4397   0.0000  31.7547 </r>
+       <r>  14.4964   0.2510  31.8471 </r>
+       <r>  14.5530   0.0000  32.0178 </r>
+       <r>  14.6097   0.0628  32.1600 </r>
+       <r>  14.6664   0.5020  32.2311 </r>
+       <r>  14.7230   0.5643  32.4195 </r>
+       <r>  14.7797   0.1673  32.5250 </r>
+       <r>  14.8363   0.0878  32.5585 </r>
+       <r>  14.8930   0.7531  32.6886 </r>
+       <r>  14.9497   0.7753  32.8830 </r>
+       <r>  15.0063   0.0000  32.9849 </r>
+       <r>  15.0630   0.5020  33.1342 </r>
+       <r>  15.1196   0.3274  33.2523 </r>
+       <r>  15.1763   1.0111  33.4617 </r>
+       <r>  15.2329   0.0000  33.5396 </r>
+       <r>  15.2896   0.4954  33.6790 </r>
+       <r>  15.3463   0.1739  33.8315 </r>
+       <r>  15.4029   0.2929  33.9603 </r>
+       <r>  15.4596   0.0000  34.1464 </r>
+       <r>  15.5162   0.6785  34.2773 </r>
+       <r>  15.5729   0.2333  34.3943 </r>
+       <r>  15.6296   0.1256  34.5873 </r>
+       <r>  15.6862   0.0001  34.6679 </r>
+       <r>  15.7429   0.5063  34.7819 </r>
+       <r>  15.7995   0.1784  34.8628 </r>
+       <r>  15.8562   0.2510  34.9523 </r>
+       <r>  15.9129   0.0000  35.0803 </r>
+       <r>  15.9695   0.5020  35.1443 </r>
+       <r>  16.0262   0.0000  35.2296 </r>
+       <r>  16.0828   0.0000  35.3007 </r>
+       <r>  16.1395   0.5012  35.4571 </r>
+       <r>  16.1962   0.0000  35.5153 </r>
+       <r>  16.2528   0.2510  35.6859 </r>
+       <r>  16.3095   0.0000  35.8246 </r>
+       <r>  16.3661   1.0041  35.9099 </r>
+       <r>  16.4228   1.0040  36.0379 </r>
+       <r>  16.4795   0.5020  36.1090 </r>
+       <r>  16.5361   0.0000  36.1612 </r>
+       <r>  16.5928   0.0000  36.1754 </r>
+       <r>  16.6494   0.0000  36.2039 </r>
+       <r>  16.7061   0.0000  36.2465 </r>
+       <r>  16.7627   0.2510  36.3212 </r>
+       <r>  16.8194   0.3357  36.3829 </r>
+       <r>  16.8761   0.5020  36.5013 </r>
+       <r>  16.9327   1.2071  36.5982 </r>
+       <r>  16.9894   0.7531  36.7929 </r>
+       <r>  17.0460   0.5413  36.9658 </r>
+       <r>  17.1027   0.5213  37.1602 </r>
+       <r>  17.1594   0.5020  37.2729 </r>
+       <r>  17.2160   0.5020  37.4009 </r>
+       <r>  17.2727   0.2510  37.5431 </r>
+       <r>  17.3293   0.7126  37.7115 </r>
+       <r>  17.3860   0.0000  37.8773 </r>
+       <r>  17.4427   1.3387  38.0527 </r>
+       <r>  17.4993   0.0000  38.1096 </r>
+       <r>  17.5560   0.0000  38.2839 </r>
+       <r>  17.6126   0.2510  38.3123 </r>
+       <r>  17.6693   0.2510  38.3692 </r>
+       <r>  17.7260   0.7530  38.5114 </r>
+       <r>  17.7826   0.0231  38.5909 </r>
+       <r>  17.8393   0.4299  38.6851 </r>
+       <r>  17.8959   0.0000  38.7603 </r>
+       <r>  17.9526   0.0000  38.8456 </r>
+       <r>  18.0093   0.2510  38.9239 </r>
+       <r>  18.0659   0.0000  39.0376 </r>
+       <r>  18.1226   0.3865  39.1520 </r>
+       <r>  18.1792   0.0000  39.2119 </r>
+       <r>  18.2359   0.0008  39.2877 </r>
+       <r>  18.2925   0.2204  39.3571 </r>
+       <r>  18.3492   0.5020  39.4584 </r>
+       <r>  18.4059   0.0000  39.6006 </r>
+       <r>  18.4625   0.0000  39.7001 </r>
+       <r>  18.5192   0.5018  39.7428 </r>
+       <r>  18.5758   0.0000  39.7713 </r>
+       <r>  18.6325   0.0000  39.7855 </r>
+       <r>  18.6892   0.0000  39.8281 </r>
+       <r>  18.7458   0.0000  39.8495 </r>
+       <r>  18.8025   0.0000  39.8637 </r>
+       <r>  18.8591   0.0000  39.8637 </r>
+       <r>  18.9158   0.0000  39.8779 </r>
+       <r>  18.9725   0.5020  39.9384 </r>
+       <r>  19.0291   0.0000  39.9384 </r>
+       <r>  19.0858   0.0000  39.9526 </r>
+       <r>  19.1424   0.0000  39.9953 </r>
+       <r>  19.1991   0.0000  40.0000 </r>
+       <r>  19.2558   0.0000  40.0000 </r>
+       <r>  19.3124   0.0000  40.0000 </r>
+       <r>  19.3691   0.0000  40.0000 </r>
+       <r>  19.4257   0.0000  40.0000 </r>
+       <r>  19.4824   0.0000  40.0000 </r>
+       <r>  19.5391   0.0000  40.0000 </r>
+       <r>  19.5957   0.0000  40.0000 </r>
+       <r>  19.6524   0.0000  40.0000 </r>
+       <r>  19.7090   0.0000  40.0000 </r>
+       <r>  19.7657   0.0000  40.0000 </r>
+       <r>  19.8223   0.0000  40.0000 </r>
+       <r>  19.8790   0.0000  40.0000 </r>
+       <r>  19.9357   0.0000  40.0000 </r>
+       <r>  19.9923   0.0000  40.0000 </r>
+       <r>  20.0490   0.0000  40.0000 </r>
+       <r>  20.1056   0.0000  40.0000 </r>
+       <r>  20.1623   0.0000  40.0000 </r>
+       <r>  20.2190   0.0000  40.0000 </r>
+       <r>  20.2756   0.0000  40.0000 </r>
+       <r>  20.3323   0.0000  40.0000 </r>
+       <r>  20.3889   0.0000  40.0000 </r>
+       <r>  20.4456   0.0000  40.0000 </r>
+       <r>  20.5023   0.0000  40.0000 </r>
+       <r>  20.5589   0.0000  40.0000 </r>
+       <r>  20.6156   0.0000  40.0000 </r>
+       <r>  20.6722   0.0000  40.0000 </r>
+       <r>  20.7289   0.0000  40.0000 </r>
+      </set>
+     </set>
+    </array>
+   </total>
+   <partial>
+    <array>
+     <dimension dim="1">gridpoints</dimension>
+     <dimension dim="2">spin</dimension>
+     <dimension dim="3">ion</dimension>
+     <field>energy</field>
+     <field>  s</field>
+     <field> py</field>
+     <field> pz</field>
+     <field> px</field>
+     <field>dxy</field>
+     <field>dyz</field>
+     <field>dz2</field>
+     <field>dxz</field>
+     <field>dx2</field>
+     <set>
+      <set comment="ion 1">
+       <set comment="spin 1">
+        <r> -13.2667   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.2100   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.1534   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.0967   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.0400   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.9834   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.9267   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.8701   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.8134   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.7567   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.7001   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.6434   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.5868   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.5301   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.4734   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.4168   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.3601   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.3035   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.2468   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.1901   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.1335   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.0768   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.0202   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.9635   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.9068   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.8502   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.7935   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.7369   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.6802   0.0026   0.0048   0.0023   0.0032   0.0000   0.0000   0.0004   0.0000   0.0003 </r>
+        <r> -11.6236   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.5669   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.5102   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.4536   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.3969   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.3403   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.2836   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.2269   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.1703   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.1136   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.0570   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.0003   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.9436   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.8870   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.8303   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.7737   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.7170   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.6603   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.6037   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.5470   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.4904   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.4337   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.3770   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.3204   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.2637   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.2071   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.1504   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.0937   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.0371   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.9804   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.9238   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.8671   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.8105   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.7538   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.6971   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.6405   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.5838   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.5272   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.4705   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.4138   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.3572   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.3005   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.2439   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.1872   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.1305   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.0739   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.0172   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.9606   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.9039   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.8472   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.7906   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.7339   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.6773   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.6206   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.5639   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.5073   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.4506   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.3940   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.3373   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.2807   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.2240   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.1673   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.1107   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.0540   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.9974   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.9407   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.8840   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.8274   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.7707   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.7141   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.6574   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.6007   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.5441   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.4874   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.4308   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.3741   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.3174   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.2608   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.2041   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.1475   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.0908   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.0341   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.9775   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.9208   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.8642   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.8075   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.7509   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.6942   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.6375   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.5809   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.5242   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.4676   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.4109   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.3542   0.0975   0.0001   0.0002   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.2976   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.2409   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.1843   0.2296   0.0003   0.0007   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.1276   0.1160   0.0001   0.0005   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.0709   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.0143   0.1282   0.0001   0.0005   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.9576   0.2427   0.0004   0.0008   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.9010   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.8443   0.1619   0.0001   0.0007   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.7876   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.7310   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.6743   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.6177   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.5610   0.1679   0.0001   0.0007   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.5043   0.0479   0.0001   0.0001   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.4477   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.3910   0.1385   0.0000   0.0005   0.0000   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -5.3344   0.3586   0.0002   0.0009   0.0001   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -5.2777   0.0137   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.2211   0.3089   0.0000   0.0004   0.0000   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -5.1644   0.3236   0.0001   0.0001   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.1077   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.0511   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.9944   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.9378   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.8811   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.8244   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.7678   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.7111   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.6545   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.5978   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.5411   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.4845   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.4278   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.3712   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.3145   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.2578   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.2012   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.1445   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.0879   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.0312   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.9745   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.9179   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.8612   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.8046   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.7479   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.6913   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.6346   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.5779   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.5213   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.4646   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.4080   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.3513   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.2946   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.2380   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.1813   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.1247   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.0680   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.0113   0.0021   0.0024   0.0018   0.0024   0.0000   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>  -2.9547   0.0224   0.0100   0.0039   0.0089   0.0000   0.0000   0.0005   0.0000   0.0001 </r>
+        <r>  -2.8980   0.0319   0.0066   0.0068   0.0046   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -2.8414   0.0015   0.0011   0.0001   0.0007   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -2.7847   0.0390   0.0214   0.0039   0.0105   0.0000   0.0000   0.0023   0.0000   0.0003 </r>
+        <r>  -2.7280   0.0036   0.0020   0.0009   0.0000   0.0000   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>  -2.6714   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.6147   0.0037   0.0004   0.0005   0.0003   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.5581   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.5014   0.0005   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.4447   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.3881   0.0311   0.0037   0.0018   0.0005   0.0000   0.0000   0.0013   0.0000   0.0000 </r>
+        <r>  -2.3314   0.0396   0.0027   0.0039   0.0027   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.2748   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.2181   0.0404   0.0029   0.0042   0.0000   0.0000   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>  -2.1615   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.1048   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.0481   0.0449   0.0010   0.0044   0.0010   0.0000   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>  -1.9915   0.0604   0.0012   0.0052   0.0012   0.0000   0.0000   0.0004   0.0000   0.0000 </r>
+        <r>  -1.9348   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.8782   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.8215   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.7648   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.7082   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.6515   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.5949   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.5382   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.4815   0.0343   0.0007   0.0020   0.0007   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.4249   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.3682   0.0638   0.0012   0.0036   0.0012   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.3116   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.2549   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.1982   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.1416   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.0849   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.0283   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.9716   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.9149   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.8583   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.8016   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.7450   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.6883   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.6317   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.5750   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.5183   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.4617   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.4050   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.3484   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.2917   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.2350   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.1784   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.1217   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.0651   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.0084   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.0483   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.1049   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.1616   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.2182   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.2749   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.3316   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.3882   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.4449   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.5015   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.5582   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.6149   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.6715   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.7282   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.7848   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.8415   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.8981   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.9548   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.0115   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.0681   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.1248   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.1814   0.0002   0.0001   0.0577   0.0000   0.0000   0.0001   0.0001   0.0000   0.0000 </r>
+        <r>   1.2381   0.0000   0.0000   0.0588   0.0000   0.0000   0.0001   0.0000   0.0000   0.0000 </r>
+        <r>   1.2948   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.3514   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.4081   0.0008   0.0002   0.0577   0.0002   0.0000   0.0001   0.0002   0.0001   0.0000 </r>
+        <r>   1.4647   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.5214   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.5781   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.6347   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.6914   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.7480   0.0030   0.0010   0.1162   0.0009   0.0000   0.0002   0.0007   0.0001   0.0000 </r>
+        <r>   1.8047   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.8614   0.0003   0.0001   0.0637   0.0001   0.0000   0.0002   0.0000   0.0002   0.0000 </r>
+        <r>   1.9180   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.9747   0.0038   0.0008   0.1169   0.0064   0.0000   0.0003   0.0005   0.0001   0.0000 </r>
+        <r>   2.0313   0.0037   0.0018   0.1152   0.0008   0.0000   0.0001   0.0012   0.0000   0.0000 </r>
+        <r>   2.0880   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.1447   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.2013   0.0024   0.0006   0.0510   0.0194   0.0001   0.0001   0.0004   0.0000   0.0000 </r>
+        <r>   2.2580   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.3146   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.3713   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.4280   0.0000   0.0000   0.0000   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.4846   0.0007   0.0001   0.0006   0.1375   0.0004   0.0000   0.0000   0.0003   0.0000 </r>
+        <r>   2.5413   0.0000   0.0189   0.0000   0.0189   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.5979   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.6546   0.0021   0.0380   0.1431   0.0385   0.0000   0.0004   0.0002   0.0004   0.0001 </r>
+        <r>   2.7112   0.0000   0.0000   0.0377   0.0757   0.0002   0.0001   0.0000   0.0003   0.0000 </r>
+        <r>   2.7679   0.0000   0.0000   0.0001   0.0038   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.8246   0.0018   0.0362   0.0001   0.0362   0.0001   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>   2.8812   0.0005   0.0424   0.0000   0.0000   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>   2.9379   0.0024   0.0157   0.0328   0.0157   0.0001   0.0001   0.0003   0.0001   0.0000 </r>
+        <r>   2.9945   0.0033   0.0581   0.0000   0.0581   0.0002   0.0000   0.0004   0.0000   0.0002 </r>
+        <r>   3.0512   0.0049   0.0410   0.0517   0.1338   0.0002   0.0001   0.0004   0.0003   0.0003 </r>
+        <r>   3.1079   0.0041   0.0886   0.0000   0.0686   0.0002   0.0000   0.0005   0.0000   0.0006 </r>
+        <r>   3.1645   0.0001   0.0063   0.0211   0.0549   0.0001   0.0001   0.0007   0.0000   0.0003 </r>
+        <r>   3.2212   0.0000   0.0429   0.0000   0.0429   0.0000   0.0001   0.0000   0.0001   0.0000 </r>
+        <r>   3.2778   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.3345   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.3912   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.4478   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.5045   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.5611   0.0067   0.0532   0.0108   0.0532   0.0004   0.0001   0.0004   0.0001   0.0000 </r>
+        <r>   3.6178   0.0055   0.0390   0.0113   0.0323   0.0004   0.0000   0.0009   0.0000   0.0000 </r>
+        <r>   3.6745   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.7311   0.0000   0.0467   0.0000   0.0467   0.0000   0.0000   0.0000   0.0000   0.0006 </r>
+        <r>   3.7878   0.0052   0.1613   0.0000   0.0001   0.0003   0.0000   0.0009   0.0000   0.0004 </r>
+        <r>   3.8444   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.9011   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.9578   0.0066   0.2209   0.0330   0.0371   0.0003   0.0003   0.0002   0.0001   0.0001 </r>
+        <r>   4.0144   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.0711   0.0040   0.1847   0.0731   0.0133   0.0002   0.0003   0.0014   0.0000   0.0002 </r>
+        <r>   4.1277   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.1844   0.0042   0.1738   0.0001   0.0001   0.0004   0.0000   0.0010   0.0000   0.0003 </r>
+        <r>   4.2410   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.2977   0.0022   0.0676   0.0097   0.0676   0.0000   0.0001   0.0000   0.0001   0.0001 </r>
+        <r>   4.3544   0.0025   0.0004   0.1047   0.0004   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.4110   0.0000   0.0018   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.4677   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.5243   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.5810   0.0053   0.0472   0.0006   0.0472   0.0002   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.6377   0.0017   0.0190   0.0000   0.0190   0.0001   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.6943   0.0004   0.2189   0.0000   0.0028   0.0000   0.0000   0.0005   0.0000   0.0002 </r>
+        <r>   4.7510   0.0015   0.0038   0.0911   0.0038   0.0001   0.0000   0.0003   0.0000   0.0000 </r>
+        <r>   4.8076   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.8643   0.0027   0.0513   0.0000   0.0513   0.0001   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.9210   0.0002   0.0535   0.0000   0.0535   0.0000   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>   4.9776   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.0343   0.0003   0.0096   0.0096   0.0096   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.0909   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.1476   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.2043   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.2609   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.3176   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.3742   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.4309   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.4876   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.5442   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.6009   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.6575   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.7142   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.7708   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.8275   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.8842   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.9408   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.9975   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.0541   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.1108   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.1675   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.2241   0.0034   0.0001   0.0002   0.0001   0.0003   0.0001   0.0003   0.0001   0.0000 </r>
+        <r>   6.2808   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.3374   0.0210   0.0006   0.0003   0.0006   0.0021   0.0002   0.0019   0.0002   0.0000 </r>
+        <r>   6.3941   0.0054   0.0003   0.0002   0.0007   0.0005   0.0002   0.0005   0.0000   0.0013 </r>
+        <r>   6.4508   0.0000   0.0002   0.0002   0.0002   0.0003   0.0003   0.0026   0.0003   0.0026 </r>
+        <r>   6.5074   0.0287   0.0025   0.0005   0.0074   0.0032   0.0005   0.0029   0.0000   0.0042 </r>
+        <r>   6.5641   0.0000   0.0031   0.0000   0.0031   0.0000   0.0006   0.0000   0.0006   0.0077 </r>
+        <r>   6.6207   0.0000   0.0003   0.0000   0.0003   0.0000   0.0004   0.0000   0.0004   0.0079 </r>
+        <r>   6.6774   0.0000   0.0001   0.0000   0.0001   0.0000   0.0001   0.0000   0.0001   0.0081 </r>
+        <r>   6.7341   0.0331   0.0198   0.0032   0.0015   0.0008   0.0026   0.0027   0.0001   0.0110 </r>
+        <r>   6.7907   0.0000   0.0066   0.0000   0.0066   0.0000   0.0006   0.0000   0.0006   0.0074 </r>
+        <r>   6.8474   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.9040   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.9607   0.0043   0.0033   0.0340   0.0013   0.0001   0.0002   0.0082   0.0013   0.0024 </r>
+        <r>   7.0174   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.0740   0.0267   0.0012   0.0631   0.0001   0.0000   0.0014   0.0068   0.0002   0.0000 </r>
+        <r>   7.1307   0.0000   0.0095   0.0000   0.0095   0.0000   0.0006   0.0000   0.0006   0.0070 </r>
+        <r>   7.1873   0.0116   0.0014   0.0014   0.0609   0.0009   0.0000   0.0016   0.0006   0.0110 </r>
+        <r>   7.2440   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.3006   0.0000   0.0138   0.0000   0.0138   0.0000   0.0003   0.0000   0.0003   0.0077 </r>
+        <r>   7.3573   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.4140   0.0050   0.0370   0.0005   0.0002   0.0006   0.0014   0.0048   0.0000   0.0060 </r>
+        <r>   7.4706   0.0000   0.0101   0.0000   0.0101   0.0000   0.0000   0.0000   0.0000   0.0051 </r>
+        <r>   7.5273   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.5839   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.6406   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.6973   0.0126   0.0051   0.0274   0.0902   0.0024   0.0002   0.0069   0.0004   0.0090 </r>
+        <r>   7.7539   0.0052   0.0202   0.0250   0.0001   0.0002   0.0003   0.0076   0.0002   0.0027 </r>
+        <r>   7.8106   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.8672   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.9239   0.0068   0.0501   0.0000   0.0034   0.0006   0.0018   0.0035   0.0000   0.0052 </r>
+        <r>   7.9806   0.0138   0.0007   0.0528   0.0414   0.0007   0.0006   0.0023   0.0033   0.0052 </r>
+        <r>   8.0372   0.0103   0.0163   0.0938   0.0140   0.0000   0.0017   0.0095   0.0008   0.0064 </r>
+        <r>   8.0939   0.0039   0.0000   0.0005   0.0345   0.0009   0.0000   0.0002   0.0003   0.0031 </r>
+        <r>   8.1505   0.0036   0.0594   0.0012   0.0001   0.0004   0.0022   0.0035   0.0000   0.0052 </r>
+        <r>   8.2072   0.0018   0.0003   0.0440   0.0003   0.0001   0.0010   0.0047   0.0010   0.0000 </r>
+        <r>   8.2639   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.3205   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.3772   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.4338   0.0111   0.0838   0.0003   0.0016   0.0027   0.0002   0.0010   0.0000   0.0065 </r>
+        <r>   8.4905   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.5472   0.0083   0.0219   0.0065   0.0219   0.0037   0.0006   0.0002   0.0006   0.0000 </r>
+        <r>   8.6038   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.6605   0.0000   0.0004   0.0000   0.0004   0.0044   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.7171   0.0000   0.0000   0.0000   0.0051   0.0162   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.7738   0.0086   0.0004   0.0249   0.0846   0.0036   0.0002   0.0003   0.0026   0.0062 </r>
+        <r>   8.8304   0.0023   0.0004   0.1054   0.0016   0.0005   0.0037   0.0075   0.0023   0.0000 </r>
+        <r>   8.8871   0.0052   0.0612   0.0444   0.0318   0.0321   0.0018   0.0019   0.0016   0.0023 </r>
+        <r>   8.9438   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.0004   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.0571   0.0000   0.0000   0.0175   0.0000   0.0000   0.0005   0.0000   0.0005   0.0000 </r>
+        <r>   9.1137   0.0028   0.0247   0.0352   0.0247   0.0107   0.0008   0.0034   0.0008   0.0000 </r>
+        <r>   9.1704   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.2271   0.0000   0.0226   0.0000   0.0226   0.0000   0.0012   0.0000   0.0012   0.0013 </r>
+        <r>   9.2837   0.0001   0.0007   0.0000   0.0726   0.0221   0.0000   0.0000   0.0001   0.0031 </r>
+        <r>   9.3404   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.3970   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.4537   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.5104   0.0004   0.0003   0.0162   0.0837   0.0198   0.0005   0.0012   0.0007   0.0003 </r>
+        <r>   9.5670   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.6237   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.6803   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.7370   0.0000   0.0278   0.0000   0.0278   0.0000   0.0001   0.0000   0.0001   0.0041 </r>
+        <r>   9.7937   0.0012   0.0005   0.0830   0.0005   0.0002   0.0026   0.0024   0.0026   0.0000 </r>
+        <r>   9.8503   0.0000   0.0141   0.0000   0.0141   0.0000   0.0005   0.0000   0.0005   0.0000 </r>
+        <r>   9.9070   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.9636   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.0203   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.0770   0.0016   0.0001   0.0001   0.0001   0.0236   0.0001   0.0006   0.0001   0.0000 </r>
+        <r>  10.1336   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.1903   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.2469   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.3036   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.3602   0.0000   0.0000   0.0489   0.0000   0.0000   0.0062   0.0000   0.0001   0.0000 </r>
+        <r>  10.4169   0.0035   0.0005   0.2027   0.0006   0.0004   0.0075   0.0031   0.0019   0.0003 </r>
+        <r>  10.4736   0.0008   0.0002   0.1621   0.0002   0.0176   0.0113   0.0009   0.0010   0.0001 </r>
+        <r>  10.5302   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.5869   0.0009   0.0005   0.0829   0.0005   0.0000   0.0010   0.0021   0.0010   0.0000 </r>
+        <r>  10.6435   0.0009   0.0002   0.0001   0.0374   0.0131   0.0000   0.0006   0.0018   0.0007 </r>
+        <r>  10.7002   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.7569   0.0000   0.0000   0.0021   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.8135   0.0000   0.0000   0.0002   0.0000   0.0000   0.0029   0.0000   0.0029   0.0000 </r>
+        <r>  10.8702   0.0012   0.0006   0.1806   0.0011   0.0016   0.0071   0.0012   0.0027   0.0000 </r>
+        <r>  10.9268   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.9835   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.0402   0.0021   0.0021   0.0003   0.0008   0.0270   0.0001   0.0011   0.0005   0.0009 </r>
+        <r>  11.0968   0.0000   0.0000   0.0081   0.0000   0.0000   0.0074   0.0000   0.0008   0.0000 </r>
+        <r>  11.1535   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.2101   0.0015   0.0018   0.0001   0.0018   0.0158   0.0113   0.0010   0.0113   0.0001 </r>
+        <r>  11.2668   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.3235   0.0026   0.0052   0.0006   0.0026   0.0311   0.0004   0.0020   0.0002   0.0002 </r>
+        <r>  11.3801   0.0004   0.0001   0.0004   0.0001   0.0015   0.0124   0.0000   0.0124   0.0000 </r>
+        <r>  11.4368   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.4934   0.0015   0.0011   0.0097   0.0245   0.0181   0.0212   0.0017   0.0015   0.0008 </r>
+        <r>  11.5501   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.6068   0.0025   0.0066   0.0031   0.0015   0.0294   0.0276   0.0031   0.0005   0.0009 </r>
+        <r>  11.6634   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.7201   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.7767   0.0024   0.0064   0.0042   0.0021   0.0006   0.0294   0.0021   0.0000   0.0003 </r>
+        <r>  11.8334   0.0000   0.0000   0.0000   0.0000   0.0000   0.0011   0.0000   0.0011   0.0000 </r>
+        <r>  11.8900   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.9467   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.0034   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.0600   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.1167   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.1733   0.0011   0.0163   0.0058   0.0111   0.0353   0.0086   0.0044   0.0002   0.0004 </r>
+        <r>  12.2300   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.2867   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.3433   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.4000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.4566   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0008   0.0000 </r>
+        <r>  12.5133   0.0024   0.0059   0.0041   0.0000   0.0003   0.0554   0.0000   0.0011   0.0011 </r>
+        <r>  12.5700   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.6266   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.6833   0.0011   0.0023   0.0003   0.0000   0.0000   0.0171   0.0014   0.0000   0.0004 </r>
+        <r>  12.7399   0.0000   0.0006   0.0006   0.0006   0.0069   0.0068   0.0004   0.0069   0.0004 </r>
+        <r>  12.7966   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.8533   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.9099   0.0002   0.0000   0.0000   0.0000   0.0004   0.0004   0.0000   0.0004   0.0000 </r>
+        <r>  12.9666   0.0000   0.0004   0.0000   0.0004   0.0000   0.0046   0.0000   0.0046   0.0006 </r>
+        <r>  13.0232   0.0151   0.0015   0.0011   0.0015   0.0000   0.0014   0.0112   0.0014   0.0000 </r>
+        <r>  13.0799   0.0000   0.0010   0.0003   0.0016   0.0029   0.0016   0.0013   0.0086   0.0000 </r>
+        <r>  13.1366   0.0000   0.0000   0.0014   0.0000   0.0000   0.0172   0.0000   0.0002   0.0000 </r>
+        <r>  13.1932   0.0018   0.0026   0.0003   0.0003   0.0001   0.0353   0.0026   0.0000   0.0002 </r>
+        <r>  13.2499   0.0145   0.0080   0.0016   0.0055   0.0254   0.0019   0.0324   0.0148   0.0159 </r>
+        <r>  13.3065   0.0004   0.0064   0.0000   0.0053   0.0172   0.0158   0.0041   0.0158   0.0033 </r>
+        <r>  13.3632   0.0009   0.0005   0.0105   0.0053   0.0107   0.0004   0.0002   0.0458   0.0018 </r>
+        <r>  13.4198   0.0000   0.0007   0.0000   0.0007   0.0000   0.0166   0.0000   0.0166   0.0005 </r>
+        <r>  13.4765   0.0002   0.0000   0.0000   0.0000   0.0000   0.0000   0.0003   0.0000   0.0000 </r>
+        <r>  13.5332   0.0000   0.0008   0.0000   0.0015   0.0008   0.0001   0.0000   0.0292   0.0471 </r>
+        <r>  13.5898   0.0000   0.0000   0.0000   0.0000   0.0059   0.0010   0.0001   0.0010   0.0000 </r>
+        <r>  13.6465   0.0003   0.0021   0.0000   0.0021   0.0190   0.0014   0.0012   0.0014   0.0000 </r>
+        <r>  13.7031   0.0002   0.0004   0.0004   0.0000   0.0000   0.0198   0.0006   0.0000   0.0000 </r>
+        <r>  13.7598   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  13.8165   0.0000   0.0038   0.0005   0.0006   0.0000   0.0230   0.0004   0.0008   0.0642 </r>
+        <r>  13.8731   0.0014   0.0079   0.0061   0.0000   0.0015   0.0562   0.0002   0.0038   0.0032 </r>
+        <r>  13.9298   0.0001   0.0007   0.0005   0.0001   0.0000   0.0039   0.0006   0.0000   0.0001 </r>
+        <r>  13.9864   0.0015   0.0050   0.0001   0.0050   0.0321   0.0007   0.0006   0.0007   0.0000 </r>
+        <r>  14.0431   0.0021   0.0038   0.0073   0.0038   0.0021   0.0097   0.0006   0.0097   0.0000 </r>
+        <r>  14.0998   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.1564   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.2131   0.0000   0.0001   0.0000   0.0001   0.0063   0.0011   0.0003   0.0037   0.0000 </r>
+        <r>  14.2697   0.0000   0.0022   0.0000   0.0022   0.0000   0.0003   0.0000   0.0003   0.0440 </r>
+        <r>  14.3264   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.3831   0.0053   0.0099   0.0083   0.0063   0.0004   0.0417   0.0163   0.0024   0.0005 </r>
+        <r>  14.4397   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.4964   0.0000   0.0001   0.0000   0.0001   0.0000   0.0255   0.0000   0.0255   0.0032 </r>
+        <r>  14.5530   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.6097   0.0023   0.0000   0.0004   0.0000   0.0000   0.0000   0.0044   0.0000   0.0000 </r>
+        <r>  14.6664   0.0015   0.0001   0.0046   0.0052   0.0054   0.0003   0.0001   0.0627   0.0031 </r>
+        <r>  14.7230   0.0010   0.0251   0.0254   0.0027   0.0031   0.0174   0.0005   0.0130   0.0031 </r>
+        <r>  14.7797   0.0000   0.0015   0.0015   0.0015   0.0000   0.0000   0.0149   0.0000   0.0149 </r>
+        <r>  14.8363   0.0002   0.0036   0.0006   0.0036   0.0048   0.0007   0.0000   0.0018   0.0000 </r>
+        <r>  14.8930   0.0006   0.0096   0.0229   0.0193   0.0075   0.0370   0.0092   0.0302   0.0014 </r>
+        <r>  14.9497   0.0045   0.0022   0.0116   0.0023   0.0019   0.0010   0.0235   0.0896   0.0101 </r>
+        <r>  15.0063   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.0630   0.0006   0.0045   0.0111   0.0045   0.0079   0.0357   0.0001   0.0357   0.0001 </r>
+        <r>  15.1196   0.0042   0.0040   0.0109   0.0040   0.0054   0.0022   0.0231   0.0022   0.0000 </r>
+        <r>  15.1763   0.0000   0.0035   0.0013   0.0052   0.0080   0.0099   0.0035   0.0654   0.0380 </r>
+        <r>  15.2329   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.2896   0.0011   0.0150   0.0001   0.0135   0.0166   0.0046   0.0133   0.0046   0.0005 </r>
+        <r>  15.3463   0.0002   0.0001   0.0009   0.0006   0.0000   0.0016   0.0025   0.0209   0.0011 </r>
+        <r>  15.4029   0.0005   0.0089   0.0084   0.0089   0.0195   0.0063   0.0055   0.0063   0.0000 </r>
+        <r>  15.4596   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.5162   0.0029   0.0258   0.0017   0.0187   0.0219   0.0007   0.0137   0.0046   0.0175 </r>
+        <r>  15.5729   0.0064   0.0005   0.0003   0.0000   0.0000   0.0004   0.0088   0.0000   0.0355 </r>
+        <r>  15.6296   0.0000   0.0019   0.0000   0.0019   0.0000   0.0000   0.0000   0.0000   0.0231 </r>
+        <r>  15.6862   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.7429   0.0105   0.0029   0.0003   0.0057   0.0011   0.0008   0.0454   0.0000   0.0460 </r>
+        <r>  15.7995   0.0000   0.0024   0.0024   0.0024   0.0001   0.0001   0.0149   0.0001   0.0149 </r>
+        <r>  15.8562   0.0014   0.0020   0.0000   0.0016   0.0005   0.0000   0.0478   0.0000   0.0040 </r>
+        <r>  15.9129   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.9695   0.0004   0.0026   0.0004   0.0310   0.0002   0.0008   0.0054   0.0097   0.0133 </r>
+        <r>  16.0262   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.0828   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.1395   0.0008   0.0150   0.0136   0.0003   0.0013   0.0295   0.0028   0.0000   0.0646 </r>
+        <r>  16.1962   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.2528   0.0000   0.0102   0.0090   0.0000   0.0000   0.0221   0.0059   0.0000   0.0218 </r>
+        <r>  16.3095   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.3661   0.0101   0.0098   0.0053   0.0003   0.0182   0.0114   0.0448   0.0158   0.0404 </r>
+        <r>  16.4228   0.0232   0.0018   0.0457   0.0001   0.0002   0.0047   0.1007   0.0060   0.0369 </r>
+        <r>  16.4795   0.0008   0.0002   0.0140   0.0002   0.0107   0.0008   0.0329   0.0043   0.0000 </r>
+        <r>  16.5361   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.5928   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.6494   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.7061   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.7627   0.0030   0.0049   0.0167   0.0000   0.0000   0.0121   0.0109   0.0000   0.0181 </r>
+        <r>  16.8194   0.0006   0.0027   0.0006   0.0009   0.0090   0.0074   0.0022   0.0086   0.0101 </r>
+        <r>  16.8761   0.0068   0.0021   0.0144   0.0077   0.0000   0.0110   0.0000   0.0044   0.0697 </r>
+        <r>  16.9327   0.0166   0.0145   0.0110   0.0399   0.0309   0.0218   0.0306   0.0127   0.0649 </r>
+        <r>  16.9894   0.0032   0.0164   0.0040   0.0375   0.0485   0.0016   0.0329   0.0145   0.0102 </r>
+        <r>  17.0460   0.0090   0.0011   0.0040   0.0011   0.0018   0.0159   0.0150   0.0024   0.0389 </r>
+        <r>  17.1027   0.0010   0.0009   0.0275   0.0000   0.0000   0.0131   0.0489   0.0040   0.0100 </r>
+        <r>  17.1594   0.0003   0.0022   0.0000   0.0018   0.0010   0.0008   0.0404   0.0086   0.0050 </r>
+        <r>  17.2160   0.0002   0.0000   0.0164   0.0002   0.0027   0.0029   0.0251   0.0441   0.0006 </r>
+        <r>  17.2727   0.0255   0.0039   0.0000   0.0001   0.0001   0.0001   0.0062   0.0003   0.0071 </r>
+        <r>  17.3293   0.0090   0.0062   0.0042   0.0023   0.0001   0.0031   0.0120   0.0297   0.0405 </r>
+        <r>  17.3860   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.4427   0.0262   0.0116   0.0034   0.0114   0.0072   0.0093   0.0138   0.0404   0.0837 </r>
+        <r>  17.4993   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.5560   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.6126   0.0001   0.0005   0.0001   0.0006   0.0000   0.0070   0.0021   0.0064   0.0108 </r>
+        <r>  17.6693   0.0001   0.0003   0.0000   0.0000   0.0000   0.0014   0.0001   0.0019   0.0406 </r>
+        <r>  17.7260   0.0057   0.0168   0.0036   0.0128   0.0094   0.0152   0.0323   0.0024   0.0364 </r>
+        <r>  17.7826   0.0001   0.0002   0.0000   0.0000   0.0000   0.0000   0.0011   0.0001   0.0030 </r>
+        <r>  17.8393   0.0071   0.0104   0.0008   0.0009   0.0003   0.0030   0.0207   0.0049   0.0346 </r>
+        <r>  17.8959   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.9526   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.0093   0.0027   0.0002   0.0032   0.0004   0.0065   0.0000   0.0001   0.0002   0.0041 </r>
+        <r>  18.0659   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.1226   0.0022   0.0001   0.0002   0.0030   0.0001   0.0093   0.0729   0.0020   0.0122 </r>
+        <r>  18.1792   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.2359   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.2925   0.0028   0.0008   0.0032   0.0024   0.0026   0.0000   0.0000   0.0244   0.0024 </r>
+        <r>  18.3492   0.0002   0.0142   0.0053   0.0052   0.0359   0.0000   0.0270   0.0002   0.0286 </r>
+        <r>  18.4059   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.4625   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.5192   0.0007   0.0063   0.0096   0.0073   0.0000   0.0398   0.0230   0.0110   0.0459 </r>
+        <r>  18.5758   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.6325   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.6892   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.7458   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.8025   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.8591   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.9158   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.9725   0.0006   0.0000   0.0072   0.0007   0.0068   0.0029   0.0269   0.0526   0.0110 </r>
+        <r>  19.0291   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.0858   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.1424   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.1991   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.2558   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.3124   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.3691   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.4257   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.4824   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.5391   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.5957   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.6524   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.7090   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.7657   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.8223   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.8790   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.9357   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.9923   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.0490   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.1056   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.1623   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.2190   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.2756   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.3323   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.3889   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.4456   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.5023   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.5589   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.6156   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.6722   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.7289   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+       </set>
+      </set>
+      <set comment="ion 2">
+       <set comment="spin 1">
+        <r> -13.2667   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.2100   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.1534   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.0967   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -13.0400   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.9834   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.9267   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.8701   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.8134   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.7567   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.7001   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.6434   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.5868   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.5301   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.4734   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.4168   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.3601   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.3035   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.2468   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.1901   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.1335   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.0768   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -12.0202   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.9635   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.9068   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.8502   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.7935   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.7369   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.6802   0.0000   0.0000   0.0000   0.0000   0.3209   0.2990   6.6191   0.2812   9.1807 </r>
+        <r> -11.6236   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.5669   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.5102   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.4536   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.3969   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.3403   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.2836   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.2269   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.1703   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.1136   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.0570   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -11.0003   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.9436   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.8870   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.8303   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.7737   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.7170   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.6603   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.6037   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.5470   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.4904   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.4337   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.3770   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.3204   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.2637   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.2071   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.1504   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.0937   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r> -10.0371   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.9804   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.9238   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.8671   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.8105   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.7538   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.6971   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.6405   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.5838   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.5272   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.4705   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.4138   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.3572   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.3005   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.2439   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.1872   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.1305   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.0739   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -9.0172   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.9606   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.9039   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.8472   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.7906   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.7339   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.6773   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.6206   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.5639   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.5073   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.4506   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.3940   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.3373   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.2807   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.2240   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.1673   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.1107   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -8.0540   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.9974   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.9407   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.8840   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.8274   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.7707   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.7141   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.6574   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.6007   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.5441   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.4874   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.4308   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.3741   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.3174   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.2608   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.2041   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.1475   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.0908   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -7.0341   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.9775   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.9208   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.8642   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.8075   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.7509   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.6942   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.6375   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.5809   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.5242   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.4676   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.4109   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.3542   0.0336   0.0001   0.0004   0.0000   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -6.2976   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.2409   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.1843   0.0709   0.0006   0.0014   0.0001   0.0000   0.0000   0.0002   0.0000   0.0000 </r>
+        <r>  -6.1276   0.0350   0.0001   0.0009   0.0000   0.0000   0.0000   0.0003   0.0000   0.0000 </r>
+        <r>  -6.0709   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -6.0143   0.0357   0.0002   0.0010   0.0002   0.0000   0.0000   0.0006   0.0000   0.0000 </r>
+        <r>  -5.9576   0.0618   0.0010   0.0019   0.0003   0.0000   0.0000   0.0004   0.0000   0.0001 </r>
+        <r>  -5.9010   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.8443   0.0376   0.0004   0.0015   0.0004   0.0000   0.0000   0.0007   0.0000   0.0000 </r>
+        <r>  -5.7876   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.7310   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.6743   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.6177   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.5610   0.0286   0.0004   0.0016   0.0004   0.0000   0.0000   0.0017   0.0000   0.0000 </r>
+        <r>  -5.5043   0.0046   0.0004   0.0004   0.0004   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.4477   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.3910   0.0222   0.0000   0.0010   0.0000   0.0000   0.0000   0.0027   0.0000   0.0000 </r>
+        <r>  -5.3344   0.0430   0.0015   0.0019   0.0008   0.0000   0.0000   0.0056   0.0000   0.0000 </r>
+        <r>  -5.2777   0.0019   0.0000   0.0001   0.0000   0.0000   0.0000   0.0003   0.0000   0.0000 </r>
+        <r>  -5.2211   0.0167   0.0016   0.0018   0.0016   0.0000   0.0000   0.0039   0.0000   0.0000 </r>
+        <r>  -5.1644   0.0033   0.0025   0.0015   0.0025   0.0000   0.0000   0.0029   0.0000   0.0000 </r>
+        <r>  -5.1077   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -5.0511   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.9944   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.9378   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.8811   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.8244   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.7678   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.7111   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.6545   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.5978   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.5411   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.4845   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.4278   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.3712   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.3145   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.2578   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.2012   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.1445   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.0879   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -4.0312   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.9745   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.9179   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.8612   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.8046   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.7479   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.6913   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.6346   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.5779   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.5213   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.4646   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.4080   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.3513   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.2946   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.2380   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.1813   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.1247   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.0680   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -3.0113   0.1076   0.0001   0.0000   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.9547   0.3578   0.0002   0.0005   0.0000   0.0002   0.0001   0.0003   0.0001   0.0000 </r>
+        <r>  -2.8980   0.2440   0.0005   0.0002   0.0006   0.0001   0.0001   0.0001   0.0001   0.0000 </r>
+        <r>  -2.8414   0.0386   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.7847   0.7893   0.0007   0.0003   0.0004   0.0002   0.0001   0.0005   0.0000   0.0002 </r>
+        <r>  -2.7280   0.0712   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0001 </r>
+        <r>  -2.6714   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.6147   0.0207   0.0001   0.0000   0.0001   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.5581   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.5014   0.0018   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.4447   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.3881   0.2654   0.0006   0.0000   0.0001   0.0000   0.0000   0.0004   0.0000   0.0000 </r>
+        <r>  -2.3314   0.1252   0.0005   0.0005   0.0005   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -2.2748   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.2181   0.1314   0.0005   0.0002   0.0000   0.0000   0.0001   0.0003   0.0000   0.0001 </r>
+        <r>  -2.1615   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.1048   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -2.0481   0.1307   0.0003   0.0002   0.0003   0.0000   0.0000   0.0004   0.0000   0.0000 </r>
+        <r>  -1.9915   0.1754   0.0003   0.0003   0.0003   0.0000   0.0000   0.0006   0.0000   0.0000 </r>
+        <r>  -1.9348   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.8782   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.8215   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.7648   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.7082   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.6515   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.5949   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.5382   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.4815   0.0738   0.0002   0.0003   0.0002   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -1.4249   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.3682   0.1321   0.0003   0.0007   0.0003   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  -1.3116   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.2549   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.1982   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.1416   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.0849   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -1.0283   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.9716   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.9149   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.8583   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.8016   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.7450   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.6883   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.6317   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.5750   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.5183   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.4617   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.4050   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.3484   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.2917   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.2350   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.1784   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.1217   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.0651   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  -0.0084   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.0483   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.1049   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.1616   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.2182   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.2749   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.3316   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.3882   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.4449   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.5015   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.5582   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.6149   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.6715   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.7282   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.7848   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.8415   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.8981   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   0.9548   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.0115   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.0681   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.1248   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.1814   0.0008   0.0000   0.0311   0.0000   0.0000   0.0002   0.0001   0.0000   0.0000 </r>
+        <r>   1.2381   0.0000   0.0000   0.0313   0.0000   0.0000   0.0003   0.0000   0.0000   0.0000 </r>
+        <r>   1.2948   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.3514   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.4081   0.0026   0.0000   0.0305   0.0000   0.0000   0.0001   0.0004   0.0001   0.0000 </r>
+        <r>   1.4647   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.5214   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.5781   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.6347   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.6914   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.7480   0.0095   0.0001   0.0592   0.0002   0.0000   0.0004   0.0016   0.0001   0.0000 </r>
+        <r>   1.8047   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.8614   0.0005   0.0000   0.0306   0.0000   0.0000   0.0004   0.0001   0.0004   0.0000 </r>
+        <r>   1.9180   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   1.9747   0.0066   0.0000   0.0563   0.0023   0.0001   0.0007   0.0017   0.0000   0.0000 </r>
+        <r>   2.0313   0.0156   0.0002   0.0574   0.0002   0.0000   0.0002   0.0025   0.0000   0.0000 </r>
+        <r>   2.0880   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.1447   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.2013   0.0042   0.0000   0.0237   0.0082   0.0001   0.0002   0.0013   0.0000   0.0000 </r>
+        <r>   2.2580   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.3146   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.3713   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.4280   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.4846   0.0007   0.0000   0.0001   0.0576   0.0009   0.0000   0.0001   0.0007   0.0001 </r>
+        <r>   2.5413   0.0000   0.0079   0.0000   0.0079   0.0000   0.0000   0.0000   0.0000   0.0001 </r>
+        <r>   2.5979   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.6546   0.0029   0.0149   0.0577   0.0149   0.0000   0.0010   0.0009   0.0008   0.0004 </r>
+        <r>   2.7112   0.0000   0.0000   0.0149   0.0299   0.0004   0.0002   0.0000   0.0007   0.0000 </r>
+        <r>   2.7679   0.0000   0.0000   0.0000   0.0015   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   2.8246   0.0067   0.0148   0.0002   0.0148   0.0003   0.0001   0.0002   0.0001   0.0000 </r>
+        <r>   2.8812   0.0019   0.0164   0.0001   0.0000   0.0000   0.0001   0.0001   0.0000   0.0001 </r>
+        <r>   2.9379   0.0064   0.0063   0.0121   0.0063   0.0002   0.0002   0.0007   0.0002   0.0000 </r>
+        <r>   2.9945   0.0119   0.0225   0.0001   0.0225   0.0005   0.0001   0.0005   0.0001   0.0006 </r>
+        <r>   3.0512   0.0024   0.0131   0.0168   0.0461   0.0004   0.0000   0.0028   0.0006   0.0013 </r>
+        <r>   3.1079   0.0147   0.0317   0.0001   0.0252   0.0004   0.0001   0.0007   0.0000   0.0022 </r>
+        <r>   3.1645   0.0130   0.0003   0.0099   0.0214   0.0002   0.0000   0.0002   0.0005   0.0012 </r>
+        <r>   3.2212   0.0000   0.0143   0.0000   0.0143   0.0000   0.0002   0.0000   0.0002   0.0001 </r>
+        <r>   3.2778   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.3345   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.3912   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.4478   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.5045   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.5611   0.0144   0.0172   0.0004   0.0172   0.0009   0.0001   0.0020   0.0001   0.0000 </r>
+        <r>   3.6178   0.0221   0.0134   0.0028   0.0122   0.0009   0.0000   0.0016   0.0000   0.0001 </r>
+        <r>   3.6745   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.7311   0.0000   0.0087   0.0000   0.0087   0.0000   0.0001   0.0000   0.0001   0.0037 </r>
+        <r>   3.7878   0.0256   0.0439   0.0002   0.0003   0.0006   0.0001   0.0013   0.0000   0.0024 </r>
+        <r>   3.8444   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.9011   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   3.9578   0.0110   0.0488   0.0003   0.0086   0.0007   0.0006   0.0037   0.0001   0.0012 </r>
+        <r>   4.0144   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.0711   0.0344   0.0354   0.0134   0.0054   0.0005   0.0008   0.0039   0.0004   0.0018 </r>
+        <r>   4.1277   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.1844   0.0326   0.0306   0.0006   0.0007   0.0009   0.0003   0.0016   0.0000   0.0033 </r>
+        <r>   4.2410   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.2977   0.0067   0.0058   0.0023   0.0058   0.0001   0.0002   0.0000   0.0002   0.0039 </r>
+        <r>   4.3544   0.0088   0.0002   0.0163   0.0002   0.0000   0.0000   0.0009   0.0000   0.0000 </r>
+        <r>   4.4110   0.0004   0.0002   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.4677   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.5243   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.5810   0.0228   0.0068   0.0004   0.0068   0.0007   0.0001   0.0006   0.0001   0.0000 </r>
+        <r>   4.6377   0.0085   0.0024   0.0000   0.0024   0.0003   0.0000   0.0003   0.0000   0.0000 </r>
+        <r>   4.6943   0.0434   0.0041   0.0000   0.0031   0.0008   0.0000   0.0022   0.0000   0.0043 </r>
+        <r>   4.7510   0.0290   0.0019   0.0001   0.0019   0.0001   0.0005   0.0021   0.0005   0.0000 </r>
+        <r>   4.8076   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   4.8643   0.0302   0.0022   0.0001   0.0022   0.0009   0.0000   0.0012   0.0000   0.0000 </r>
+        <r>   4.9210   0.0383   0.0000   0.0003   0.0000   0.0011   0.0001   0.0018   0.0001   0.0000 </r>
+        <r>   4.9776   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.0343   0.0168   0.0002   0.0002   0.0002   0.0003   0.0003   0.0000   0.0003   0.0000 </r>
+        <r>   5.0909   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.1476   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.2043   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.2609   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.3176   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.3742   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.4309   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.4876   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.5442   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.6009   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.6575   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.7142   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.7708   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.8275   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.8842   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.9408   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   5.9975   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.0541   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.1108   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.1675   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.2241   0.0003   0.0061   0.0000   0.0061   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.2808   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.3374   0.0000   0.0403   0.0000   0.0403   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.3941   0.0001   0.0364   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.4508   0.0000   0.0219   0.0219   0.0219   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.5074   0.0001   0.1620   0.0000   0.0047   0.0000   0.0000   0.0001   0.0000   0.0009 </r>
+        <r>   6.5641   0.0000   0.0482   0.0000   0.0482   0.0000   0.0000   0.0000   0.0000   0.0004 </r>
+        <r>   6.6207   0.0000   0.0507   0.0000   0.0507   0.0000   0.0000   0.0000   0.0000   0.0004 </r>
+        <r>   6.6774   0.0000   0.0526   0.0000   0.0526   0.0000   0.0000   0.0000   0.0000   0.0002 </r>
+        <r>   6.7341   0.0028   0.2584   0.0004   0.0022   0.0000   0.0002   0.0004   0.0000   0.0013 </r>
+        <r>   6.7907   0.0000   0.0452   0.0000   0.0452   0.0000   0.0000   0.0000   0.0000   0.0012 </r>
+        <r>   6.8474   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.9040   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   6.9607   0.0065   0.0372   0.1007   0.0018   0.0000   0.0003   0.0007   0.0002   0.0004 </r>
+        <r>   7.0174   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.0740   0.0036   0.0026   0.1534   0.0001   0.0000   0.0002   0.0010   0.0000   0.0000 </r>
+        <r>   7.1307   0.0000   0.0426   0.0000   0.0426   0.0000   0.0000   0.0000   0.0000   0.0020 </r>
+        <r>   7.1873   0.0099   0.0188   0.0241   0.1416   0.0003   0.0000   0.0010   0.0001   0.0006 </r>
+        <r>   7.2440   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.3006   0.0000   0.0434   0.0000   0.0434   0.0000   0.0000   0.0000   0.0000   0.0018 </r>
+        <r>   7.3573   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.4140   0.0077   0.1527   0.0143   0.0000   0.0000   0.0001   0.0007   0.0000   0.0022 </r>
+        <r>   7.4706   0.0000   0.0282   0.0000   0.0282   0.0000   0.0000   0.0000   0.0000   0.0013 </r>
+        <r>   7.5273   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.5839   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.6406   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.6973   0.0228   0.0173   0.0538   0.1498   0.0002   0.0002   0.0010   0.0003   0.0018 </r>
+        <r>   7.7539   0.0110   0.0585   0.1170   0.0001   0.0000   0.0002   0.0015   0.0000   0.0011 </r>
+        <r>   7.8106   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.8672   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   7.9239   0.0075   0.1637   0.0059   0.0039   0.0000   0.0000   0.0011   0.0000   0.0024 </r>
+        <r>   7.9806   0.0005   0.0128   0.0611   0.0512   0.0000   0.0002   0.0031   0.0000   0.0017 </r>
+        <r>   8.0372   0.0133   0.0543   0.1336   0.0420   0.0000   0.0004   0.0021   0.0000   0.0028 </r>
+        <r>   8.0939   0.0032   0.0016   0.0002   0.0475   0.0000   0.0000   0.0004   0.0000   0.0009 </r>
+        <r>   8.1505   0.0087   0.1502   0.0085   0.0000   0.0000   0.0001   0.0005   0.0000   0.0025 </r>
+        <r>   8.2072   0.0067   0.0024   0.0620   0.0024   0.0000   0.0001   0.0015   0.0001   0.0000 </r>
+        <r>   8.2639   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.3205   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.3772   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.4338   0.0080   0.1417   0.0000   0.0000   0.0007   0.0000   0.0006   0.0000   0.0028 </r>
+        <r>   8.4905   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.5472   0.0031   0.0218   0.0030   0.0218   0.0009   0.0000   0.0011   0.0000   0.0000 </r>
+        <r>   8.6038   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.6605   0.0000   0.0000   0.0000   0.0000   0.0036   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.7171   0.0000   0.0000   0.0000   0.0004   0.0129   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   8.7738   0.0004   0.0087   0.0198   0.0902   0.0004   0.0000   0.0020   0.0000   0.0026 </r>
+        <r>   8.8304   0.0106   0.0021   0.1185   0.0058   0.0003   0.0000   0.0027   0.0001   0.0000 </r>
+        <r>   8.8871   0.0045   0.0832   0.1032   0.0294   0.0211   0.0002   0.0013   0.0002   0.0011 </r>
+        <r>   8.9438   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.0004   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.0571   0.0000   0.0000   0.0463   0.0000   0.0000   0.0001   0.0000   0.0001   0.0000 </r>
+        <r>   9.1137   0.0070   0.0327   0.0400   0.0327   0.0065   0.0000   0.0007   0.0000   0.0000 </r>
+        <r>   9.1704   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.2271   0.0000   0.0420   0.0000   0.0420   0.0000   0.0000   0.0000   0.0000   0.0008 </r>
+        <r>   9.2837   0.0005   0.0150   0.0000   0.0362   0.0125   0.0000   0.0001   0.0000   0.0014 </r>
+        <r>   9.3404   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.3970   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.4537   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.5104   0.0034   0.0001   0.0168   0.0400   0.0085   0.0000   0.0001   0.0000   0.0002 </r>
+        <r>   9.5670   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.6237   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.6803   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.7370   0.0000   0.0425   0.0000   0.0425   0.0000   0.0000   0.0000   0.0000   0.0021 </r>
+        <r>   9.7937   0.0037   0.0011   0.0656   0.0011   0.0000   0.0001   0.0008   0.0001   0.0000 </r>
+        <r>   9.8503   0.0000   0.0217   0.0000   0.0217   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.9070   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>   9.9636   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.0203   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.0770   0.0007   0.0114   0.0001   0.0114   0.0189   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  10.1336   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.1903   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.2469   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.3036   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.3602   0.0000   0.0000   0.0225   0.0000   0.0000   0.0013   0.0000   0.0000   0.0000 </r>
+        <r>  10.4169   0.0034   0.0016   0.1392   0.0019   0.0004   0.0001   0.0018   0.0000   0.0001 </r>
+        <r>  10.4736   0.0012   0.0022   0.0951   0.0018   0.0120   0.0011   0.0005   0.0001   0.0000 </r>
+        <r>  10.5302   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.5869   0.0029   0.0017   0.0622   0.0017   0.0001   0.0000   0.0007   0.0000   0.0000 </r>
+        <r>  10.6435   0.0012   0.0004   0.0006   0.1255   0.0161   0.0000   0.0000   0.0001   0.0004 </r>
+        <r>  10.7002   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.7569   0.0001   0.0000   0.0015   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.8135   0.0000   0.0000   0.0163   0.0000   0.0000   0.0027   0.0000   0.0027   0.0000 </r>
+        <r>  10.8702   0.0017   0.0019   0.1180   0.0026   0.0012   0.0013   0.0005   0.0012   0.0000 </r>
+        <r>  10.9268   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  10.9835   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.0402   0.0009   0.0018   0.0003   0.0572   0.0226   0.0001   0.0001   0.0002   0.0005 </r>
+        <r>  11.0968   0.0000   0.0000   0.0423   0.0000   0.0000   0.0077   0.0000   0.0000   0.0000 </r>
+        <r>  11.1535   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.2101   0.0002   0.0092   0.0002   0.0092   0.0116   0.0067   0.0000   0.0067   0.0000 </r>
+        <r>  11.2668   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.3235   0.0004   0.0090   0.0005   0.0258   0.0225   0.0002   0.0000   0.0001   0.0001 </r>
+        <r>  11.3801   0.0003   0.0022   0.0005   0.0022   0.0008   0.0077   0.0000   0.0077   0.0000 </r>
+        <r>  11.4368   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.4934   0.0015   0.0005   0.0869   0.1175   0.0194   0.0196   0.0004   0.0001   0.0004 </r>
+        <r>  11.5501   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.6068   0.0011   0.0030   0.0762   0.0353   0.0209   0.0224   0.0004   0.0006   0.0004 </r>
+        <r>  11.6634   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.7201   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.7767   0.0003   0.0027   0.0323   0.0001   0.0004   0.0200   0.0004   0.0008   0.0000 </r>
+        <r>  11.8334   0.0000   0.0000   0.0000   0.0000   0.0000   0.0005   0.0000   0.0005   0.0000 </r>
+        <r>  11.8900   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  11.9467   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.0034   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.0600   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.1167   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.1733   0.0003   0.0071   0.0060   0.0205   0.0215   0.0051   0.0002   0.0008   0.0001 </r>
+        <r>  12.2300   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.2867   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.3433   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.4000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.4566   0.0000   0.0000   0.0000   0.0004   0.0000   0.0000   0.0000   0.0004   0.0000 </r>
+        <r>  12.5133   0.0009   0.0087   0.0025   0.0013   0.0001   0.0286   0.0001   0.0006   0.0002 </r>
+        <r>  12.5700   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.6266   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.6833   0.0006   0.0031   0.0230   0.0000   0.0000   0.0104   0.0001   0.0000   0.0001 </r>
+        <r>  12.7399   0.0000   0.0013   0.0013   0.0013   0.0029   0.0029   0.0000   0.0029   0.0000 </r>
+        <r>  12.7966   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.8533   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  12.9099   0.0004   0.0001   0.0001   0.0001   0.0002   0.0002   0.0000   0.0002   0.0000 </r>
+        <r>  12.9666   0.0000   0.0011   0.0000   0.0011   0.0000   0.0019   0.0000   0.0019   0.0001 </r>
+        <r>  13.0232   0.0275   0.0034   0.0022   0.0034   0.0000   0.0005   0.0063   0.0005   0.0000 </r>
+        <r>  13.0799   0.0003   0.0019   0.0030   0.0013   0.0016   0.0004   0.0003   0.0038   0.0000 </r>
+        <r>  13.1366   0.0000   0.0000   0.0406   0.0000   0.0000   0.0099   0.0000   0.0001   0.0000 </r>
+        <r>  13.1932   0.0009   0.0033   0.0548   0.0001   0.0001   0.0189   0.0004   0.0004   0.0000 </r>
+        <r>  13.2499   0.0247   0.0167   0.0173   0.0255   0.0125   0.0003   0.0165   0.0069   0.0091 </r>
+        <r>  13.3065   0.0011   0.0116   0.0000   0.0186   0.0088   0.0063   0.0006   0.0063   0.0007 </r>
+        <r>  13.3632   0.0001   0.0016   0.0059   0.0049   0.0026   0.0009   0.0001   0.0181   0.0001 </r>
+        <r>  13.4198   0.0000   0.0017   0.0000   0.0017   0.0000   0.0050   0.0000   0.0050   0.0000 </r>
+        <r>  13.4765   0.0005   0.0000   0.0001   0.0000   0.0000   0.0000   0.0001   0.0000   0.0000 </r>
+        <r>  13.5332   0.0000   0.0024   0.0000   0.0190   0.0002   0.0001   0.0000   0.0125   0.0266 </r>
+        <r>  13.5898   0.0001   0.0004   0.0000   0.0004   0.0027   0.0005   0.0001   0.0005   0.0000 </r>
+        <r>  13.6465   0.0000   0.0024   0.0011   0.0024   0.0063   0.0003   0.0000   0.0003   0.0000 </r>
+        <r>  13.7031   0.0003   0.0004   0.0345   0.0000   0.0000   0.0089   0.0001   0.0000   0.0000 </r>
+        <r>  13.7598   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  13.8165   0.0004   0.0082   0.0013   0.0037   0.0000   0.0086   0.0001   0.0004   0.0338 </r>
+        <r>  13.8731   0.0000   0.0091   0.0055   0.0024   0.0004   0.0179   0.0000   0.0008   0.0002 </r>
+        <r>  13.9298   0.0003   0.0009   0.0044   0.0001   0.0000   0.0016   0.0000   0.0001   0.0000 </r>
+        <r>  13.9864   0.0002   0.0040   0.0014   0.0040   0.0104   0.0002   0.0000   0.0002   0.0000 </r>
+        <r>  14.0431   0.0014   0.0006   0.0013   0.0006   0.0005   0.0046   0.0004   0.0046   0.0000 </r>
+        <r>  14.0998   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.1564   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.2131   0.0000   0.0000   0.0003   0.0009   0.0026   0.0005   0.0002   0.0016   0.0000 </r>
+        <r>  14.2697   0.0000   0.0067   0.0000   0.0067   0.0000   0.0002   0.0000   0.0002   0.0240 </r>
+        <r>  14.3264   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.3831   0.0168   0.0055   0.0557   0.0010   0.0001   0.0156   0.0023   0.0026   0.0002 </r>
+        <r>  14.4397   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.4964   0.0000   0.0061   0.0000   0.0061   0.0000   0.0003   0.0000   0.0003   0.0001 </r>
+        <r>  14.5530   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  14.6097   0.0062   0.0000   0.0033   0.0000   0.0000   0.0000   0.0008   0.0000   0.0000 </r>
+        <r>  14.6664   0.0006   0.0000   0.0128   0.0135   0.0003   0.0001   0.0000   0.0099   0.0004 </r>
+        <r>  14.7230   0.0010   0.0029   0.0038   0.0166   0.0003   0.0293   0.0002   0.0000   0.0014 </r>
+        <r>  14.7797   0.0000   0.0037   0.0037   0.0037   0.0000   0.0000   0.0079   0.0000   0.0079 </r>
+        <r>  14.8363   0.0002   0.0001   0.0028   0.0001   0.0041   0.0000   0.0001   0.0003   0.0000 </r>
+        <r>  14.8930   0.0071   0.0138   0.0148   0.0330   0.0001   0.0012   0.0014   0.0102   0.0000 </r>
+        <r>  14.9497   0.0091   0.0027   0.0391   0.0263   0.0002   0.0000   0.0110   0.0008   0.0039 </r>
+        <r>  15.0063   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.0630   0.0002   0.0068   0.0146   0.0068   0.0000   0.0025   0.0000   0.0025   0.0001 </r>
+        <r>  15.1196   0.0091   0.0040   0.0204   0.0040   0.0000   0.0004   0.0104   0.0004   0.0000 </r>
+        <r>  15.1763   0.0022   0.0057   0.0231   0.0090   0.0029   0.0013   0.0002   0.0119   0.0181 </r>
+        <r>  15.2329   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.2896   0.0019   0.0028   0.0019   0.0031   0.0169   0.0017   0.0055   0.0017   0.0001 </r>
+        <r>  15.3463   0.0014   0.0000   0.0066   0.0008   0.0000   0.0000   0.0003   0.0026   0.0006 </r>
+        <r>  15.4029   0.0015   0.0002   0.0174   0.0002   0.0033   0.0002   0.0031   0.0002   0.0000 </r>
+        <r>  15.4596   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.5162   0.0081   0.0289   0.0001   0.0164   0.0170   0.0000   0.0059   0.0013   0.0066 </r>
+        <r>  15.5729   0.0137   0.0000   0.0009   0.0000   0.0000   0.0000   0.0018   0.0000   0.0142 </r>
+        <r>  15.6296   0.0000   0.0048   0.0000   0.0048   0.0000   0.0000   0.0000   0.0000   0.0114 </r>
+        <r>  15.6862   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.7429   0.0281   0.0012   0.0004   0.0025   0.0001   0.0005   0.0114   0.0000   0.0186 </r>
+        <r>  15.7995   0.0002   0.0054   0.0054   0.0054   0.0000   0.0000   0.0073   0.0000   0.0073 </r>
+        <r>  15.8562   0.0223   0.0001   0.0000   0.0001   0.0000   0.0000   0.0075   0.0000   0.0033 </r>
+        <r>  15.9129   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  15.9695   0.0038   0.0001   0.0038   0.0338   0.0001   0.0119   0.0014   0.0083   0.0067 </r>
+        <r>  16.0262   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.0828   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.1395   0.0003   0.0001   0.0038   0.0069   0.0001   0.0039   0.0021   0.0026   0.0220 </r>
+        <r>  16.1962   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.2528   0.0024   0.0000   0.0005   0.0000   0.0000   0.0019   0.0003   0.0000   0.0065 </r>
+        <r>  16.3095   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.3661   0.0107   0.0036   0.0065   0.0147   0.0050   0.0006   0.0184   0.0034   0.0127 </r>
+        <r>  16.4228   0.0099   0.0014   0.0663   0.0024   0.0000   0.0001   0.0624   0.0018   0.0062 </r>
+        <r>  16.4795   0.0030   0.0002   0.0318   0.0016   0.0030   0.0000   0.0158   0.0006   0.0000 </r>
+        <r>  16.5361   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.5928   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.6494   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.7061   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  16.7627   0.0011   0.0005   0.0023   0.0000   0.0000   0.0013   0.0058   0.0000   0.0033 </r>
+        <r>  16.8194   0.0001   0.0075   0.0035   0.0039   0.0024   0.0003   0.0011   0.0003   0.0046 </r>
+        <r>  16.8761   0.0035   0.0025   0.0073   0.0181   0.0004   0.0046   0.0102   0.0026   0.0168 </r>
+        <r>  16.9327   0.0109   0.0093   0.0115   0.0058   0.0060   0.0346   0.0237   0.0059   0.0129 </r>
+        <r>  16.9894   0.0010   0.0109   0.0015   0.0116   0.0217   0.0016   0.0137   0.0052   0.0004 </r>
+        <r>  17.0460   0.0099   0.0124   0.0045   0.0001   0.0006   0.0213   0.0074   0.0021   0.0144 </r>
+        <r>  17.1027   0.0000   0.0004   0.0469   0.0001   0.0000   0.0100   0.0235   0.0000   0.0029 </r>
+        <r>  17.1594   0.0162   0.0001   0.0297   0.0040   0.0000   0.0001   0.0053   0.0151   0.0038 </r>
+        <r>  17.2160   0.0001   0.0019   0.0207   0.0015   0.0004   0.0009   0.0115   0.0060   0.0001 </r>
+        <r>  17.2727   0.0005   0.0129   0.0000   0.0025   0.0000   0.0000   0.0237   0.0000   0.0032 </r>
+        <r>  17.3293   0.0090   0.0202   0.0138   0.0002   0.0001   0.0171   0.0068   0.0223   0.0148 </r>
+        <r>  17.3860   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.4427   0.0201   0.0432   0.0143   0.0179   0.0130   0.0077   0.0165   0.0251   0.0303 </r>
+        <r>  17.4993   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.5560   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.6126   0.0010   0.0094   0.0001   0.0084   0.0000   0.0061   0.0000   0.0057   0.0059 </r>
+        <r>  17.6693   0.0000   0.0137   0.0000   0.0102   0.0000   0.0059   0.0001   0.0054   0.0165 </r>
+        <r>  17.7260   0.0057   0.0059   0.0001   0.0513   0.0086   0.0086   0.0162   0.0133   0.0116 </r>
+        <r>  17.7826   0.0004   0.0019   0.0000   0.0000   0.0000   0.0007   0.0002   0.0001   0.0010 </r>
+        <r>  17.8393   0.0115   0.0339   0.0013   0.0000   0.0009   0.0076   0.0064   0.0002   0.0123 </r>
+        <r>  17.8959   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  17.9526   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.0093   0.0010   0.0000   0.0032   0.0004   0.0014   0.0001   0.0012   0.0014   0.0011 </r>
+        <r>  18.0659   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.1226   0.0131   0.0021   0.0084   0.0103   0.0009   0.0050   0.0087   0.0065   0.0036 </r>
+        <r>  18.1792   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.2359   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.2925   0.0011   0.0004   0.0028   0.0015   0.0004   0.0001   0.0016   0.0053   0.0005 </r>
+        <r>  18.3492   0.0017   0.0243   0.0048   0.0001   0.0164   0.0033   0.0013   0.0005   0.0114 </r>
+        <r>  18.4059   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.4625   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.5192   0.0053   0.0027   0.0017   0.0125   0.0009   0.0112   0.0015   0.0032   0.0067 </r>
+        <r>  18.5758   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.6325   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.6892   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.7458   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.8025   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.8591   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.9158   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  18.9725   0.0063   0.0001   0.0004   0.0322   0.0004   0.0001   0.0001   0.0038   0.0087 </r>
+        <r>  19.0291   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.0858   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.1424   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.1991   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.2558   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.3124   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.3691   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.4257   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.4824   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.5391   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.5957   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.6524   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.7090   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.7657   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.8223   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.8790   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.9357   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  19.9923   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.0490   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.1056   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.1623   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.2190   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.2756   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.3323   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.3889   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.4456   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.5023   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.5589   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.6156   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.6722   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+        <r>  20.7289   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000   0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </array>
+   </partial>
+  </dos>
+  <projected>
+   <eigenvalues>
+    <array>
+     <dimension dim="1">band</dimension>
+     <dimension dim="2">kpoint</dimension>
+     <dimension dim="3">spin</dimension>
+     <field>eigene</field>
+     <field>occ</field>
+     <set>
+      <set comment="spin 1">
+       <set comment="kpoint 1">
+        <r>  -11.6752    1.0000 </r>
+        <r>  -11.6752    1.0000 </r>
+        <r>  -11.6668    1.0000 </r>
+        <r>  -11.6668    1.0000 </r>
+        <r>  -11.6668    1.0000 </r>
+        <r>   -6.5891    1.0000 </r>
+        <r>   -0.6273    1.0000 </r>
+        <r>    3.8650    1.0000 </r>
+        <r>    3.8650    1.0000 </r>
+        <r>    3.8650    1.0000 </r>
+        <r>    9.0634    0.0000 </r>
+        <r>    9.0634    0.0000 </r>
+        <r>    9.0634    0.0000 </r>
+        <r>   10.9300    0.0000 </r>
+        <r>   10.9300    0.0000 </r>
+        <r>   10.9300    0.0000 </r>
+        <r>   12.4676    0.0000 </r>
+        <r>   12.5580    0.0000 </r>
+        <r>   12.9992    0.0000 </r>
+        <r>   12.9992    0.0000 </r>
+       </set>
+       <set comment="kpoint 2">
+        <r>  -11.6755    1.0000 </r>
+        <r>  -11.6755    1.0000 </r>
+        <r>  -11.6667    1.0000 </r>
+        <r>  -11.6663    1.0000 </r>
+        <r>  -11.6663    1.0000 </r>
+        <r>   -6.5534    1.0000 </r>
+        <r>   -0.7398    1.0000 </r>
+        <r>    3.8755    1.0000 </r>
+        <r>    3.8755    1.0000 </r>
+        <r>    3.9272    1.0000 </r>
+        <r>    8.8082    0.0000 </r>
+        <r>    8.8818    0.0000 </r>
+        <r>    8.8818    0.0000 </r>
+        <r>   10.8561    0.0000 </r>
+        <r>   11.0134    0.0000 </r>
+        <r>   11.0134    0.0000 </r>
+        <r>   12.7707    0.0000 </r>
+        <r>   12.9045    0.0000 </r>
+        <r>   13.2469    0.0000 </r>
+        <r>   13.2469    0.0000 </r>
+       </set>
+       <set comment="kpoint 3">
+        <r>  -11.6767    1.0000 </r>
+        <r>  -11.6767    1.0000 </r>
+        <r>  -11.6664    1.0000 </r>
+        <r>  -11.6648    1.0000 </r>
+        <r>  -11.6648    1.0000 </r>
+        <r>   -6.4476    1.0000 </r>
+        <r>   -1.0485    1.0000 </r>
+        <r>    3.9076    1.0000 </r>
+        <r>    3.9076    1.0000 </r>
+        <r>    4.0876    1.0000 </r>
+        <r>    8.2493    0.0000 </r>
+        <r>    8.4476    0.0000 </r>
+        <r>    8.4476    0.0000 </r>
+        <r>   10.7812    0.0000 </r>
+        <r>   11.2488    0.0000 </r>
+        <r>   11.2488    0.0000 </r>
+        <r>   13.4897    0.0000 </r>
+        <r>   13.7682    0.0000 </r>
+        <r>   13.8916    0.0000 </r>
+        <r>   13.8916    0.0000 </r>
+       </set>
+       <set comment="kpoint 4">
+        <r>  -11.6787    1.0000 </r>
+        <r>  -11.6787    1.0000 </r>
+        <r>  -11.6660    1.0000 </r>
+        <r>  -11.6624    1.0000 </r>
+        <r>  -11.6624    1.0000 </r>
+        <r>   -6.2757    1.0000 </r>
+        <r>   -1.4886    1.0000 </r>
+        <r>    3.9622    1.0000 </r>
+        <r>    3.9622    1.0000 </r>
+        <r>    4.2933    1.0000 </r>
+        <r>    7.6301    0.0000 </r>
+        <r>    7.9263    0.0000 </r>
+        <r>    7.9263    0.0000 </r>
+        <r>   10.8679    0.0000 </r>
+        <r>   11.6206    0.0000 </r>
+        <r>   11.6206    0.0000 </r>
+        <r>   14.4083    0.0000 </r>
+        <r>   14.7757    0.0000 </r>
+        <r>   14.7757    0.0000 </r>
+        <r>   14.9063    0.0000 </r>
+       </set>
+       <set comment="kpoint 5">
+        <r>  -11.6811    1.0000 </r>
+        <r>  -11.6811    1.0000 </r>
+        <r>  -11.6654    1.0000 </r>
+        <r>  -11.6594    1.0000 </r>
+        <r>  -11.6594    1.0000 </r>
+        <r>   -6.0464    1.0000 </r>
+        <r>   -1.9929    1.0000 </r>
+        <r>    4.0386    1.0000 </r>
+        <r>    4.0386    1.0000 </r>
+        <r>    4.5038    1.0000 </r>
+        <r>    7.0507    0.0000 </r>
+        <r>    7.4160    0.0000 </r>
+        <r>    7.4160    0.0000 </r>
+        <r>   11.1692    0.0000 </r>
+        <r>   12.1202    0.0000 </r>
+        <r>   12.1202    0.0000 </r>
+        <r>   15.3527    0.0000 </r>
+        <r>   15.7941    0.0000 </r>
+        <r>   15.7941    0.0000 </r>
+        <r>   16.1596    0.0000 </r>
+       </set>
+       <set comment="kpoint 6">
+        <r>  -11.6835    1.0000 </r>
+        <r>  -11.6835    1.0000 </r>
+        <r>  -11.6650    1.0000 </r>
+        <r>  -11.6565    1.0000 </r>
+        <r>  -11.6565    1.0000 </r>
+        <r>   -5.7774    1.0000 </r>
+        <r>   -2.5002    1.0000 </r>
+        <r>    4.1305    1.0000 </r>
+        <r>    4.1305    1.0000 </r>
+        <r>    4.7035    1.0000 </r>
+        <r>    6.5490    0.0000 </r>
+        <r>    6.9714    0.0000 </r>
+        <r>    6.9714    0.0000 </r>
+        <r>   11.6822    0.0000 </r>
+        <r>   12.7353    0.0000 </r>
+        <r>   12.7353    0.0000 </r>
+        <r>   15.8003    0.0000 </r>
+        <r>   16.8147    0.0000 </r>
+        <r>   16.8210    0.0000 </r>
+        <r>   17.4373    0.0000 </r>
+       </set>
+       <set comment="kpoint 7">
+        <r>  -11.6854    1.0000 </r>
+        <r>  -11.6854    1.0000 </r>
+        <r>  -11.6647    1.0000 </r>
+        <r>  -11.6542    1.0000 </r>
+        <r>  -11.6542    1.0000 </r>
+        <r>   -5.5070    1.0000 </r>
+        <r>   -2.9435    1.0000 </r>
+        <r>    4.2210    1.0000 </r>
+        <r>    4.2210    1.0000 </r>
+        <r>    4.8883    1.0000 </r>
+        <r>    6.1482    0.0000 </r>
+        <r>    6.6347    0.0000 </r>
+        <r>    6.6347    0.0000 </r>
+        <r>   12.3733    0.0000 </r>
+        <r>   13.4410    0.0000 </r>
+        <r>   13.4409    0.0000 </r>
+        <r>   15.2625    0.0000 </r>
+        <r>   16.5149    0.0000 </r>
+        <r>   16.5149    0.0000 </r>
+        <r>   18.1998    0.0000 </r>
+       </set>
+       <set comment="kpoint 8">
+        <r>  -11.6864    1.0000 </r>
+        <r>  -11.6864    1.0000 </r>
+        <r>  -11.6645    1.0000 </r>
+        <r>  -11.6530    1.0000 </r>
+        <r>  -11.6530    1.0000 </r>
+        <r>   -5.3168    1.0000 </r>
+        <r>   -3.2243    1.0000 </r>
+        <r>    4.2806    1.0000 </r>
+        <r>    4.2806    1.0000 </r>
+        <r>    5.0281    1.0000 </r>
+        <r>    5.8955    0.0000 </r>
+        <r>    6.4490    0.0000 </r>
+        <r>    6.4490    0.0000 </r>
+        <r>   13.1470    0.0000 </r>
+        <r>   14.1299    0.0000 </r>
+        <r>   14.1299    0.0000 </r>
+        <r>   14.4047    0.0000 </r>
+        <r>   15.6705    0.0000 </r>
+        <r>   15.6706    0.0000 </r>
+        <r>   19.1836    0.0000 </r>
+       </set>
+       <set comment="kpoint 9">
+        <r>  -11.6765    1.0000 </r>
+        <r>  -11.6748    1.0000 </r>
+        <r>  -11.6671    1.0000 </r>
+        <r>  -11.6659    1.0000 </r>
+        <r>  -11.6659    1.0000 </r>
+        <r>   -6.5415    1.0000 </r>
+        <r>   -0.7705    1.0000 </r>
+        <r>    3.7914    1.0000 </r>
+        <r>    3.7914    1.0000 </r>
+        <r>    4.1141    1.0000 </r>
+        <r>    8.3553    0.0000 </r>
+        <r>    9.0644    0.0000 </r>
+        <r>    9.0644    0.0000 </r>
+        <r>   10.6264    0.0000 </r>
+        <r>   11.1635    0.0000 </r>
+        <r>   11.1635    0.0000 </r>
+        <r>   12.6556    0.0000 </r>
+        <r>   12.9774    0.0000 </r>
+        <r>   13.0446    0.0000 </r>
+        <r>   13.7169    0.0000 </r>
+       </set>
+       <set comment="kpoint 10">
+        <r>  -11.6782    1.0000 </r>
+        <r>  -11.6749    1.0000 </r>
+        <r>  -11.6672    1.0000 </r>
+        <r>  -11.6648    1.0000 </r>
+        <r>  -11.6646    1.0000 </r>
+        <r>   -6.4592    1.0000 </r>
+        <r>   -0.9971    1.0000 </r>
+        <r>    3.7352    1.0000 </r>
+        <r>    3.7591    1.0000 </r>
+        <r>    4.3519    1.0000 </r>
+        <r>    7.7514    0.0000 </r>
+        <r>    8.8585    0.0000 </r>
+        <r>    8.9046    0.0000 </r>
+        <r>   10.4728    0.0000 </r>
+        <r>   11.3735    0.0000 </r>
+        <r>   11.4485    0.0000 </r>
+        <r>   13.0167    0.0000 </r>
+        <r>   13.3398    0.0000 </r>
+        <r>   13.5856    0.0000 </r>
+        <r>   14.5253    0.0000 </r>
+       </set>
+       <set comment="kpoint 11">
+        <r>  -11.6804    1.0000 </r>
+        <r>  -11.6762    1.0000 </r>
+        <r>  -11.6668    1.0000 </r>
+        <r>  -11.6630    1.0000 </r>
+        <r>  -11.6621    1.0000 </r>
+        <r>   -6.3095    1.0000 </r>
+        <r>   -1.3740    1.0000 </r>
+        <r>    3.7150    1.0000 </r>
+        <r>    3.7912    1.0000 </r>
+        <r>    4.5700    1.0000 </r>
+        <r>    7.1749    0.0000 </r>
+        <r>    8.3956    0.0000 </r>
+        <r>    8.5125    0.0000 </r>
+        <r>   10.5036    0.0000 </r>
+        <r>   11.6399    0.0000 </r>
+        <r>   11.8441    0.0000 </r>
+        <r>   13.7694    0.0000 </r>
+        <r>   14.0323    0.0000 </r>
+        <r>   14.5626    0.0000 </r>
+        <r>   15.4855    0.0000 </r>
+       </set>
+       <set comment="kpoint 12">
+        <r>  -11.6829    1.0000 </r>
+        <r>  -11.6783    1.0000 </r>
+        <r>  -11.6661    1.0000 </r>
+        <r>  -11.6608    1.0000 </r>
+        <r>  -11.6592    1.0000 </r>
+        <r>   -6.0994    1.0000 </r>
+        <r>   -1.8400    1.0000 </r>
+        <r>    3.7371    1.0000 </r>
+        <r>    3.8640    1.0000 </r>
+        <r>    4.7177    1.0000 </r>
+        <r>    6.7099    0.0000 </r>
+        <r>    7.8790    0.0000 </r>
+        <r>    8.0339    0.0000 </r>
+        <r>   10.7229    0.0000 </r>
+        <r>   12.0424    0.0000 </r>
+        <r>   12.3524    0.0000 </r>
+        <r>   14.6913    0.0000 </r>
+        <r>   14.9524    0.0000 </r>
+        <r>   15.7631    0.0000 </r>
+        <r>   16.4724    0.0000 </r>
+       </set>
+       <set comment="kpoint 13">
+        <r>  -11.6853    1.0000 </r>
+        <r>  -11.6808    1.0000 </r>
+        <r>  -11.6653    1.0000 </r>
+        <r>  -11.6582    1.0000 </r>
+        <r>  -11.6562    1.0000 </r>
+        <r>   -5.8431    1.0000 </r>
+        <r>   -2.3344    1.0000 </r>
+        <r>    3.8043    1.0000 </r>
+        <r>    3.9550    1.0000 </r>
+        <r>    4.7485    1.0000 </r>
+        <r>    6.4238    0.0000 </r>
+        <r>    7.4019    0.0000 </r>
+        <r>    7.5568    0.0000 </r>
+        <r>   11.1423    0.0000 </r>
+        <r>   12.5871    0.0000 </r>
+        <r>   12.9670    0.0000 </r>
+        <r>   15.4721    0.0000 </r>
+        <r>   15.9549    0.0000 </r>
+        <r>   17.0117    0.0000 </r>
+        <r>   17.2114    0.0000 </r>
+       </set>
+       <set comment="kpoint 14">
+        <r>  -11.6870    1.0000 </r>
+        <r>  -11.6832    1.0000 </r>
+        <r>  -11.6646    1.0000 </r>
+        <r>  -11.6558    1.0000 </r>
+        <r>  -11.6539    1.0000 </r>
+        <r>   -5.5701    1.0000 </r>
+        <r>   -2.7942    1.0000 </r>
+        <r>    3.9135    1.0000 </r>
+        <r>    4.0273    1.0000 </r>
+        <r>    4.6845    1.0000 </r>
+        <r>    6.3199    0.0000 </r>
+        <r>    7.0260    0.0000 </r>
+        <r>    7.1289    0.0000 </r>
+        <r>   11.7468    0.0000 </r>
+        <r>   13.2571    0.0000 </r>
+        <r>   13.6602    0.0000 </r>
+        <r>   15.2933    0.0000 </r>
+        <r>   16.2823    0.0000 </r>
+        <r>   17.3380    0.0000 </r>
+        <r>   17.4828    0.0000 </r>
+       </set>
+       <set comment="kpoint 15">
+        <r>  -11.6879    1.0000 </r>
+        <r>  -11.6850    1.0000 </r>
+        <r>  -11.6642    1.0000 </r>
+        <r>  -11.6541    1.0000 </r>
+        <r>  -11.6527    1.0000 </r>
+        <r>   -5.3445    1.0000 </r>
+        <r>   -3.1340    1.0000 </r>
+        <r>    4.0043    1.0000 </r>
+        <r>    4.0530    1.0000 </r>
+        <r>    4.6662    1.0000 </r>
+        <r>    6.2580    0.0000 </r>
+        <r>    6.7837    0.0000 </r>
+        <r>    6.8630    0.0000 </r>
+        <r>   12.4882    0.0000 </r>
+        <r>   14.0080    0.0000 </r>
+        <r>   14.2788    0.0000 </r>
+        <r>   14.4445    0.0000 </r>
+        <r>   15.5969    0.0000 </r>
+        <r>   16.6375    0.0000 </r>
+        <r>   18.5008    0.0000 </r>
+       </set>
+       <set comment="kpoint 16">
+        <r>  -11.6876    1.0000 </r>
+        <r>  -11.6859    1.0000 </r>
+        <r>  -11.6641    1.0000 </r>
+        <r>  -11.6533    1.0000 </r>
+        <r>  -11.6528    1.0000 </r>
+        <r>   -5.2737    1.0000 </r>
+        <r>   -3.2349    1.0000 </r>
+        <r>    3.8726    1.0000 </r>
+        <r>    4.1966    1.0000 </r>
+        <r>    4.7647    1.0000 </r>
+        <r>    6.1296    0.0000 </r>
+        <r>    6.5564    0.0000 </r>
+        <r>    6.9863    0.0000 </r>
+        <r>   13.0355    0.0000 </r>
+        <r>   13.8228    0.0000 </r>
+        <r>   14.0551    0.0000 </r>
+        <r>   14.6774    0.0000 </r>
+        <r>   15.8210    0.0000 </r>
+        <r>   15.9033    0.0000 </r>
+        <r>   19.0375    0.0000 </r>
+       </set>
+       <set comment="kpoint 17">
+        <r>  -11.6863    1.0000 </r>
+        <r>  -11.6859    1.0000 </r>
+        <r>  -11.6642    1.0000 </r>
+        <r>  -11.6541    1.0000 </r>
+        <r>  -11.6536    1.0000 </r>
+        <r>   -5.4081    1.0000 </r>
+        <r>   -3.0439    1.0000 </r>
+        <r>    3.7209    1.0000 </r>
+        <r>    4.3029    1.0000 </r>
+        <r>    4.8777    1.0000 </r>
+        <r>    6.0749    0.0000 </r>
+        <r>    6.4893    0.0000 </r>
+        <r>    7.2755    0.0000 </r>
+        <r>   12.4274    0.0000 </r>
+        <r>   13.3210    0.0000 </r>
+        <r>   14.3012    0.0000 </r>
+        <r>   14.6436    0.0000 </r>
+        <r>   16.1056    0.0000 </r>
+        <r>   16.7288    0.0000 </r>
+        <r>   17.9921    0.0000 </r>
+       </set>
+       <set comment="kpoint 18">
+        <r>  -11.6848    1.0000 </r>
+        <r>  -11.6841    1.0000 </r>
+        <r>  -11.6646    1.0000 </r>
+        <r>  -11.6564    1.0000 </r>
+        <r>  -11.6551    1.0000 </r>
+        <r>   -5.6597    1.0000 </r>
+        <r>   -2.6545    1.0000 </r>
+        <r>    3.6035    1.0000 </r>
+        <r>    4.3350    1.0000 </r>
+        <r>    4.8863    1.0000 </r>
+        <r>    6.2248    0.0000 </r>
+        <r>    6.6144    0.0000 </r>
+        <r>    7.6519    0.0000 </r>
+        <r>   11.7247    0.0000 </r>
+        <r>   12.6146    0.0000 </r>
+        <r>   13.6462    0.0000 </r>
+        <r>   15.3698    0.0000 </r>
+        <r>   16.2054    0.0000 </r>
+        <r>   17.6474    0.0000 </r>
+        <r>   17.7234    0.0000 </r>
+       </set>
+       <set comment="kpoint 19">
+        <r>  -11.6830    1.0000 </r>
+        <r>  -11.6814    1.0000 </r>
+        <r>  -11.6652    1.0000 </r>
+        <r>  -11.6592    1.0000 </r>
+        <r>  -11.6574    1.0000 </r>
+        <r>   -5.9321    1.0000 </r>
+        <r>   -2.1778    1.0000 </r>
+        <r>    3.5401    1.0000 </r>
+        <r>    4.2918    1.0000 </r>
+        <r>    4.7699    1.0000 </r>
+        <r>    6.5858    0.0000 </r>
+        <r>    6.9223    0.0000 </r>
+        <r>    8.0784    0.0000 </r>
+        <r>   11.1839    0.0000 </r>
+        <r>   12.0134    0.0000 </r>
+        <r>   12.9436    0.0000 </r>
+        <r>   14.9452    0.0000 </r>
+        <r>   16.1435    0.0000 </r>
+        <r>   16.6359    0.0000 </r>
+        <r>   16.7432    0.0000 </r>
+       </set>
+       <set comment="kpoint 20">
+        <r>  -11.6808    1.0000 </r>
+        <r>  -11.6788    1.0000 </r>
+        <r>  -11.6659    1.0000 </r>
+        <r>  -11.6621    1.0000 </r>
+        <r>  -11.6601    1.0000 </r>
+        <r>   -6.1754    1.0000 </r>
+        <r>   -1.6885    1.0000 </r>
+        <r>    3.5373    1.0000 </r>
+        <r>    4.2014    1.0000 </r>
+        <r>    4.5753    1.0000 </r>
+        <r>    7.0914    0.0000 </r>
+        <r>    7.3677    0.0000 </r>
+        <r>    8.5136    0.0000 </r>
+        <r>   10.8484    0.0000 </r>
+        <r>   11.5407    0.0000 </r>
+        <r>   12.3217    0.0000 </r>
+        <r>   14.0209    0.0000 </r>
+        <r>   15.2816    0.0000 </r>
+        <r>   15.5593    0.0000 </r>
+        <r>   15.6700    0.0000 </r>
+       </set>
+       <set comment="kpoint 21">
+        <r>  -11.6787    1.0000 </r>
+        <r>  -11.6766    1.0000 </r>
+        <r>  -11.6664    1.0000 </r>
+        <r>  -11.6644    1.0000 </r>
+        <r>  -11.6628    1.0000 </r>
+        <r>   -6.3666    1.0000 </r>
+        <r>   -1.2463    1.0000 </r>
+        <r>    3.5963    1.0000 </r>
+        <r>    4.0911    1.0000 </r>
+        <r>    4.3411    1.0000 </r>
+        <r>    7.6844    0.0000 </r>
+        <r>    7.8955    0.0000 </r>
+        <r>    8.8849    0.0000 </r>
+        <r>   10.7160    0.0000 </r>
+        <r>   11.2095    0.0000 </r>
+        <r>   11.7936    0.0000 </r>
+        <r>   13.2586    0.0000 </r>
+        <r>   14.2136    0.0000 </r>
+        <r>   14.5447    0.0000 </r>
+        <r>   14.6841    0.0000 </r>
+       </set>
+       <set comment="kpoint 22">
+        <r>  -11.6768    1.0000 </r>
+        <r>  -11.6755    1.0000 </r>
+        <r>  -11.6667    1.0000 </r>
+        <r>  -11.6658    1.0000 </r>
+        <r>  -11.6650    1.0000 </r>
+        <r>   -6.4944    1.0000 </r>
+        <r>   -0.9108    1.0000 </r>
+        <r>    3.7154    1.0000 </r>
+        <r>    3.9786    1.0000 </r>
+        <r>    4.1056    1.0000 </r>
+        <r>    8.3025    0.0000 </r>
+        <r>    8.4373    0.0000 </r>
+        <r>    9.0545    0.0000 </r>
+        <r>   10.7359    0.0000 </r>
+        <r>   11.0301    0.0000 </r>
+        <r>   11.3562    0.0000 </r>
+        <r>   12.8658    0.0000 </r>
+        <r>   13.3638    0.0000 </r>
+        <r>   13.6612    0.0000 </r>
+        <r>   13.8445    0.0000 </r>
+       </set>
+       <set comment="kpoint 23">
+        <r>  -11.6807    1.0000 </r>
+        <r>  -11.6737    1.0000 </r>
+        <r>  -11.6681    1.0000 </r>
+        <r>  -11.6635    1.0000 </r>
+        <r>  -11.6635    1.0000 </r>
+        <r>   -6.4011    1.0000 </r>
+        <r>   -1.1068    1.0000 </r>
+        <r>    3.5929    1.0000 </r>
+        <r>    3.5929    1.0000 </r>
+        <r>    4.6509    1.0000 </r>
+        <r>    7.1836    0.0000 </r>
+        <r>    9.1175    0.0000 </r>
+        <r>    9.1175    0.0000 </r>
+        <r>   10.0936    0.0000 </r>
+        <r>   11.7858    0.0000 </r>
+        <r>   11.7858    0.0000 </r>
+        <r>   12.8440    0.0000 </r>
+        <r>   13.1809    0.0000 </r>
+        <r>   13.8574    0.0000 </r>
+        <r>   15.4026    0.0000 </r>
+       </set>
+       <set comment="kpoint 24">
+        <r>  -11.6837    1.0000 </r>
+        <r>  -11.6737    1.0000 </r>
+        <r>  -11.6684    1.0000 </r>
+        <r>  -11.6618    1.0000 </r>
+        <r>  -11.6614    1.0000 </r>
+        <r>   -6.2756    1.0000 </r>
+        <r>   -1.3670    1.0000 </r>
+        <r>    3.4950    1.0000 </r>
+        <r>    3.5154    1.0000 </r>
+        <r>    4.7690    1.0000 </r>
+        <r>    6.8181    0.0000 </r>
+        <r>    8.9545    0.0000 </r>
+        <r>    9.0110    0.0000 </r>
+        <r>    9.9726    0.0000 </r>
+        <r>   12.1198    0.0000 </r>
+        <r>   12.2045    0.0000 </r>
+        <r>   13.2444    0.0000 </r>
+        <r>   13.5263    0.0000 </r>
+        <r>   14.5626    0.0000 </r>
+        <r>   16.3788    0.0000 </r>
+       </set>
+       <set comment="kpoint 25">
+        <r>  -11.6867    1.0000 </r>
+        <r>  -11.6750    1.0000 </r>
+        <r>  -11.6679    1.0000 </r>
+        <r>  -11.6599    1.0000 </r>
+        <r>  -11.6585    1.0000 </r>
+        <r>   -6.0886    1.0000 </r>
+        <r>   -1.7410    1.0000 </r>
+        <r>    3.4512    1.0000 </r>
+        <r>    3.5146    1.0000 </r>
+        <r>    4.6204    1.0000 </r>
+        <r>    6.7498    0.0000 </r>
+        <r>    8.5512    0.0000 </r>
+        <r>    8.6746    0.0000 </r>
+        <r>   10.0769    0.0000 </r>
+        <r>   12.4749    0.0000 </r>
+        <r>   12.7022    0.0000 </r>
+        <r>   14.0251    0.0000 </r>
+        <r>   14.2646    0.0000 </r>
+        <r>   15.5995    0.0000 </r>
+        <r>   17.3183    0.0000 </r>
+       </set>
+       <set comment="kpoint 26">
+        <r>  -11.6894    1.0000 </r>
+        <r>  -11.6771    1.0000 </r>
+        <r>  -11.6668    1.0000 </r>
+        <r>  -11.6581    1.0000 </r>
+        <r>  -11.6556    1.0000 </r>
+        <r>   -5.8521    1.0000 </r>
+        <r>   -2.1766    1.0000 </r>
+        <r>    3.4680    1.0000 </r>
+        <r>    3.5586    1.0000 </r>
+        <r>    4.3160    1.0000 </r>
+        <r>    6.8791    0.0000 </r>
+        <r>    8.1139    0.0000 </r>
+        <r>    8.2417    0.0000 </r>
+        <r>   10.3694    0.0000 </r>
+        <r>   12.9584    0.0000 </r>
+        <r>   13.2994    0.0000 </r>
+        <r>   14.8714    0.0000 </r>
+        <r>   15.1902    0.0000 </r>
+        <r>   16.8125    0.0000 </r>
+        <r>   17.5032    0.0000 </r>
+       </set>
+       <set comment="kpoint 27">
+        <r>  -11.6912    1.0000 </r>
+        <r>  -11.6796    1.0000 </r>
+        <r>  -11.6654    1.0000 </r>
+        <r>  -11.6566    1.0000 </r>
+        <r>  -11.6533    1.0000 </r>
+        <r>   -5.5896    1.0000 </r>
+        <r>   -2.6139    1.0000 </r>
+        <r>    3.5472    1.0000 </r>
+        <r>    3.5660    1.0000 </r>
+        <r>    4.0678    1.0000 </r>
+        <r>    7.0315    0.0000 </r>
+        <r>    7.7602    0.0000 </r>
+        <r>    7.7967    0.0000 </r>
+        <r>   10.8539    0.0000 </r>
+        <r>   13.5764    0.0000 </r>
+        <r>   13.9699    0.0000 </r>
+        <r>   15.1200    0.0000 </r>
+        <r>   15.9043    0.0000 </r>
+        <r>   17.0515    0.0000 </r>
+        <r>   17.2033    0.0000 </r>
+       </set>
+       <set comment="kpoint 28">
+        <r>  -11.6919    1.0000 </r>
+        <r>  -11.6819    1.0000 </r>
+        <r>  -11.6641    1.0000 </r>
+        <r>  -11.6554    1.0000 </r>
+        <r>  -11.6521    1.0000 </r>
+        <r>   -5.3500    1.0000 </r>
+        <r>   -2.9774    1.0000 </r>
+        <r>    3.4006    1.0000 </r>
+        <r>    3.6861    1.0000 </r>
+        <r>    4.0801    1.0000 </r>
+        <r>    6.9813    0.0000 </r>
+        <r>    7.3836    0.0000 </r>
+        <r>    7.6917    0.0000 </r>
+        <r>   11.5110    0.0000 </r>
+        <r>   14.2559    0.0000 </r>
+        <r>   14.4473    0.0000 </r>
+        <r>   14.4907    0.0000 </r>
+        <r>   15.5947    0.0000 </r>
+        <r>   17.6491    0.0000 </r>
+        <r>   17.7688    0.0000 </r>
+       </set>
+       <set comment="kpoint 29">
+        <r>  -11.6913    1.0000 </r>
+        <r>  -11.6837    1.0000 </r>
+        <r>  -11.6632    1.0000 </r>
+        <r>  -11.6547    1.0000 </r>
+        <r>  -11.6521    1.0000 </r>
+        <r>   -5.2229    1.0000 </r>
+        <r>   -3.1617    1.0000 </r>
+        <r>    3.1806    1.0000 </r>
+        <r>    3.8739    1.0000 </r>
+        <r>    4.2631    1.0000 </r>
+        <r>    6.7350    0.0000 </r>
+        <r>    7.0303    0.0000 </r>
+        <r>    7.9022    0.0000 </r>
+        <r>   12.2750    0.0000 </r>
+        <r>   13.5145    0.0000 </r>
+        <r>   14.0657    0.0000 </r>
+        <r>   15.0567    0.0000 </r>
+        <r>   16.0374    0.0000 </r>
+        <r>   16.9849    0.0000 </r>
+        <r>   18.6173    0.0000 </r>
+       </set>
+       <set comment="kpoint 30">
+        <r>  -11.6895    1.0000 </r>
+        <r>  -11.6846    1.0000 </r>
+        <r>  -11.6629    1.0000 </r>
+        <r>  -11.6545    1.0000 </r>
+        <r>  -11.6534    1.0000 </r>
+        <r>   -5.2876    1.0000 </r>
+        <r>   -3.0816    1.0000 </r>
+        <r>    3.0164    1.0000 </r>
+        <r>    4.0865    1.0000 </r>
+        <r>    4.5112    1.0000 </r>
+        <r>    6.4895    0.0000 </r>
+        <r>    6.7645    0.0000 </r>
+        <r>    8.2000    0.0000 </r>
+        <r>   12.4192    0.0000 </r>
+        <r>   13.3090    0.0000 </r>
+        <r>   13.4476    0.0000 </r>
+        <r>   15.3959    0.0000 </r>
+        <r>   16.2731    0.0000 </r>
+        <r>   16.9710    0.0000 </r>
+        <r>   17.8648    0.0000 </r>
+       </set>
+       <set comment="kpoint 31">
+        <r>  -11.6868    1.0000 </r>
+        <r>  -11.6847    1.0000 </r>
+        <r>  -11.6634    1.0000 </r>
+        <r>  -11.6557    1.0000 </r>
+        <r>  -11.6550    1.0000 </r>
+        <r>   -5.5011    1.0000 </r>
+        <r>   -2.7838    1.0000 </r>
+        <r>    2.9380    1.0000 </r>
+        <r>    4.2785    1.0000 </r>
+        <r>    4.7655    1.0000 </r>
+        <r>    6.3227    0.0000 </r>
+        <r>    6.6280    0.0000 </r>
+        <r>    8.5209    0.0000 </r>
+        <r>   11.7890    0.0000 </r>
+        <r>   12.6149    0.0000 </r>
+        <r>   14.3148    0.0000 </r>
+        <r>   14.8367    0.0000 </r>
+        <r>   15.6190    0.0000 </r>
+        <r>   18.0395    0.0000 </r>
+        <r>   18.0471    0.0000 </r>
+       </set>
+       <set comment="kpoint 32">
+        <r>  -11.6838    1.0000 </r>
+        <r>  -11.6836    1.0000 </r>
+        <r>  -11.6642    1.0000 </r>
+        <r>  -11.6584    1.0000 </r>
+        <r>  -11.6561    1.0000 </r>
+        <r>   -5.7640    1.0000 </r>
+        <r>   -2.3800    1.0000 </r>
+        <r>    2.9567    1.0000 </r>
+        <r>    4.3870    1.0000 </r>
+        <r>    4.9191    1.0000 </r>
+        <r>    6.3297    0.0000 </r>
+        <r>    6.6752    0.0000 </r>
+        <r>    8.8193    0.0000 </r>
+        <r>   11.2917    0.0000 </r>
+        <r>   12.0416    0.0000 </r>
+        <r>   13.9797    0.0000 </r>
+        <r>   14.4236    0.0000 </r>
+        <r>   15.6199    0.0000 </r>
+        <r>   17.3368    0.0000 </r>
+        <r>   17.7676    0.0000 </r>
+       </set>
+       <set comment="kpoint 33">
+        <r>  -11.6824    1.0000 </r>
+        <r>  -11.6804    1.0000 </r>
+        <r>  -11.6653    1.0000 </r>
+        <r>  -11.6610    1.0000 </r>
+        <r>  -11.6580    1.0000 </r>
+        <r>   -6.0136    1.0000 </r>
+        <r>   -1.9532    1.0000 </r>
+        <r>    3.0769    1.0000 </r>
+        <r>    4.3733    1.0000 </r>
+        <r>    4.8624    1.0000 </r>
+        <r>    6.6031    0.0000 </r>
+        <r>    6.9326    0.0000 </r>
+        <r>    9.0328    0.0000 </r>
+        <r>   10.9890    0.0000 </r>
+        <r>   11.6101    0.0000 </r>
+        <r>   13.1994    0.0000 </r>
+        <r>   13.6584    0.0000 </r>
+        <r>   16.0445    0.0000 </r>
+        <r>   16.1238    0.0000 </r>
+        <r>   16.6667    0.0000 </r>
+       </set>
+       <set comment="kpoint 34">
+        <r>  -11.6806    1.0000 </r>
+        <r>  -11.6780    1.0000 </r>
+        <r>  -11.6661    1.0000 </r>
+        <r>  -11.6631    1.0000 </r>
+        <r>  -11.6603    1.0000 </r>
+        <r>   -6.2194    1.0000 </r>
+        <r>   -1.5604    1.0000 </r>
+        <r>    3.2955    1.0000 </r>
+        <r>    4.2591    1.0000 </r>
+        <r>    4.6372    1.0000 </r>
+        <r>    7.0892    0.0000 </r>
+        <r>    7.3629    0.0000 </r>
+        <r>    9.0878    0.0000 </r>
+        <r>   10.8061    0.0000 </r>
+        <r>   11.3309    0.0000 </r>
+        <r>   12.4681    0.0000 </r>
+        <r>   13.2072    0.0000 </r>
+        <r>   15.0255    0.0000 </r>
+        <r>   15.4620    0.0000 </r>
+        <r>   15.6261    0.0000 </r>
+       </set>
+       <set comment="kpoint 35">
+        <r>  -11.6878    1.0000 </r>
+        <r>  -11.6720    1.0000 </r>
+        <r>  -11.6695    1.0000 </r>
+        <r>  -11.6599    1.0000 </r>
+        <r>  -11.6599    1.0000 </r>
+        <r>   -6.1757    1.0000 </r>
+        <r>   -1.4842    1.0000 </r>
+        <r>    3.3233    1.0000 </r>
+        <r>    3.3233    1.0000 </r>
+        <r>    4.5549    1.0000 </r>
+        <r>    6.9085    0.0000 </r>
+        <r>    9.2757    0.0000 </r>
+        <r>    9.2757    0.0000 </r>
+        <r>    9.5907    0.0000 </r>
+        <r>   12.6719    0.0000 </r>
+        <r>   12.6719    0.0000 </r>
+        <r>   13.1079    0.0000 </r>
+        <r>   13.4071    0.0000 </r>
+        <r>   14.9373    0.0000 </r>
+        <r>   17.3516    0.0000 </r>
+       </set>
+       <set comment="kpoint 36">
+        <r>  -11.6918    1.0000 </r>
+        <r>  -11.6720    1.0000 </r>
+        <r>  -11.6699    1.0000 </r>
+        <r>  -11.6578    1.0000 </r>
+        <r>  -11.6574    1.0000 </r>
+        <r>   -6.0152    1.0000 </r>
+        <r>   -1.7225    1.0000 </r>
+        <r>    3.2133    1.0000 </r>
+        <r>    3.2283    1.0000 </r>
+        <r>    4.1054    1.0000 </r>
+        <r>    7.2604    0.0000 </r>
+        <r>    9.1120    0.0000 </r>
+        <r>    9.2235    0.0000 </r>
+        <r>    9.5787    0.0000 </r>
+        <r>   13.0533    0.0000 </r>
+        <r>   13.1635    0.0000 </r>
+        <r>   13.5960    0.0000 </r>
+        <r>   13.8138    0.0000 </r>
+        <r>   15.7058    0.0000 </r>
+        <r>   18.2095    0.0000 </r>
+       </set>
+       <set comment="kpoint 37">
+        <r>  -11.6952    1.0000 </r>
+        <r>  -11.6732    1.0000 </r>
+        <r>  -11.6693    1.0000 </r>
+        <r>  -11.6561    1.0000 </r>
+        <r>  -11.6546    1.0000 </r>
+        <r>   -5.8046    1.0000 </r>
+        <r>   -2.0529    1.0000 </r>
+        <r>    3.1732    1.0000 </r>
+        <r>    3.1990    1.0000 </r>
+        <r>    3.6538    1.0000 </r>
+        <r>    7.6477    0.0000 </r>
+        <r>    8.7871    0.0000 </r>
+        <r>    8.9324    0.0000 </r>
+        <r>    9.7401    0.0000 </r>
+        <r>   13.4812    0.0000 </r>
+        <r>   13.7154    0.0000 </r>
+        <r>   14.3650    0.0000 </r>
+        <r>   14.5864    0.0000 </r>
+        <r>   16.7669    0.0000 </r>
+        <r>   17.7967    0.0000 </r>
+       </set>
+       <set comment="kpoint 38">
+        <r>  -11.6974    1.0000 </r>
+        <r>  -11.6753    1.0000 </r>
+        <r>  -11.6678    1.0000 </r>
+        <r>  -11.6550    1.0000 </r>
+        <r>  -11.6523    1.0000 </r>
+        <r>   -5.5637    1.0000 </r>
+        <r>   -2.4259    1.0000 </r>
+        <r>    3.0447    1.0000 </r>
+        <r>    3.2069    1.0000 </r>
+        <r>    3.4574    1.0000 </r>
+        <r>    7.9108    0.0000 </r>
+        <r>    8.5237    0.0000 </r>
+        <r>    8.5306    0.0000 </r>
+        <r>   10.0738    0.0000 </r>
+        <r>   14.0420    0.0000 </r>
+        <r>   14.3558    0.0000 </r>
+        <r>   14.8900    0.0000 </r>
+        <r>   15.3867    0.0000 </r>
+        <r>   16.9522    0.0000 </r>
+        <r>   16.9919    0.0000 </r>
+       </set>
+       <set comment="kpoint 39">
+        <r>  -11.6981    1.0000 </r>
+        <r>  -11.6778    1.0000 </r>
+        <r>  -11.6658    1.0000 </r>
+        <r>  -11.6547    1.0000 </r>
+        <r>  -11.6511    1.0000 </r>
+        <r>   -5.3298    1.0000 </r>
+        <r>   -2.7749    1.0000 </r>
+        <r>    2.7369    1.0000 </r>
+        <r>    3.3149    1.0000 </r>
+        <r>    3.5653    1.0000 </r>
+        <r>    7.7817    0.0000 </r>
+        <r>    8.0996    0.0000 </r>
+        <r>    8.6102    0.0000 </r>
+        <r>   10.6049    0.0000 </r>
+        <r>   14.3917    0.0000 </r>
+        <r>   14.7550    0.0000 </r>
+        <r>   14.7654    0.0000 </r>
+        <r>   15.6184    0.0000 </r>
+        <r>   17.1703    0.0000 </r>
+        <r>   17.4867    0.0000 </r>
+       </set>
+       <set comment="kpoint 40">
+        <r>  -11.6972    1.0000 </r>
+        <r>  -11.6801    1.0000 </r>
+        <r>  -11.6635    1.0000 </r>
+        <r>  -11.6551    1.0000 </r>
+        <r>  -11.6511    1.0000 </r>
+        <r>   -5.1707    1.0000 </r>
+        <r>   -3.0117    1.0000 </r>
+        <r>    2.4913    1.0000 </r>
+        <r>    3.4928    1.0000 </r>
+        <r>    3.7731    1.0000 </r>
+        <r>    7.4564    0.0000 </r>
+        <r>    7.6797    0.0000 </r>
+        <r>    8.8747    0.0000 </r>
+        <r>   11.3100    0.0000 </r>
+        <r>   13.5756    0.0000 </r>
+        <r>   14.1732    0.0000 </r>
+        <r>   15.4113    0.0000 </r>
+        <r>   16.2857    0.0000 </r>
+        <r>   18.1688    0.0000 </r>
+        <r>   18.2049    0.0000 </r>
+       </set>
+       <set comment="kpoint 41">
+        <r>  -11.6948    1.0000 </r>
+        <r>  -11.6820    1.0000 </r>
+        <r>  -11.6617    1.0000 </r>
+        <r>  -11.6559    1.0000 </r>
+        <r>  -11.6523    1.0000 </r>
+        <r>   -5.1663    1.0000 </r>
+        <r>   -3.0470    1.0000 </r>
+        <r>    2.3525    1.0000 </r>
+        <r>    3.7292    1.0000 </r>
+        <r>    4.0448    1.0000 </r>
+        <r>    7.1189    0.0000 </r>
+        <r>    7.2943    0.0000 </r>
+        <r>    9.1346    0.0000 </r>
+        <r>   12.1051    0.0000 </r>
+        <r>   12.8398    0.0000 </r>
+        <r>   13.4156    0.0000 </r>
+        <r>   15.7028    0.0000 </r>
+        <r>   17.0380    0.0000 </r>
+        <r>   17.2303    0.0000 </r>
+        <r>   18.0436    0.0000 </r>
+       </set>
+       <set comment="kpoint 42">
+        <r>  -11.6913    1.0000 </r>
+        <r>  -11.6832    1.0000 </r>
+        <r>  -11.6613    1.0000 </r>
+        <r>  -11.6563    1.0000 </r>
+        <r>  -11.6544    1.0000 </r>
+        <r>   -5.3212    1.0000 </r>
+        <r>   -2.8764    1.0000 </r>
+        <r>    2.3369    1.0000 </r>
+        <r>    3.9992    1.0000 </r>
+        <r>    4.3650    1.0000 </r>
+        <r>    6.7985    0.0000 </r>
+        <r>    6.9682    0.0000 </r>
+        <r>    9.3317    0.0000 </r>
+        <r>   12.0444    0.0000 </r>
+        <r>   12.7475    0.0000 </r>
+        <r>   13.2344    0.0000 </r>
+        <r>   15.1175    0.0000 </r>
+        <r>   16.1253    0.0000 </r>
+        <r>   18.2705    0.0000 </r>
+        <r>   18.4264    0.0000 </r>
+       </set>
+       <set comment="kpoint 43">
+        <r>  -11.6873    1.0000 </r>
+        <r>  -11.6836    1.0000 </r>
+        <r>  -11.6625    1.0000 </r>
+        <r>  -11.6569    1.0000 </r>
+        <r>  -11.6562    1.0000 </r>
+        <r>   -5.5566    1.0000 </r>
+        <r>   -2.5871    1.0000 </r>
+        <r>    2.4537    1.0000 </r>
+        <r>    4.2515    1.0000 </r>
+        <r>    4.6960    1.0000 </r>
+        <r>    6.5227    0.0000 </r>
+        <r>    6.7479    0.0000 </r>
+        <r>    9.4066    0.0000 </r>
+        <r>   11.6357    0.0000 </r>
+        <r>   12.2149    0.0000 </r>
+        <r>   13.9682    0.0000 </r>
+        <r>   14.5411    0.0000 </r>
+        <r>   15.2411    0.0000 </r>
+        <r>   18.2378    0.0000 </r>
+        <r>   18.8690    0.0000 </r>
+       </set>
+       <set comment="kpoint 44">
+        <r>  -11.6835    1.0000 </r>
+        <r>  -11.6833    1.0000 </r>
+        <r>  -11.6641    1.0000 </r>
+        <r>  -11.6592    1.0000 </r>
+        <r>  -11.6566    1.0000 </r>
+        <r>   -5.8006    1.0000 </r>
+        <r>   -2.2625    1.0000 </r>
+        <r>    2.7045    1.0000 </r>
+        <r>    4.3996    1.0000 </r>
+        <r>    4.9217    1.0000 </r>
+        <r>    6.3977    0.0000 </r>
+        <r>    6.7143    0.0000 </r>
+        <r>    9.3179    0.0000 </r>
+        <r>   11.3046    0.0000 </r>
+        <r>   11.8341    0.0000 </r>
+        <r>   13.6282    0.0000 </r>
+        <r>   14.1622    0.0000 </r>
+        <r>   15.5417    0.0000 </r>
+        <r>   17.0723    0.0000 </r>
+        <r>   17.7508    0.0000 </r>
+       </set>
+       <set comment="kpoint 45">
+        <r>  -11.6972    1.0000 </r>
+        <r>  -11.6711    1.0000 </r>
+        <r>  -11.6702    1.0000 </r>
+        <r>  -11.6555    1.0000 </r>
+        <r>  -11.6555    1.0000 </r>
+        <r>   -5.8841    1.0000 </r>
+        <r>   -1.8060    1.0000 </r>
+        <r>    3.0409    1.0000 </r>
+        <r>    3.0409    1.0000 </r>
+        <r>    3.5126    1.0000 </r>
+        <r>    7.8771    0.0000 </r>
+        <r>    9.1733    0.0000 </r>
+        <r>    9.5331    0.0000 </r>
+        <r>    9.5331    0.0000 </r>
+        <r>   13.4775    0.0000 </r>
+        <r>   13.7211    0.0000 </r>
+        <r>   13.7314    0.0000 </r>
+        <r>   13.7314    0.0000 </r>
+        <r>   16.1590    0.0000 </r>
+        <r>   18.9503    0.0000 </r>
+       </set>
+       <set comment="kpoint 46">
+        <r>  -11.7017    1.0000 </r>
+        <r>  -11.6714    1.0000 </r>
+        <r>  -11.6700    1.0000 </r>
+        <r>  -11.6536    1.0000 </r>
+        <r>  -11.6531    1.0000 </r>
+        <r>   -5.7053    1.0000 </r>
+        <r>   -1.9937    1.0000 </r>
+        <r>    2.8958    1.0000 </r>
+        <r>    2.9439    1.0000 </r>
+        <r>    3.0336    1.0000 </r>
+        <r>    8.4491    0.0000 </r>
+        <r>    9.0378    0.0000 </r>
+        <r>    9.5160    0.0000 </r>
+        <r>    9.5963    0.0000 </r>
+        <r>   13.8307    0.0000 </r>
+        <r>   14.0502    0.0000 </r>
+        <r>   14.3384    0.0000 </r>
+        <r>   14.3861    0.0000 </r>
+        <r>   16.9764    0.0000 </r>
+        <r>   17.9364    0.0000 </r>
+       </set>
+       <set comment="kpoint 47">
+        <r>  -11.7047    1.0000 </r>
+        <r>  -11.6713    1.0000 </r>
+        <r>  -11.6706    1.0000 </r>
+        <r>  -11.6524    1.0000 </r>
+        <r>  -11.6510    1.0000 </r>
+        <r>   -5.4960    1.0000 </r>
+        <r>   -2.2597    1.0000 </r>
+        <r>    2.4726    1.0000 </r>
+        <r>    2.9278    1.0000 </r>
+        <r>    3.0241    1.0000 </r>
+        <r>    8.7533    0.0000 </r>
+        <r>    9.1107    0.0000 </r>
+        <r>    9.2460    0.0000 </r>
+        <r>    9.6376    0.0000 </r>
+        <r>   14.3793    0.0000 </r>
+        <r>   14.6909    0.0000 </r>
+        <r>   14.8956    0.0000 </r>
+        <r>   15.0335    0.0000 </r>
+        <r>   16.9790    0.0000 </r>
+        <r>   17.0468    0.0000 </r>
+       </set>
+       <set comment="kpoint 48">
+        <r>  -11.7056    1.0000 </r>
+        <r>  -11.6734    1.0000 </r>
+        <r>  -11.6688    1.0000 </r>
+        <r>  -11.6522    1.0000 </r>
+        <r>  -11.6498    1.0000 </r>
+        <r>   -5.2857    1.0000 </r>
+        <r>   -2.5531    1.0000 </r>
+        <r>    2.1175    1.0000 </r>
+        <r>    2.9944    1.0000 </r>
+        <r>    3.1448    1.0000 </r>
+        <r>    8.5420    0.0000 </r>
+        <r>    8.8468    0.0000 </r>
+        <r>    9.4872    0.0000 </r>
+        <r>    9.9111    0.0000 </r>
+        <r>   14.5174    0.0000 </r>
+        <r>   15.0593    0.0000 </r>
+        <r>   15.2477    0.0000 </r>
+        <r>   15.5395    0.0000 </r>
+        <r>   16.8801    0.0000 </r>
+        <r>   17.0673    0.0000 </r>
+       </set>
+       <set comment="kpoint 49">
+        <r>  -11.7044    1.0000 </r>
+        <r>  -11.6759    1.0000 </r>
+        <r>  -11.6661    1.0000 </r>
+        <r>  -11.6531    1.0000 </r>
+        <r>  -11.6497    1.0000 </r>
+        <r>   -5.1225    1.0000 </r>
+        <r>   -2.8042    1.0000 </r>
+        <r>    1.8861    1.0000 </r>
+        <r>    3.1422    1.0000 </r>
+        <r>    3.3437    1.0000 </r>
+        <r>    8.1893    0.0000 </r>
+        <r>    8.3952    0.0000 </r>
+        <r>    9.7933    0.0000 </r>
+        <r>   10.4552    0.0000 </r>
+        <r>   13.8335    0.0000 </r>
+        <r>   14.3906    0.0000 </r>
+        <r>   15.7699    0.0000 </r>
+        <r>   16.4392    0.0000 </r>
+        <r>   17.6641    0.0000 </r>
+        <r>   18.0184    0.0000 </r>
+       </set>
+       <set comment="kpoint 50">
+        <r>  -11.7013    1.0000 </r>
+        <r>  -11.6784    1.0000 </r>
+        <r>  -11.6631    1.0000 </r>
+        <r>  -11.6549    1.0000 </r>
+        <r>  -11.6508    1.0000 </r>
+        <r>   -5.0678    1.0000 </r>
+        <r>   -2.9377    1.0000 </r>
+        <r>    1.7953    1.0000 </r>
+        <r>    3.3651    1.0000 </r>
+        <r>    3.6106    1.0000 </r>
+        <r>    7.7912    0.0000 </r>
+        <r>    7.9285    0.0000 </r>
+        <r>    9.9687    0.0000 </r>
+        <r>   11.2052    0.0000 </r>
+        <r>   13.1258    0.0000 </r>
+        <r>   13.6531    0.0000 </r>
+        <r>   15.7227    0.0000 </r>
+        <r>   17.4031    0.0000 </r>
+        <r>   17.6896    0.0000 </r>
+        <r>   18.6514    0.0000 </r>
+       </set>
+       <set comment="kpoint 51">
+        <r>  -11.6970    1.0000 </r>
+        <r>  -11.6808    1.0000 </r>
+        <r>  -11.6602    1.0000 </r>
+        <r>  -11.6573    1.0000 </r>
+        <r>  -11.6527    1.0000 </r>
+        <r>   -5.1523    1.0000 </r>
+        <r>   -2.9171    1.0000 </r>
+        <r>    1.8579    1.0000 </r>
+        <r>    3.6497    1.0000 </r>
+        <r>    3.9388    1.0000 </r>
+        <r>    7.3668    0.0000 </r>
+        <r>    7.4704    0.0000 </r>
+        <r>    9.9751    0.0000 </r>
+        <r>   12.0986    0.0000 </r>
+        <r>   12.5861    0.0000 </r>
+        <r>   13.0242    0.0000 </r>
+        <r>   15.0102    0.0000 </r>
+        <r>   17.2574    0.0000 </r>
+        <r>   18.3742    0.0000 </r>
+        <r>   18.7543    0.0000 </r>
+       </set>
+       <set comment="kpoint 52">
+        <r>  -11.6920    1.0000 </r>
+        <r>  -11.6826    1.0000 </r>
+        <r>  -11.6601    1.0000 </r>
+        <r>  -11.6575    1.0000 </r>
+        <r>  -11.6548    1.0000 </r>
+        <r>   -5.3369    1.0000 </r>
+        <r>   -2.7796    1.0000 </r>
+        <r>    2.0796    1.0000 </r>
+        <r>    3.9667    1.0000 </r>
+        <r>    4.3155    1.0000 </r>
+        <r>    6.9276    0.0000 </r>
+        <r>    7.0540    0.0000 </r>
+        <r>    9.7871    0.0000 </r>
+        <r>   12.1038    0.0000 </r>
+        <r>   12.5416    0.0000 </r>
+        <r>   13.1194    0.0000 </r>
+        <r>   14.4567    0.0000 </r>
+        <r>   16.2755    0.0000 </r>
+        <r>   19.0910    0.0000 </r>
+        <r>   19.1005    0.0000 </r>
+       </set>
+       <set comment="kpoint 53">
+        <r>  -11.7075    1.0000 </r>
+        <r>  -11.6727    1.0000 </r>
+        <r>  -11.6684    1.0000 </r>
+        <r>  -11.6513    1.0000 </r>
+        <r>  -11.6513    1.0000 </r>
+        <r>   -5.5637    1.0000 </r>
+        <r>   -2.0239    1.0000 </r>
+        <r>    2.4009    1.0000 </r>
+        <r>    2.7928    1.0000 </r>
+        <r>    2.7928    1.0000 </r>
+        <r>    8.8557    0.0000 </r>
+        <r>    9.1814    0.0000 </r>
+        <r>    9.8443    0.0000 </r>
+        <r>    9.8443    0.0000 </r>
+        <r>   13.9686    0.0000 </r>
+        <r>   14.1150    0.0000 </r>
+        <r>   14.8827    0.0000 </r>
+        <r>   14.8827    0.0000 </r>
+        <r>   17.5155    0.0000 </r>
+        <r>   18.1249    0.0000 </r>
+       </set>
+       <set comment="kpoint 54">
+        <r>  -11.7114    1.0000 </r>
+        <r>  -11.6728    1.0000 </r>
+        <r>  -11.6683    1.0000 </r>
+        <r>  -11.6498    1.0000 </r>
+        <r>  -11.6494    1.0000 </r>
+        <r>   -5.3958    1.0000 </r>
+        <r>   -2.1487    1.0000 </r>
+        <r>    1.9351    1.0000 </r>
+        <r>    2.7264    1.0000 </r>
+        <r>    2.7490    1.0000 </r>
+        <r>    8.8095    0.0000 </r>
+        <r>    9.7058    0.0000 </r>
+        <r>    9.8305    0.0000 </r>
+        <r>    9.9550    0.0000 </r>
+        <r>   14.3922    0.0000 </r>
+        <r>   14.5243    0.0000 </r>
+        <r>   15.4141    0.0000 </r>
+        <r>   15.4339    0.0000 </r>
+        <r>   17.1299    0.0000 </r>
+        <r>   17.2544    0.0000 </r>
+       </set>
+       <set comment="kpoint 55">
+        <r>  -11.7128    1.0000 </r>
+        <r>  -11.6717    1.0000 </r>
+        <r>  -11.6696    1.0000 </r>
+        <r>  -11.6494    1.0000 </r>
+        <r>  -11.6483    1.0000 </r>
+        <r>   -5.2252    1.0000 </r>
+        <r>   -2.3458    1.0000 </r>
+        <r>    1.5953    1.0000 </r>
+        <r>    2.7479    1.0000 </r>
+        <r>    2.8208    1.0000 </r>
+        <r>    8.8792    0.0000 </r>
+        <r>    9.5452    0.0000 </r>
+        <r>    9.6993    0.0000 </r>
+        <r>   10.3185    0.0000 </r>
+        <r>   14.7251    0.0000 </r>
+        <r>   15.1723    0.0000 </r>
+        <r>   15.5379    0.0000 </r>
+        <r>   15.7143    0.0000 </r>
+        <r>   16.8533    0.0000 </r>
+        <r>   16.9712    0.0000 </r>
+       </set>
+       <set comment="kpoint 56">
+        <r>  -11.7116    1.0000 </r>
+        <r>  -11.6719    1.0000 </r>
+        <r>  -11.6694    1.0000 </r>
+        <r>  -11.6502    1.0000 </r>
+        <r>  -11.6482    1.0000 </r>
+        <r>   -5.0848    1.0000 </r>
+        <r>   -2.5696    1.0000 </r>
+        <r>    1.4050    1.0000 </r>
+        <r>    2.8571    1.0000 </r>
+        <r>    2.9888    1.0000 </r>
+        <r>    8.7855    0.0000 </r>
+        <r>    9.1057    0.0000 </r>
+        <r>    9.8554    0.0000 </r>
+        <r>   10.5802    0.0000 </r>
+        <r>   14.2738    0.0000 </r>
+        <r>   14.7326    0.0000 </r>
+        <r>   16.0973    0.0000 </r>
+        <r>   16.2028    0.0000 </r>
+        <r>   17.4368    0.0000 </r>
+        <r>   17.6078    0.0000 </r>
+       </set>
+       <set comment="kpoint 57">
+        <r>  -11.7081    1.0000 </r>
+        <r>  -11.6747    1.0000 </r>
+        <r>  -11.6664    1.0000 </r>
+        <r>  -11.6522    1.0000 </r>
+        <r>  -11.6491    1.0000 </r>
+        <r>   -5.0128    1.0000 </r>
+        <r>   -2.7644    1.0000 </r>
+        <r>    1.3813    1.0000 </r>
+        <r>    3.0508    1.0000 </r>
+        <r>    3.2375    1.0000 </r>
+        <r>    8.4188    0.0000 </r>
+        <r>    8.5860    0.0000 </r>
+        <r>   10.3978    0.0000 </r>
+        <r>   10.6188    0.0000 </r>
+        <r>   13.6643    0.0000 </r>
+        <r>   14.0341    0.0000 </r>
+        <r>   15.8377    0.0000 </r>
+        <r>   17.1398    0.0000 </r>
+        <r>   17.9341    0.0000 </r>
+        <r>   18.4406    0.0000 </r>
+       </set>
+       <set comment="kpoint 58">
+        <r>  -11.7029    1.0000 </r>
+        <r>  -11.6778    1.0000 </r>
+        <r>  -11.6629    1.0000 </r>
+        <r>  -11.6548    1.0000 </r>
+        <r>  -11.6508    1.0000 </r>
+        <r>   -5.0371    1.0000 </r>
+        <r>   -2.8849    1.0000 </r>
+        <r>    1.5334    1.0000 </r>
+        <r>    3.3207    1.0000 </r>
+        <r>    3.5569    1.0000 </r>
+        <r>    7.9243    0.0000 </r>
+        <r>    8.0283    0.0000 </r>
+        <r>   10.4095    0.0000 </r>
+        <r>   11.1807    0.0000 </r>
+        <r>   13.1150    0.0000 </r>
+        <r>   13.4536    0.0000 </r>
+        <r>   15.2549    0.0000 </r>
+        <r>   17.9770    0.0000 </r>
+        <r>   18.1343    0.0000 </r>
+        <r>   18.7364    0.0000 </r>
+       </set>
+       <set comment="kpoint 59">
+        <r>  -11.7163    1.0000 </r>
+        <r>  -11.6739    1.0000 </r>
+        <r>  -11.6669    1.0000 </r>
+        <r>  -11.6479    1.0000 </r>
+        <r>  -11.6479    1.0000 </r>
+        <r>   -5.2775    1.0000 </r>
+        <r>   -2.1222    1.0000 </r>
+        <r>    1.4996    1.0000 </r>
+        <r>    2.6112    1.0000 </r>
+        <r>    2.6112    1.0000 </r>
+        <r>    8.6427    0.0000 </r>
+        <r>   10.1369    0.0000 </r>
+        <r>   10.1369    0.0000 </r>
+        <r>   10.4622    0.0000 </r>
+        <r>   14.5618    0.0000 </r>
+        <r>   14.6023    0.0000 </r>
+        <r>   15.9558    0.0000 </r>
+        <r>   15.9558    0.0000 </r>
+        <r>   17.0915    0.0000 </r>
+        <r>   17.3307    0.0000 </r>
+       </set>
+       <set comment="kpoint 60">
+        <r>  -11.7185    1.0000 </r>
+        <r>  -11.6737    1.0000 </r>
+        <r>  -11.6672    1.0000 </r>
+        <r>  -11.6472    1.0000 </r>
+        <r>  -11.6469    1.0000 </r>
+        <r>   -5.1602    1.0000 </r>
+        <r>   -2.1932    1.0000 </r>
+        <r>    1.2044    1.0000 </r>
+        <r>    2.5865    1.0000 </r>
+        <r>    2.6060    1.0000 </r>
+        <r>    8.6609    0.0000 </r>
+        <r>   10.0829    0.0000 </r>
+        <r>   10.1066    0.0000 </r>
+        <r>   10.9429    0.0000 </r>
+        <r>   14.9633    0.0000 </r>
+        <r>   15.0150    0.0000 </r>
+        <r>   15.9741    0.0000 </r>
+        <r>   16.0452    0.0000 </r>
+        <r>   16.8565    0.0000 </r>
+        <r>   17.1422    0.0000 </r>
+       </set>
+       <set comment="kpoint 61">
+        <r>  -11.7176    1.0000 </r>
+        <r>  -11.6722    1.0000 </r>
+        <r>  -11.6687    1.0000 </r>
+        <r>  -11.6477    1.0000 </r>
+        <r>  -11.6468    1.0000 </r>
+        <r>   -5.0654    1.0000 </r>
+        <r>   -2.3490    1.0000 </r>
+        <r>    1.0780    1.0000 </r>
+        <r>    2.6532    1.0000 </r>
+        <r>    2.7209    1.0000 </r>
+        <r>    8.8318    0.0000 </r>
+        <r>    9.7354    0.0000 </r>
+        <r>    9.8955    0.0000 </r>
+        <r>   11.1436    0.0000 </r>
+        <r>   14.8619    0.0000 </r>
+        <r>   15.2101    0.0000 </r>
+        <r>   15.7058    0.0000 </r>
+        <r>   16.2105    0.0000 </r>
+        <r>   17.1044    0.0000 </r>
+        <r>   17.7098    0.0000 </r>
+       </set>
+       <set comment="kpoint 62">
+        <r>  -11.7139    1.0000 </r>
+        <r>  -11.6713    1.0000 </r>
+        <r>  -11.6697    1.0000 </r>
+        <r>  -11.6495    1.0000 </r>
+        <r>  -11.6476    1.0000 </r>
+        <r>   -5.0123    1.0000 </r>
+        <r>   -2.5545    1.0000 </r>
+        <r>    1.1371    1.0000 </r>
+        <r>    2.8098    1.0000 </r>
+        <r>    2.9370    1.0000 </r>
+        <r>    8.8538    0.0000 </r>
+        <r>    9.2085    0.0000 </r>
+        <r>    9.8796    0.0000 </r>
+        <r>   11.0254    0.0000 </r>
+        <r>   14.2751    0.0000 </r>
+        <r>   14.5655    0.0000 </r>
+        <r>   16.1795    0.0000 </r>
+        <r>   16.4501    0.0000 </r>
+        <r>   17.4298    0.0000 </r>
+        <r>   18.0722    0.0000 </r>
+       </set>
+       <set comment="kpoint 63">
+        <r>  -11.7214    1.0000 </r>
+        <r>  -11.6745    1.0000 </r>
+        <r>  -11.6662    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -5.1050    1.0000 </r>
+        <r>   -2.1342    1.0000 </r>
+        <r>    0.9746    1.0000 </r>
+        <r>    2.5159    1.0000 </r>
+        <r>    2.5159    1.0000 </r>
+        <r>    8.5359    0.0000 </r>
+        <r>   10.3198    0.0000 </r>
+        <r>   10.3198    0.0000 </r>
+        <r>   11.3457    0.0000 </r>
+        <r>   14.9497    0.0000 </r>
+        <r>   15.3810    0.0000 </r>
+        <r>   16.2715    0.0000 </r>
+        <r>   16.4648    0.0000 </r>
+        <r>   16.4651    0.0000 </r>
+        <r>   16.7284    0.0000 </r>
+       </set>
+       <set comment="kpoint 64">
+        <r>  -11.7211    1.0000 </r>
+        <r>  -11.6740    1.0000 </r>
+        <r>  -11.6667    1.0000 </r>
+        <r>  -11.6462    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -5.0715    1.0000 </r>
+        <r>   -2.1903    1.0000 </r>
+        <r>    0.9301    1.0000 </r>
+        <r>    2.5383    1.0000 </r>
+        <r>    2.5572    1.0000 </r>
+        <r>    8.6101    0.0000 </r>
+        <r>   10.1816    0.0000 </r>
+        <r>   10.2138    0.0000 </r>
+        <r>   11.4212    0.0000 </r>
+        <r>   15.2172    0.0000 </r>
+        <r>   15.5248    0.0000 </r>
+        <r>   15.8587    0.0000 </r>
+        <r>   15.8727    0.0000 </r>
+        <r>   16.9569    0.0000 </r>
+        <r>   17.3906    0.0000 </r>
+       </set>
+       <set comment="kpoint 65">
+        <r>  -11.6805    1.0000 </r>
+        <r>  -11.6750    1.0000 </r>
+        <r>  -11.6674    1.0000 </r>
+        <r>  -11.6636    1.0000 </r>
+        <r>  -11.6625    1.0000 </r>
+        <r>   -6.3551    1.0000 </r>
+        <r>   -1.2415    1.0000 </r>
+        <r>    3.5117    1.0000 </r>
+        <r>    3.8323    1.0000 </r>
+        <r>    4.6140    1.0000 </r>
+        <r>    7.1782    0.0000 </r>
+        <r>    8.4491    0.0000 </r>
+        <r>    9.0831    0.0000 </r>
+        <r>   10.3484    0.0000 </r>
+        <r>   11.5679    0.0000 </r>
+        <r>   11.9307    0.0000 </r>
+        <r>   13.0405    0.0000 </r>
+        <r>   13.8929    0.0000 </r>
+        <r>   14.2123    0.0000 </r>
+        <r>   15.4431    0.0000 </r>
+       </set>
+       <set comment="kpoint 66">
+        <r>  -11.6830    1.0000 </r>
+        <r>  -11.6764    1.0000 </r>
+        <r>  -11.6669    1.0000 </r>
+        <r>  -11.6618    1.0000 </r>
+        <r>  -11.6599    1.0000 </r>
+        <r>   -6.1863    1.0000 </r>
+        <r>   -1.6066    1.0000 </r>
+        <r>    3.3441    1.0000 </r>
+        <r>    3.9500    1.0000 </r>
+        <r>    4.7612    1.0000 </r>
+        <r>    6.7550    0.0000 </r>
+        <r>    7.9202    0.0000 </r>
+        <r>    8.9604    0.0000 </r>
+        <r>   10.4262    0.0000 </r>
+        <r>   11.8140    0.0000 </r>
+        <r>   12.5066    0.0000 </r>
+        <r>   13.4623    0.0000 </r>
+        <r>   14.7698    0.0000 </r>
+        <r>   15.1763    0.0000 </r>
+        <r>   16.4199    0.0000 </r>
+       </set>
+       <set comment="kpoint 67">
+        <r>  -11.6855    1.0000 </r>
+        <r>  -11.6785    1.0000 </r>
+        <r>  -11.6660    1.0000 </r>
+        <r>  -11.6596    1.0000 </r>
+        <r>  -11.6573    1.0000 </r>
+        <r>   -5.9622    1.0000 </r>
+        <r>   -2.0431    1.0000 </r>
+        <r>    3.2545    1.0000 </r>
+        <r>    4.0691    1.0000 </r>
+        <r>    4.7251    1.0000 </r>
+        <r>    6.5665    0.0000 </r>
+        <r>    7.4105    0.0000 </r>
+        <r>    8.6638    0.0000 </r>
+        <r>   10.6590    0.0000 </r>
+        <r>   12.1869    0.0000 </r>
+        <r>   13.1583    0.0000 </r>
+        <r>   14.2452    0.0000 </r>
+        <r>   15.6321    0.0000 </r>
+        <r>   16.3624    0.0000 </r>
+        <r>   17.0976    0.0000 </r>
+       </set>
+       <set comment="kpoint 68">
+        <r>  -11.6877    1.0000 </r>
+        <r>  -11.6810    1.0000 </r>
+        <r>  -11.6649    1.0000 </r>
+        <r>  -11.6574    1.0000 </r>
+        <r>  -11.6549    1.0000 </r>
+        <r>   -5.7012    1.0000 </r>
+        <r>   -2.4962    1.0000 </r>
+        <r>    3.2451    1.0000 </r>
+        <r>    4.1141    1.0000 </r>
+        <r>    4.5978    1.0000 </r>
+        <r>    6.5490    0.0000 </r>
+        <r>    7.0201    0.0000 </r>
+        <r>    8.2974    0.0000 </r>
+        <r>   11.0813    0.0000 </r>
+        <r>   12.7103    0.0000 </r>
+        <r>   13.8721    0.0000 </r>
+        <r>   15.0217    0.0000 </r>
+        <r>   15.7441    0.0000 </r>
+        <r>   17.4032    0.0000 </r>
+        <r>   17.6762    0.0000 </r>
+       </set>
+       <set comment="kpoint 69">
+        <r>  -11.6891    1.0000 </r>
+        <r>  -11.6831    1.0000 </r>
+        <r>  -11.6640    1.0000 </r>
+        <r>  -11.6556    1.0000 </r>
+        <r>  -11.6533    1.0000 </r>
+        <r>   -5.4420    1.0000 </r>
+        <r>   -2.8989    1.0000 </r>
+        <r>    3.3108    1.0000 </r>
+        <r>    3.9722    1.0000 </r>
+        <r>    4.5914    1.0000 </r>
+        <r>    6.4292    0.0000 </r>
+        <r>    6.9600    0.0000 </r>
+        <r>    7.9302    0.0000 </r>
+        <r>   11.6885    0.0000 </r>
+        <r>   13.3587    0.0000 </r>
+        <r>   14.3880    0.0000 </r>
+        <r>   14.7215    0.0000 </r>
+        <r>   15.9641    0.0000 </r>
+        <r>   17.2321    0.0000 </r>
+        <r>   17.9996    0.0000 </r>
+       </set>
+       <set comment="kpoint 70">
+        <r>  -11.6898    1.0000 </r>
+        <r>  -11.6844    1.0000 </r>
+        <r>  -11.6634    1.0000 </r>
+        <r>  -11.6545    1.0000 </r>
+        <r>  -11.6525    1.0000 </r>
+        <r>   -5.2624    1.0000 </r>
+        <r>   -3.1548    1.0000 </r>
+        <r>    3.4240    1.0000 </r>
+        <r>    3.7703    1.0000 </r>
+        <r>    4.6457    1.0000 </r>
+        <r>    6.2710    0.0000 </r>
+        <r>    7.1210    0.0000 </r>
+        <r>    7.6318    0.0000 </r>
+        <r>   12.4087    0.0000 </r>
+        <r>   13.4971    0.0000 </r>
+        <r>   14.1643    0.0000 </r>
+        <r>   14.8872    0.0000 </r>
+        <r>   15.9751    0.0000 </r>
+        <r>   16.8108    0.0000 </r>
+        <r>   18.3264    0.0000 </r>
+       </set>
+       <set comment="kpoint 71">
+        <r>  -11.6872    1.0000 </r>
+        <r>  -11.6736    1.0000 </r>
+        <r>  -11.6687    1.0000 </r>
+        <r>  -11.6599    1.0000 </r>
+        <r>  -11.6591    1.0000 </r>
+        <r>   -6.1318    1.0000 </r>
+        <r>   -1.6135    1.0000 </r>
+        <r>    3.2363    1.0000 </r>
+        <r>    3.5678    1.0000 </r>
+        <r>    4.5908    1.0000 </r>
+        <r>    6.8287    0.0000 </r>
+        <r>    8.6188    0.0000 </r>
+        <r>    9.1814    0.0000 </r>
+        <r>    9.9255    0.0000 </r>
+        <r>   12.4580    0.0000 </r>
+        <r>   12.7661    0.0000 </r>
+        <r>   13.2974    0.0000 </r>
+        <r>   14.1361    0.0000 </r>
+        <r>   15.2732    0.0000 </r>
+        <r>   17.3302    0.0000 </r>
+       </set>
+       <set comment="kpoint 72">
+        <r>  -11.6904    1.0000 </r>
+        <r>  -11.6749    1.0000 </r>
+        <r>  -11.6682    1.0000 </r>
+        <r>  -11.6580    1.0000 </r>
+        <r>  -11.6566    1.0000 </r>
+        <r>   -5.9319    1.0000 </r>
+        <r>   -1.9527    1.0000 </r>
+        <r>    3.0511    1.0000 </r>
+        <r>    3.6650    1.0000 </r>
+        <r>    4.2275    1.0000 </r>
+        <r>    7.0685    0.0000 </r>
+        <r>    8.1464    0.0000 </r>
+        <r>    9.1037    0.0000 </r>
+        <r>   10.0792    0.0000 </r>
+        <r>   12.7782    0.0000 </r>
+        <r>   13.4319    0.0000 </r>
+        <r>   13.7672    0.0000 </r>
+        <r>   14.9852    0.0000 </r>
+        <r>   16.2881    0.0000 </r>
+        <r>   17.4661    0.0000 </r>
+       </set>
+       <set comment="kpoint 73">
+        <r>  -11.6929    1.0000 </r>
+        <r>  -11.6769    1.0000 </r>
+        <r>  -11.6669    1.0000 </r>
+        <r>  -11.6565    1.0000 </r>
+        <r>  -11.6542    1.0000 </r>
+        <r>   -5.6913    1.0000 </r>
+        <r>   -2.3405    1.0000 </r>
+        <r>    2.9578    1.0000 </r>
+        <r>    3.6187    1.0000 </r>
+        <r>    4.0178    1.0000 </r>
+        <r>    7.2893    0.0000 </r>
+        <r>    7.7539    0.0000 </r>
+        <r>    8.8959    0.0000 </r>
+        <r>   10.3519    0.0000 </r>
+        <r>   13.2094    0.0000 </r>
+        <r>   14.1673    0.0000 </r>
+        <r>   14.5124    0.0000 </r>
+        <r>   15.4113    0.0000 </r>
+        <r>   17.0437    0.0000 </r>
+        <r>   17.5197    0.0000 </r>
+       </set>
+       <set comment="kpoint 74">
+        <r>  -11.6943    1.0000 </r>
+        <r>  -11.6792    1.0000 </r>
+        <r>  -11.6651    1.0000 </r>
+        <r>  -11.6557    1.0000 </r>
+        <r>  -11.6524    1.0000 </r>
+        <r>   -5.4405    1.0000 </r>
+        <r>   -2.7186    1.0000 </r>
+        <r>    2.9478    1.0000 </r>
+        <r>    3.3219    1.0000 </r>
+        <r>    4.1440    1.0000 </r>
+        <r>    7.0836    0.0000 </r>
+        <r>    7.8224    0.0000 </r>
+        <r>    8.6105    0.0000 </r>
+        <r>   10.8183    0.0000 </r>
+        <r>   13.7674    0.0000 </r>
+        <r>   14.4455    0.0000 </r>
+        <r>   14.9008    0.0000 </r>
+        <r>   15.5880    0.0000 </r>
+        <r>   17.0793    0.0000 </r>
+        <r>   17.8385    0.0000 </r>
+       </set>
+       <set comment="kpoint 75">
+        <r>  -11.6946    1.0000 </r>
+        <r>  -11.6812    1.0000 </r>
+        <r>  -11.6633    1.0000 </r>
+        <r>  -11.6556    1.0000 </r>
+        <r>  -11.6515    1.0000 </r>
+        <r>   -5.2388    1.0000 </r>
+        <r>   -3.0055    1.0000 </r>
+        <r>    2.9121    1.0000 </r>
+        <r>    3.1644    1.0000 </r>
+        <r>    4.3397    1.0000 </r>
+        <r>    6.7438    0.0000 </r>
+        <r>    7.9770    0.0000 </r>
+        <r>    8.4030    0.0000 </r>
+        <r>   11.4700    0.0000 </r>
+        <r>   13.4808    0.0000 </r>
+        <r>   14.5149    0.0000 </r>
+        <r>   14.9819    0.0000 </r>
+        <r>   16.1268    0.0000 </r>
+        <r>   17.3400    0.0000 </r>
+        <r>   18.3436    0.0000 </r>
+       </set>
+       <set comment="kpoint 76">
+        <r>  -11.6938    1.0000 </r>
+        <r>  -11.6825    1.0000 </r>
+        <r>  -11.6622    1.0000 </r>
+        <r>  -11.6558    1.0000 </r>
+        <r>  -11.6517    1.0000 </r>
+        <r>   -5.1759    1.0000 </r>
+        <r>   -3.0990    1.0000 </r>
+        <r>    2.7476    1.0000 </r>
+        <r>    3.3070    1.0000 </r>
+        <r>    4.5294    1.0000 </r>
+        <r>    6.4904    0.0000 </r>
+        <r>    7.7825    0.0000 </r>
+        <r>    8.5585    0.0000 </r>
+        <r>   12.1680    0.0000 </r>
+        <r>   12.7314    0.0000 </r>
+        <r>   14.2163    0.0000 </r>
+        <r>   15.2706    0.0000 </r>
+        <r>   16.8594    0.0000 </r>
+        <r>   17.0939    0.0000 </r>
+        <r>   18.1220    0.0000 </r>
+       </set>
+       <set comment="kpoint 77">
+        <r>  -11.6922    1.0000 </r>
+        <r>  -11.6826    1.0000 </r>
+        <r>  -11.6624    1.0000 </r>
+        <r>  -11.6560    1.0000 </r>
+        <r>  -11.6529    1.0000 </r>
+        <r>   -5.2922    1.0000 </r>
+        <r>   -2.9558    1.0000 </r>
+        <r>    2.6461    1.0000 </r>
+        <r>    3.5636    1.0000 </r>
+        <r>    4.6527    1.0000 </r>
+        <r>    6.3947    0.0000 </r>
+        <r>    7.4762    0.0000 </r>
+        <r>    8.8282    0.0000 </r>
+        <r>   11.7751    0.0000 </r>
+        <r>   13.2384    0.0000 </r>
+        <r>   13.5672    0.0000 </r>
+        <r>   15.4499    0.0000 </r>
+        <r>   16.1194    0.0000 </r>
+        <r>   17.3107    0.0000 </r>
+        <r>   18.3783    0.0000 </r>
+       </set>
+       <set comment="kpoint 78">
+        <r>  -11.6902    1.0000 </r>
+        <r>  -11.6816    1.0000 </r>
+        <r>  -11.6637    1.0000 </r>
+        <r>  -11.6564    1.0000 </r>
+        <r>  -11.6546    1.0000 </r>
+        <r>   -5.5194    1.0000 </r>
+        <r>   -2.6509    1.0000 </r>
+        <r>    2.6506    1.0000 </r>
+        <r>    3.8738    1.0000 </r>
+        <r>    4.6603    1.0000 </r>
+        <r>    6.5018    0.0000 </r>
+        <r>    7.1851    0.0000 </r>
+        <r>    9.0650    0.0000 </r>
+        <r>   11.2261    0.0000 </r>
+        <r>   12.8393    0.0000 </r>
+        <r>   14.2375    0.0000 </r>
+        <r>   14.8104    0.0000 </r>
+        <r>   15.2458    0.0000 </r>
+        <r>   18.0294    0.0000 </r>
+        <r>   18.3348    0.0000 </r>
+       </set>
+       <set comment="kpoint 79">
+        <r>  -11.6880    1.0000 </r>
+        <r>  -11.6797    1.0000 </r>
+        <r>  -11.6652    1.0000 </r>
+        <r>  -11.6580    1.0000 </r>
+        <r>  -11.6560    1.0000 </r>
+        <r>   -5.7727    1.0000 </r>
+        <r>   -2.2830    1.0000 </r>
+        <r>    2.7710    1.0000 </r>
+        <r>    4.1386    1.0000 </r>
+        <r>    4.6188    1.0000 </r>
+        <r>    6.6831    0.0000 </r>
+        <r>    7.0556    0.0000 </r>
+        <r>    9.1989    0.0000 </r>
+        <r>   10.8551    0.0000 </r>
+        <r>   12.3762    0.0000 </r>
+        <r>   13.8776    0.0000 </r>
+        <r>   14.1703    0.0000 </r>
+        <r>   15.5110    0.0000 </r>
+        <r>   17.1674    0.0000 </r>
+        <r>   17.4373    0.0000 </r>
+       </set>
+       <set comment="kpoint 80">
+        <r>  -11.6856    1.0000 </r>
+        <r>  -11.6777    1.0000 </r>
+        <r>  -11.6664    1.0000 </r>
+        <r>  -11.6601    1.0000 </r>
+        <r>  -11.6577    1.0000 </r>
+        <r>   -6.0032    1.0000 </r>
+        <r>   -1.9200    1.0000 </r>
+        <r>    3.0069    1.0000 </r>
+        <r>    4.1302    1.0000 </r>
+        <r>    4.7221    1.0000 </r>
+        <r>    6.6362    0.0000 </r>
+        <r>    7.4025    0.0000 </r>
+        <r>    9.1846    0.0000 </r>
+        <r>   10.5958    0.0000 </r>
+        <r>   12.0455    0.0000 </r>
+        <r>   13.2572    0.0000 </r>
+        <r>   13.4907    0.0000 </r>
+        <r>   15.6009    0.0000 </r>
+        <r>   16.0607    0.0000 </r>
+        <r>   17.0588    0.0000 </r>
+       </set>
+       <set comment="kpoint 81">
+        <r>  -11.6961    1.0000 </r>
+        <r>  -11.6718    1.0000 </r>
+        <r>  -11.6702    1.0000 </r>
+        <r>  -11.6556    1.0000 </r>
+        <r>  -11.6553    1.0000 </r>
+        <r>   -5.8438    1.0000 </r>
+        <r>   -1.9305    1.0000 </r>
+        <r>    2.9493    1.0000 </r>
+        <r>    3.2665    1.0000 </r>
+        <r>    3.5944    1.0000 </r>
+        <r>    7.7632    0.0000 </r>
+        <r>    8.8943    0.0000 </r>
+        <r>    9.1873    0.0000 </r>
+        <r>    9.7695    0.0000 </r>
+        <r>   13.5278    0.0000 </r>
+        <r>   13.5786    0.0000 </r>
+        <r>   13.8087    0.0000 </r>
+        <r>   14.4835    0.0000 </r>
+        <r>   16.4760    0.0000 </r>
+        <r>   17.7178    0.0000 </r>
+       </set>
+       <set comment="kpoint 82">
+        <r>  -11.6994    1.0000 </r>
+        <r>  -11.6730    1.0000 </r>
+        <r>  -11.6695    1.0000 </r>
+        <r>  -11.6541    1.0000 </r>
+        <r>  -11.6530    1.0000 </r>
+        <r>   -5.6316    1.0000 </r>
+        <r>   -2.2138    1.0000 </r>
+        <r>    2.7693    1.0000 </r>
+        <r>    3.0248    1.0000 </r>
+        <r>    3.4956    1.0000 </r>
+        <r>    8.1342    0.0000 </r>
+        <r>    8.5537    0.0000 </r>
+        <r>    9.1874    0.0000 </r>
+        <r>    9.9502    0.0000 </r>
+        <r>   13.8285    0.0000 </r>
+        <r>   14.1759    0.0000 </r>
+        <r>   14.5064    0.0000 </r>
+        <r>   15.0889    0.0000 </r>
+        <r>   16.9292    0.0000 </r>
+        <r>   17.5133    0.0000 </r>
+       </set>
+       <set comment="kpoint 83">
+        <r>  -11.7012    1.0000 </r>
+        <r>  -11.6749    1.0000 </r>
+        <r>  -11.6678    1.0000 </r>
+        <r>  -11.6537    1.0000 </r>
+        <r>  -11.6511    1.0000 </r>
+        <r>   -5.4034    1.0000 </r>
+        <r>   -2.5279    1.0000 </r>
+        <r>    2.5840    1.0000 </r>
+        <r>    2.7498    1.0000 </r>
+        <r>    3.6808    1.0000 </r>
+        <r>    7.8696    0.0000 </r>
+        <r>    8.7388    0.0000 </r>
+        <r>    9.1579    0.0000 </r>
+        <r>   10.1672    0.0000 </r>
+        <r>   14.2302    0.0000 </r>
+        <r>   14.5891    0.0000 </r>
+        <r>   15.0163    0.0000 </r>
+        <r>   15.3496    0.0000 </r>
+        <r>   17.0762    0.0000 </r>
+        <r>   17.3566    0.0000 </r>
+       </set>
+       <set comment="kpoint 84">
+        <r>  -11.7012    1.0000 </r>
+        <r>  -11.6772    1.0000 </r>
+        <r>  -11.6654    1.0000 </r>
+        <r>  -11.6544    1.0000 </r>
+        <r>  -11.6502    1.0000 </r>
+        <r>   -5.2033    1.0000 </r>
+        <r>   -2.8077    1.0000 </r>
+        <r>    2.3007    1.0000 </r>
+        <r>    2.7724    1.0000 </r>
+        <r>    3.9176    1.0000 </r>
+        <r>    7.4432    0.0000 </r>
+        <r>    8.7693    0.0000 </r>
+        <r>    9.2306    0.0000 </r>
+        <r>   10.6332    0.0000 </r>
+        <r>   13.6310    0.0000 </r>
+        <r>   14.9481    0.0000 </r>
+        <r>   15.1076    0.0000 </r>
+        <r>   16.2089    0.0000 </r>
+        <r>   17.0207    0.0000 </r>
+        <r>   18.3691    0.0000 </r>
+       </set>
+       <set comment="kpoint 85">
+        <r>  -11.6997    1.0000 </r>
+        <r>  -11.6793    1.0000 </r>
+        <r>  -11.6628    1.0000 </r>
+        <r>  -11.6559    1.0000 </r>
+        <r>  -11.6503    1.0000 </r>
+        <r>   -5.0995    1.0000 </r>
+        <r>   -2.9702    1.0000 </r>
+        <r>    2.1188    1.0000 </r>
+        <r>    2.9137    1.0000 </r>
+        <r>    4.1815    1.0000 </r>
+        <r>    7.0475    0.0000 </r>
+        <r>    8.4696    0.0000 </r>
+        <r>    9.4696    0.0000 </r>
+        <r>   11.3218    0.0000 </r>
+        <r>   12.8124    0.0000 </r>
+        <r>   14.3885    0.0000 </r>
+        <r>   15.5943    0.0000 </r>
+        <r>   16.9329    0.0000 </r>
+        <r>   17.7211    0.0000 </r>
+        <r>   17.9039    0.0000 </r>
+       </set>
+       <set comment="kpoint 86">
+        <r>  -11.6970    1.0000 </r>
+        <r>  -11.6808    1.0000 </r>
+        <r>  -11.6607    1.0000 </r>
+        <r>  -11.6575    1.0000 </r>
+        <r>  -11.6516    1.0000 </r>
+        <r>   -5.1466    1.0000 </r>
+        <r>   -2.9543    1.0000 </r>
+        <r>    2.0674    1.0000 </r>
+        <r>    3.1507    1.0000 </r>
+        <r>    4.4446    1.0000 </r>
+        <r>    6.7194    0.0000 </r>
+        <r>    8.0941    0.0000 </r>
+        <r>    9.6380    0.0000 </r>
+        <r>   11.9914    0.0000 </r>
+        <r>   12.3238    0.0000 </r>
+        <r>   13.7066    0.0000 </r>
+        <r>   15.4205    0.0000 </r>
+        <r>   16.9866    0.0000 </r>
+        <r>   17.7000    0.0000 </r>
+        <r>   18.5168    0.0000 </r>
+       </set>
+       <set comment="kpoint 87">
+        <r>  -11.6937    1.0000 </r>
+        <r>  -11.6814    1.0000 </r>
+        <r>  -11.6616    1.0000 </r>
+        <r>  -11.6569    1.0000 </r>
+        <r>  -11.6535    1.0000 </r>
+        <r>   -5.3203    1.0000 </r>
+        <r>   -2.7854    1.0000 </r>
+        <r>    2.1586    1.0000 </r>
+        <r>    3.4680    1.0000 </r>
+        <r>    4.6439    1.0000 </r>
+        <r>    6.5207    0.0000 </r>
+        <r>    7.6896    0.0000 </r>
+        <r>    9.6602    0.0000 </r>
+        <r>   11.6005    0.0000 </r>
+        <r>   13.0803    0.0000 </r>
+        <r>   13.2481    0.0000 </r>
+        <r>   14.6763    0.0000 </r>
+        <r>   16.2363    0.0000 </r>
+        <r>   18.3763    0.0000 </r>
+        <r>   19.1092    0.0000 </r>
+       </set>
+       <set comment="kpoint 88">
+        <r>  -11.6906    1.0000 </r>
+        <r>  -11.6809    1.0000 </r>
+        <r>  -11.6636    1.0000 </r>
+        <r>  -11.6560    1.0000 </r>
+        <r>  -11.6558    1.0000 </r>
+        <r>   -5.5481    1.0000 </r>
+        <r>   -2.5414    1.0000 </r>
+        <r>    2.3962    1.0000 </r>
+        <r>    3.8354    1.0000 </r>
+        <r>    4.6867    1.0000 </r>
+        <r>    6.5425    0.0000 </r>
+        <r>    7.2857    0.0000 </r>
+        <r>    9.5141    0.0000 </r>
+        <r>   11.2167    0.0000 </r>
+        <r>   12.7032    0.0000 </r>
+        <r>   13.8369    0.0000 </r>
+        <r>   14.5053    0.0000 </r>
+        <r>   15.2882    0.0000 </r>
+        <r>   18.1921    0.0000 </r>
+        <r>   18.3762    0.0000 </r>
+       </set>
+       <set comment="kpoint 89">
+        <r>  -11.7060    1.0000 </r>
+        <r>  -11.6716    1.0000 </r>
+        <r>  -11.6699    1.0000 </r>
+        <r>  -11.6517    1.0000 </r>
+        <r>  -11.6513    1.0000 </r>
+        <r>   -5.5291    1.0000 </r>
+        <r>   -2.1430    1.0000 </r>
+        <r>    2.4382    1.0000 </r>
+        <r>    2.6980    1.0000 </r>
+        <r>    3.0693    1.0000 </r>
+        <r>    8.9746    0.0000 </r>
+        <r>    8.9893    0.0000 </r>
+        <r>    9.3074    0.0000 </r>
+        <r>    9.9671    0.0000 </r>
+        <r>   14.0535    0.0000 </r>
+        <r>   14.5837    0.0000 </r>
+        <r>   14.6994    0.0000 </r>
+        <r>   15.0684    0.0000 </r>
+        <r>   17.0002    0.0000 </r>
+        <r>   18.0030    0.0000 </r>
+       </set>
+       <set comment="kpoint 90">
+        <r>  -11.7084    1.0000 </r>
+        <r>  -11.6711    1.0000 </r>
+        <r>  -11.6707    1.0000 </r>
+        <r>  -11.6511    1.0000 </r>
+        <r>  -11.6495    1.0000 </r>
+        <r>   -5.3362    1.0000 </r>
+        <r>   -2.3564    1.0000 </r>
+        <r>    2.0269    1.0000 </r>
+        <r>    2.5555    1.0000 </r>
+        <r>    3.2507    1.0000 </r>
+        <r>    8.6843    0.0000 </r>
+        <r>    9.1225    0.0000 </r>
+        <r>    9.6349    0.0000 </r>
+        <r>   10.1064    0.0000 </r>
+        <r>   14.3968    0.0000 </r>
+        <r>   14.9168    0.0000 </r>
+        <r>   15.1599    0.0000 </r>
+        <r>   15.4830    0.0000 </r>
+        <r>   17.0115    0.0000 </r>
+        <r>   17.2586    0.0000 </r>
+       </set>
+       <set comment="kpoint 91">
+        <r>  -11.7085    1.0000 </r>
+        <r>  -11.6731    1.0000 </r>
+        <r>  -11.6686    1.0000 </r>
+        <r>  -11.6519    1.0000 </r>
+        <r>  -11.6485    1.0000 </r>
+        <r>   -5.1597    1.0000 </r>
+        <r>   -2.5902    1.0000 </r>
+        <r>    1.7409    1.0000 </r>
+        <r>    2.5299    1.0000 </r>
+        <r>    3.4934    1.0000 </r>
+        <r>    8.2157    0.0000 </r>
+        <r>    9.2328    0.0000 </r>
+        <r>    9.9910    0.0000 </r>
+        <r>   10.2034    0.0000 </r>
+        <r>   13.9307    0.0000 </r>
+        <r>   15.1597    0.0000 </r>
+        <r>   15.4796    0.0000 </r>
+        <r>   16.1374    0.0000 </r>
+        <r>   16.9747    0.0000 </r>
+        <r>   17.8468    0.0000 </r>
+       </set>
+       <set comment="kpoint 92">
+        <r>  -11.7064    1.0000 </r>
+        <r>  -11.6755    1.0000 </r>
+        <r>  -11.6657    1.0000 </r>
+        <r>  -11.6537    1.0000 </r>
+        <r>  -11.6486    1.0000 </r>
+        <r>   -5.0451    1.0000 </r>
+        <r>   -2.7853    1.0000 </r>
+        <r>    1.6006    1.0000 </r>
+        <r>    2.6173    1.0000 </r>
+        <r>    3.7809    1.0000 </r>
+        <r>    7.7306    0.0000 </r>
+        <r>    9.0680    0.0000 </r>
+        <r>   10.2571    0.0000 </r>
+        <r>   10.5607    0.0000 </r>
+        <r>   13.1880    0.0000 </r>
+        <r>   14.7008    0.0000 </r>
+        <r>   15.8870    0.0000 </r>
+        <r>   16.6958    0.0000 </r>
+        <r>   17.5100    0.0000 </r>
+        <r>   18.0860    0.0000 </r>
+       </set>
+       <set comment="kpoint 93">
+        <r>  -11.7028    1.0000 </r>
+        <r>  -11.6780    1.0000 </r>
+        <r>  -11.6624    1.0000 </r>
+        <r>  -11.6562    1.0000 </r>
+        <r>  -11.6498    1.0000 </r>
+        <r>   -5.0369    1.0000 </r>
+        <r>   -2.8862    1.0000 </r>
+        <r>    1.6207    1.0000 </r>
+        <r>    2.8109    1.0000 </r>
+        <r>    4.0976    1.0000 </r>
+        <r>    7.2537    0.0000 </r>
+        <r>    8.6901    0.0000 </r>
+        <r>   10.2689    0.0000 </r>
+        <r>   11.2701    0.0000 </r>
+        <r>   12.5819    0.0000 </r>
+        <r>   14.0805    0.0000 </r>
+        <r>   15.4346    0.0000 </r>
+        <r>   17.3322    0.0000 </r>
+        <r>   18.2066    0.0000 </r>
+        <r>   18.4441    0.0000 </r>
+       </set>
+       <set comment="kpoint 94">
+        <r>  -11.6982    1.0000 </r>
+        <r>  -11.6801    1.0000 </r>
+        <r>  -11.6593    1.0000 </r>
+        <r>  -11.6590    1.0000 </r>
+        <r>  -11.6516    1.0000 </r>
+        <r>   -5.1422    1.0000 </r>
+        <r>   -2.8764    1.0000 </r>
+        <r>    1.8084    1.0000 </r>
+        <r>    3.1000    1.0000 </r>
+        <r>    4.4125    1.0000 </r>
+        <r>    6.8199    0.0000 </r>
+        <r>    8.2131    0.0000 </r>
+        <r>   10.0582    0.0000 </r>
+        <r>   12.0814    0.0000 </r>
+        <r>   12.1731    0.0000 </r>
+        <r>   13.5570    0.0000 </r>
+        <r>   14.8464    0.0000 </r>
+        <r>   17.2431    0.0000 </r>
+        <r>   18.5357    0.0000 </r>
+        <r>   18.7135    0.0000 </r>
+       </set>
+       <set comment="kpoint 95">
+        <r>  -11.7145    1.0000 </r>
+        <r>  -11.6728    1.0000 </r>
+        <r>  -11.6684    1.0000 </r>
+        <r>  -11.6488    1.0000 </r>
+        <r>  -11.6479    1.0000 </r>
+        <r>   -5.2501    1.0000 </r>
+        <r>   -2.2357    1.0000 </r>
+        <r>    1.5476    1.0000 </r>
+        <r>    2.5147    1.0000 </r>
+        <r>    2.8811    1.0000 </r>
+        <r>    8.8072    0.0000 </r>
+        <r>    9.4868    0.0000 </r>
+        <r>   10.2323    0.0000 </r>
+        <r>   10.3849    0.0000 </r>
+        <r>   14.5836    0.0000 </r>
+        <r>   14.9333    0.0000 </r>
+        <r>   15.6887    0.0000 </r>
+        <r>   15.8298    0.0000 </r>
+        <r>   16.9508    0.0000 </r>
+        <r>   17.3761    0.0000 </r>
+       </set>
+       <set comment="kpoint 96">
+        <r>  -11.7150    1.0000 </r>
+        <r>  -11.6715    1.0000 </r>
+        <r>  -11.6697    1.0000 </r>
+        <r>  -11.6493    1.0000 </r>
+        <r>  -11.6470    1.0000 </r>
+        <r>   -5.1162    1.0000 </r>
+        <r>   -2.3888    1.0000 </r>
+        <r>    1.3048    1.0000 </r>
+        <r>    2.4115    1.0000 </r>
+        <r>    3.1078    1.0000 </r>
+        <r>    8.8859    0.0000 </r>
+        <r>    9.1238    0.0000 </r>
+        <r>   10.2906    0.0000 </r>
+        <r>   10.7585    0.0000 </r>
+        <r>   14.3803    0.0000 </r>
+        <r>   15.1610    0.0000 </r>
+        <r>   15.8882    0.0000 </r>
+        <r>   16.2082    0.0000 </r>
+        <r>   17.0097    0.0000 </r>
+        <r>   17.5089    0.0000 </r>
+       </set>
+       <set comment="kpoint 97">
+        <r>  -11.7128    1.0000 </r>
+        <r>  -11.6720    1.0000 </r>
+        <r>  -11.6690    1.0000 </r>
+        <r>  -11.6510    1.0000 </r>
+        <r>  -11.6470    1.0000 </r>
+        <r>   -5.0218    1.0000 </r>
+        <r>   -2.5752    1.0000 </r>
+        <r>    1.2300    1.0000 </r>
+        <r>    2.4303    1.0000 </r>
+        <r>    3.3979    1.0000 </r>
+        <r>    8.4284    0.0000 </r>
+        <r>    9.2768    0.0000 </r>
+        <r>   10.2325    0.0000 </r>
+        <r>   10.8676    0.0000 </r>
+        <r>   13.7208    0.0000 </r>
+        <r>   15.1688    0.0000 </r>
+        <r>   15.9959    0.0000 </r>
+        <r>   16.3611    0.0000 </r>
+        <r>   17.5216    0.0000 </r>
+        <r>   17.7682    0.0000 </r>
+       </set>
+       <set comment="kpoint 98">
+        <r>  -11.7084    1.0000 </r>
+        <r>  -11.6749    1.0000 </r>
+        <r>  -11.6658    1.0000 </r>
+        <r>  -11.6535    1.0000 </r>
+        <r>  -11.6481    1.0000 </r>
+        <r>   -4.9917    1.0000 </r>
+        <r>   -2.7533    1.0000 </r>
+        <r>    1.3360    1.0000 </r>
+        <r>    2.5665    1.0000 </r>
+        <r>    3.7343    1.0000 </r>
+        <r>    7.8469    0.0000 </r>
+        <r>    9.1606    0.0000 </r>
+        <r>   10.5444    0.0000 </r>
+        <r>   10.6902    0.0000 </r>
+        <r>   13.1296    0.0000 </r>
+        <r>   14.5939    0.0000 </r>
+        <r>   15.7418    0.0000 </r>
+        <r>   16.8587    0.0000 </r>
+        <r>   18.1120    0.0000 </r>
+        <r>   18.3156    0.0000 </r>
+       </set>
+       <set comment="kpoint 99">
+        <r>  -11.7195    1.0000 </r>
+        <r>  -11.6734    1.0000 </r>
+        <r>  -11.6675    1.0000 </r>
+        <r>  -11.6473    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -5.0836    1.0000 </r>
+        <r>   -2.2437    1.0000 </r>
+        <r>    1.0263    1.0000 </r>
+        <r>    2.4185    1.0000 </r>
+        <r>    2.7849    1.0000 </r>
+        <r>    8.7102    0.0000 </r>
+        <r>    9.7025    0.0000 </r>
+        <r>   10.4071    0.0000 </r>
+        <r>   11.2425    0.0000 </r>
+        <r>   14.9611    0.0000 </r>
+        <r>   15.1638    0.0000 </r>
+        <r>   15.9984    0.0000 </r>
+        <r>   16.4567    0.0000 </r>
+        <r>   16.5499    0.0000 </r>
+        <r>   17.4167    0.0000 </r>
+       </set>
+       <set comment="kpoint 100">
+        <r>  -11.7174    1.0000 </r>
+        <r>  -11.6717    1.0000 </r>
+        <r>  -11.6691    1.0000 </r>
+        <r>  -11.6487    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -5.0348    1.0000 </r>
+        <r>   -2.3807    1.0000 </r>
+        <r>    1.0338    1.0000 </r>
+        <r>    2.3623    1.0000 </r>
+        <r>    3.0592    1.0000 </r>
+        <r>    8.8911    0.0000 </r>
+        <r>    9.1980    0.0000 </r>
+        <r>   10.3865    0.0000 </r>
+        <r>   11.2147    0.0000 </r>
+        <r>   14.3331    0.0000 </r>
+        <r>   15.5351    0.0000 </r>
+        <r>   15.7824    0.0000 </r>
+        <r>   16.5187    0.0000 </r>
+        <r>   17.1038    0.0000 </r>
+        <r>   17.2667    0.0000 </r>
+       </set>
+       <set comment="kpoint 101">
+        <r>  -11.6935    1.0000 </r>
+        <r>  -11.6759    1.0000 </r>
+        <r>  -11.6675    1.0000 </r>
+        <r>  -11.6558    1.0000 </r>
+        <r>  -11.6552    1.0000 </r>
+        <r>   -5.7271    1.0000 </r>
+        <r>   -2.2231    1.0000 </r>
+        <r>    2.7094    1.0000 </r>
+        <r>    3.6013    1.0000 </r>
+        <r>    4.0630    1.0000 </r>
+        <r>    7.3690    0.0000 </r>
+        <r>    7.7765    0.0000 </r>
+        <r>    9.2995    0.0000 </r>
+        <r>   10.3662    0.0000 </r>
+        <r>   13.1115    0.0000 </r>
+        <r>   13.7349    0.0000 </r>
+        <r>   14.3381    0.0000 </r>
+        <r>   15.3299    0.0000 </r>
+        <r>   17.0654    0.0000 </r>
+        <r>   17.2309    0.0000 </r>
+       </set>
+       <set comment="kpoint 102">
+        <r>  -11.6959    1.0000 </r>
+        <r>  -11.6776    1.0000 </r>
+        <r>  -11.6659    1.0000 </r>
+        <r>  -11.6551    1.0000 </r>
+        <r>  -11.6533    1.0000 </r>
+        <r>   -5.4948    1.0000 </r>
+        <r>   -2.5218    1.0000 </r>
+        <r>    2.4834    1.0000 </r>
+        <r>    3.2115    1.0000 </r>
+        <r>    4.2764    1.0000 </r>
+        <r>    7.0834    0.0000 </r>
+        <r>    8.0303    0.0000 </r>
+        <r>    9.3830    0.0000 </r>
+        <r>   10.6592    0.0000 </r>
+        <r>   13.4820    0.0000 </r>
+        <r>   14.1054    0.0000 </r>
+        <r>   14.6572    0.0000 </r>
+        <r>   15.3088    0.0000 </r>
+        <r>   17.7838    0.0000 </r>
+        <r>   18.1261    0.0000 </r>
+       </set>
+       <set comment="kpoint 103">
+        <r>  -11.6974    1.0000 </r>
+        <r>  -11.6792    1.0000 </r>
+        <r>  -11.6638    1.0000 </r>
+        <r>  -11.6558    1.0000 </r>
+        <r>  -11.6515    1.0000 </r>
+        <r>   -5.2732    1.0000 </r>
+        <r>   -2.7983    1.0000 </r>
+        <r>    2.3827    1.0000 </r>
+        <r>    2.8638    1.0000 </r>
+        <r>    4.5007    1.0000 </r>
+        <r>    6.7279    0.0000 </r>
+        <r>    8.4025    0.0000 </r>
+        <r>    9.3462    0.0000 </r>
+        <r>   11.0366    0.0000 </r>
+        <r>   13.3496    0.0000 </r>
+        <r>   14.0453    0.0000 </r>
+        <r>   15.1500    0.0000 </r>
+        <r>   16.1435    0.0000 </r>
+        <r>   17.3285    0.0000 </r>
+        <r>   18.9342    0.0000 </r>
+       </set>
+       <set comment="kpoint 104">
+        <r>  -11.6981    1.0000 </r>
+        <r>  -11.6802    1.0000 </r>
+        <r>  -11.6617    1.0000 </r>
+        <r>  -11.6572    1.0000 </r>
+        <r>  -11.6504    1.0000 </r>
+        <r>   -5.1274    1.0000 </r>
+        <r>   -2.9753    1.0000 </r>
+        <r>    2.3930    1.0000 </r>
+        <r>    2.6244    1.0000 </r>
+        <r>    4.6466    1.0000 </r>
+        <r>    6.5123    0.0000 </r>
+        <r>    8.7014    0.0000 </r>
+        <r>    9.1993    0.0000 </r>
+        <r>   11.6053    0.0000 </r>
+        <r>   12.4745    0.0000 </r>
+        <r>   14.6594    0.0000 </r>
+        <r>   15.3090    0.0000 </r>
+        <r>   16.8722    0.0000 </r>
+        <r>   17.3048    0.0000 </r>
+        <r>   18.2581    0.0000 </r>
+       </set>
+       <set comment="kpoint 105">
+        <r>  -11.7023    1.0000 </r>
+        <r>  -11.6739    1.0000 </r>
+        <r>  -11.6686    1.0000 </r>
+        <r>  -11.6531    1.0000 </r>
+        <r>  -11.6514    1.0000 </r>
+        <r>   -5.4308    1.0000 </r>
+        <r>   -2.4181    1.0000 </r>
+        <r>    2.4511    1.0000 </r>
+        <r>    2.5759    1.0000 </r>
+        <r>    3.7658    1.0000 </r>
+        <r>    7.8742    0.0000 </r>
+        <r>    8.8770    0.0000 </r>
+        <r>    9.3106    0.0000 </r>
+        <r>   10.3718    0.0000 </r>
+        <r>   14.0815    0.0000 </r>
+        <r>   14.3066    0.0000 </r>
+        <r>   14.7234    0.0000 </r>
+        <r>   15.4142    0.0000 </r>
+        <r>   17.3281    0.0000 </r>
+        <r>   18.2917    0.0000 </r>
+       </set>
+       <set comment="kpoint 106">
+        <r>  -11.7037    1.0000 </r>
+        <r>  -11.6754    1.0000 </r>
+        <r>  -11.6667    1.0000 </r>
+        <r>  -11.6539    1.0000 </r>
+        <r>  -11.6496    1.0000 </r>
+        <r>   -5.2322    1.0000 </r>
+        <r>   -2.6342    1.0000 </r>
+        <r>    2.2012    1.0000 </r>
+        <r>    2.2755    1.0000 </r>
+        <r>    4.0757    1.0000 </r>
+        <r>    7.4160    0.0000 </r>
+        <r>    9.2980    0.0000 </r>
+        <r>    9.5040    0.0000 </r>
+        <r>   10.6413    0.0000 </r>
+        <r>   13.5585    0.0000 </r>
+        <r>   14.6836    0.0000 </r>
+        <r>   14.9107    0.0000 </r>
+        <r>   16.2351    0.0000 </r>
+        <r>   17.4376    0.0000 </r>
+        <r>   18.3580    0.0000 </r>
+       </set>
+       <set comment="kpoint 107">
+        <r>  -11.7037    1.0000 </r>
+        <r>  -11.6771    1.0000 </r>
+        <r>  -11.6641    1.0000 </r>
+        <r>  -11.6559    1.0000 </r>
+        <r>  -11.6486    1.0000 </r>
+        <r>   -5.0825    1.0000 </r>
+        <r>   -2.8109    1.0000 </r>
+        <r>    1.9707    1.0000 </r>
+        <r>    2.2135    1.0000 </r>
+        <r>    4.3770    1.0000 </r>
+        <r>    7.0011    0.0000 </r>
+        <r>    9.4585    0.0000 </r>
+        <r>    9.7517    0.0000 </r>
+        <r>   10.9576    0.0000 </r>
+        <r>   12.7112    0.0000 </r>
+        <r>   15.2126    0.0000 </r>
+        <r>   15.3359    0.0000 </r>
+        <r>   16.5174    0.0000 </r>
+        <r>   17.2794    0.0000 </r>
+        <r>   18.4153    0.0000 </r>
+       </set>
+       <set comment="kpoint 108">
+        <r>  -11.7026    1.0000 </r>
+        <r>  -11.6783    1.0000 </r>
+        <r>  -11.6612    1.0000 </r>
+        <r>  -11.6584    1.0000 </r>
+        <r>  -11.6487    1.0000 </r>
+        <r>   -5.0367    1.0000 </r>
+        <r>   -2.8884    1.0000 </r>
+        <r>    1.8729    1.0000 </r>
+        <r>    2.2905    1.0000 </r>
+        <r>    4.6145    1.0000 </r>
+        <r>    6.6931    0.0000 </r>
+        <r>    9.3115    0.0000 </r>
+        <r>    9.9136    0.0000 </r>
+        <r>   11.5290    0.0000 </r>
+        <r>   12.0205    0.0000 </r>
+        <r>   14.9257    0.0000 </r>
+        <r>   15.6013    0.0000 </r>
+        <r>   16.7193    0.0000 </r>
+        <r>   17.4018    0.0000 </r>
+        <r>   18.6757    0.0000 </r>
+       </set>
+       <set comment="kpoint 109">
+        <r>  -11.7007    1.0000 </r>
+        <r>  -11.6788    1.0000 </r>
+        <r>  -11.6617    1.0000 </r>
+        <r>  -11.6578    1.0000 </r>
+        <r>  -11.6498    1.0000 </r>
+        <r>   -5.1173    1.0000 </r>
+        <r>   -2.8406    1.0000 </r>
+        <r>    1.9246    1.0000 </r>
+        <r>    2.4926    1.0000 </r>
+        <r>    4.6956    1.0000 </r>
+        <r>    6.5850    0.0000 </r>
+        <r>    8.9754    0.0000 </r>
+        <r>    9.8836    0.0000 </r>
+        <r>   11.4924    0.0000 </r>
+        <r>   12.3720    0.0000 </r>
+        <r>   14.3644    0.0000 </r>
+        <r>   15.0985    0.0000 </r>
+        <r>   16.9278    0.0000 </r>
+        <r>   17.8061    0.0000 </r>
+        <r>   18.9671    0.0000 </r>
+       </set>
+       <set comment="kpoint 110">
+        <r>  -11.6984    1.0000 </r>
+        <r>  -11.6784    1.0000 </r>
+        <r>  -11.6641    1.0000 </r>
+        <r>  -11.6557    1.0000 </r>
+        <r>  -11.6516    1.0000 </r>
+        <r>   -5.2890    1.0000 </r>
+        <r>   -2.7007    1.0000 </r>
+        <r>    2.1307    1.0000 </r>
+        <r>    2.8064    1.0000 </r>
+        <r>    4.5585    1.0000 </r>
+        <r>    6.7398    0.0000 </r>
+        <r>    8.5293    0.0000 </r>
+        <r>    9.6841    0.0000 </r>
+        <r>   11.0963    0.0000 </r>
+        <r>   13.3049    0.0000 </r>
+        <r>   13.8959    0.0000 </r>
+        <r>   14.5569    0.0000 </r>
+        <r>   16.2889    0.0000 </r>
+        <r>   18.4304    0.0000 </r>
+        <r>   18.5343    0.0000 </r>
+       </set>
+       <set comment="kpoint 111">
+        <r>  -11.7100    1.0000 </r>
+        <r>  -11.6720    1.0000 </r>
+        <r>  -11.6695    1.0000 </r>
+        <r>  -11.6516    1.0000 </r>
+        <r>  -11.6480    1.0000 </r>
+        <r>   -5.1761    1.0000 </r>
+        <r>   -2.4899    1.0000 </r>
+        <r>    1.6939    1.0000 </r>
+        <r>    2.2637    1.0000 </r>
+        <r>    3.5846    1.0000 </r>
+        <r>    8.2203    0.0000 </r>
+        <r>    9.2344    0.0000 </r>
+        <r>   10.1201    0.0000 </r>
+        <r>   10.5406    0.0000 </r>
+        <r>   13.9006    0.0000 </r>
+        <r>   14.8459    0.0000 </r>
+        <r>   15.5226    0.0000 </r>
+        <r>   16.2449    0.0000 </r>
+        <r>   17.5435    0.0000 </r>
+        <r>   17.7606    0.0000 </r>
+       </set>
+       <set comment="kpoint 112">
+        <r>  -11.7096    1.0000 </r>
+        <r>  -11.6737    1.0000 </r>
+        <r>  -11.6673    1.0000 </r>
+        <r>  -11.6534    1.0000 </r>
+        <r>  -11.6470    1.0000 </r>
+        <r>   -5.0474    1.0000 </r>
+        <r>   -2.6353    1.0000 </r>
+        <r>    1.5012    1.0000 </r>
+        <r>    2.1123    1.0000 </r>
+        <r>    3.9483    1.0000 </r>
+        <r>    7.6991    0.0000 </r>
+        <r>    9.4885    0.0000 </r>
+        <r>   10.4147    0.0000 </r>
+        <r>   10.7478    0.0000 </r>
+        <r>   13.1390    0.0000 </r>
+        <r>   15.3146    0.0000 </r>
+        <r>   15.8356    0.0000 </r>
+        <r>   16.4050    0.0000 </r>
+        <r>   17.1818    0.0000 </r>
+        <r>   17.9348    0.0000 </r>
+       </set>
+       <set comment="kpoint 113">
+        <r>  -11.7075    1.0000 </r>
+        <r>  -11.6758    1.0000 </r>
+        <r>  -11.6643    1.0000 </r>
+        <r>  -11.6561    1.0000 </r>
+        <r>  -11.6471    1.0000 </r>
+        <r>   -4.9848    1.0000 </r>
+        <r>   -2.7590    1.0000 </r>
+        <r>    1.4707    1.0000 </r>
+        <r>    2.1049    1.0000 </r>
+        <r>    4.3060    1.0000 </r>
+        <r>    7.1977    0.0000 </r>
+        <r>    9.6341    0.0000 </r>
+        <r>   10.4699    0.0000 </r>
+        <r>   10.9633    0.0000 </r>
+        <r>   12.5170    0.0000 </r>
+        <r>   15.3466    0.0000 </r>
+        <r>   15.8657    0.0000 </r>
+        <r>   16.3382    0.0000 </r>
+        <r>   17.2949    0.0000 </r>
+        <r>   18.1090    0.0000 </r>
+       </set>
+       <set comment="kpoint 114">
+        <r>  -11.7042    1.0000 </r>
+        <r>  -11.6776    1.0000 </r>
+        <r>  -11.6609    1.0000 </r>
+        <r>  -11.6590    1.0000 </r>
+        <r>  -11.6481    1.0000 </r>
+        <r>   -5.0104    1.0000 </r>
+        <r>   -2.8307    1.0000 </r>
+        <r>    1.6133    1.0000 </r>
+        <r>    2.2353    1.0000 </r>
+        <r>    4.5976    1.0000 </r>
+        <r>    6.7805    0.0000 </r>
+        <r>    9.4313    0.0000 </r>
+        <r>   10.2610    0.0000 </r>
+        <r>   11.5260    0.0000 </r>
+        <r>   12.0111    0.0000 </r>
+        <r>   14.8376    0.0000 </r>
+        <r>   15.3480    0.0000 </r>
+        <r>   16.9428    0.0000 </r>
+        <r>   17.9705    0.0000 </r>
+        <r>   18.0703    0.0000 </r>
+       </set>
+       <set comment="kpoint 115">
+        <r>  -11.7146    1.0000 </r>
+        <r>  -11.6709    1.0000 </r>
+        <r>  -11.6700    1.0000 </r>
+        <r>  -11.6509    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -5.0294    1.0000 </r>
+        <r>   -2.4821    1.0000 </r>
+        <r>    1.1786    1.0000 </r>
+        <r>    2.1657    1.0000 </r>
+        <r>    3.4911    1.0000 </r>
+        <r>    8.4426    0.0000 </r>
+        <r>    9.1740    0.0000 </r>
+        <r>   10.6835    0.0000 </r>
+        <r>   10.9543    0.0000 </r>
+        <r>   13.6980    0.0000 </r>
+        <r>   15.3477    0.0000 </r>
+        <r>   16.3995    0.0000 </r>
+        <r>   16.4138    0.0000 </r>
+        <r>   16.8654    0.0000 </r>
+        <r>   17.6532    0.0000 </r>
+       </set>
+       <set comment="kpoint 116">
+        <r>  -11.7118    1.0000 </r>
+        <r>  -11.6731    1.0000 </r>
+        <r>  -11.6675    1.0000 </r>
+        <r>  -11.6533    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -4.9822    1.0000 </r>
+        <r>   -2.6134    1.0000 </r>
+        <r>    1.2333    1.0000 </r>
+        <r>    2.0619    1.0000 </r>
+        <r>    3.9041    1.0000 </r>
+        <r>    7.8158    0.0000 </r>
+        <r>    9.4824    0.0000 </r>
+        <r>   10.8004    0.0000 </r>
+        <r>   10.8460    0.0000 </r>
+        <r>   13.0867    0.0000 </r>
+        <r>   15.7389    0.0000 </r>
+        <r>   15.9173    0.0000 </r>
+        <r>   16.2758    0.0000 </r>
+        <r>   17.1442    0.0000 </r>
+        <r>   17.5650    0.0000 </r>
+       </set>
+       <set comment="kpoint 117">
+        <r>  -11.7052    1.0000 </r>
+        <r>  -11.6763    1.0000 </r>
+        <r>  -11.6647    1.0000 </r>
+        <r>  -11.6559    1.0000 </r>
+        <r>  -11.6480    1.0000 </r>
+        <r>   -5.0821    1.0000 </r>
+        <r>   -2.7280    1.0000 </r>
+        <r>    1.9309    1.0000 </r>
+        <r>    1.9390    1.0000 </r>
+        <r>    4.4492    1.0000 </r>
+        <r>    7.0012    0.0000 </r>
+        <r>    9.7638    0.0000 </r>
+        <r>    9.7728    0.0000 </r>
+        <r>   11.1242    0.0000 </r>
+        <r>   12.6776    0.0000 </r>
+        <r>   15.0408    0.0000 </r>
+        <r>   15.1626    0.0000 </r>
+        <r>   16.7601    0.0000 </r>
+        <r>   17.8416    0.0000 </r>
+        <r>   17.8668    0.0000 </r>
+       </set>
+       <set comment="kpoint 118">
+        <r>  -11.7059    1.0000 </r>
+        <r>  -11.6768    1.0000 </r>
+        <r>  -11.6619    1.0000 </r>
+        <r>  -11.6587    1.0000 </r>
+        <r>  -11.6470    1.0000 </r>
+        <r>   -4.9918    1.0000 </r>
+        <r>   -2.7854    1.0000 </r>
+        <r>    1.7602    1.0000 </r>
+        <r>    1.7962    1.0000 </r>
+        <r>    4.6987    1.0000 </r>
+        <r>    6.7341    0.0000 </r>
+        <r>    9.9670    0.0000 </r>
+        <r>   10.0685    0.0000 </r>
+        <r>   11.4897    0.0000 </r>
+        <r>   11.9630    0.0000 </r>
+        <r>   15.5165    0.0000 </r>
+        <r>   15.6496    0.0000 </r>
+        <r>   16.4180    0.0000 </r>
+        <r>   17.1564    0.0000 </r>
+        <r>   18.0180    0.0000 </r>
+       </set>
+       <set comment="kpoint 119">
+        <r>  -11.7093    1.0000 </r>
+        <r>  -11.6749    1.0000 </r>
+        <r>  -11.6650    1.0000 </r>
+        <r>  -11.6561    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -4.9722    1.0000 </r>
+        <r>   -2.6866    1.0000 </r>
+        <r>    1.4199    1.0000 </r>
+        <r>    1.8391    1.0000 </r>
+        <r>    4.3840    1.0000 </r>
+        <r>    7.1941    0.0000 </r>
+        <r>    9.7783    0.0000 </r>
+        <r>   10.5408    0.0000 </r>
+        <r>   11.1987    0.0000 </r>
+        <r>   12.5039    0.0000 </r>
+        <r>   15.5719    0.0000 </r>
+        <r>   16.2836    0.0000 </r>
+        <r>   16.2972    0.0000 </r>
+        <r>   16.9004    0.0000 </r>
+        <r>   17.3423    0.0000 </r>
+       </set>
+       <set comment="kpoint 120">
+        <r>  -11.7078    1.0000 </r>
+        <r>  -11.6761    1.0000 </r>
+        <r>  -11.6619    1.0000 </r>
+        <r>  -11.6591    1.0000 </r>
+        <r>  -11.6460    1.0000 </r>
+        <r>   -4.9519    1.0000 </r>
+        <r>   -2.7399    1.0000 </r>
+        <r>    1.5118    1.0000 </r>
+        <r>    1.7273    1.0000 </r>
+        <r>    4.6928    1.0000 </r>
+        <r>    6.8122    0.0000 </r>
+        <r>   10.0427    0.0000 </r>
+        <r>   10.3599    0.0000 </r>
+        <r>   11.5079    0.0000 </r>
+        <r>   12.0103    0.0000 </r>
+        <r>   15.8509    0.0000 </r>
+        <r>   16.0318    0.0000 </r>
+        <r>   16.1092    0.0000 </r>
+        <r>   17.1866    0.0000 </r>
+        <r>   17.2120    0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </array>
+   </eigenvalues>
+   <array>
+    <dimension dim="1">ion</dimension>
+    <dimension dim="2">band</dimension>
+    <dimension dim="3">kpoint</dimension>
+    <dimension dim="4">spin</dimension>
+    <field>  s</field>
+    <field> py</field>
+    <field> pz</field>
+    <field> px</field>
+    <field>dxy</field>
+    <field>dyz</field>
+    <field>dz2</field>
+    <field>dxz</field>
+    <field>dx2</field>
+    <set>
+     <set comment="spin1">
+      <set comment="kpoint 1">
+       <set comment="band 1">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.7032  0.0000  0.2739 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.2739  0.0000  0.7032 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0020  0.6203  0.0000  0.3555  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2145  0.2865  0.0000  0.4768  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7613  0.0710  0.0000  0.1455  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4246  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1656  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.3014  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5447  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0064  0.2944  0.1015  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0016  0.0726  0.0250  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.3260  0.0054  0.0709  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0804  0.0013  0.0175  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0699  0.1026  0.2299  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0172  0.0253  0.0567  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0759  0.0413  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.2595  0.1411  0.0142  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0322  0.0759  0.0132  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1101  0.2595  0.0452  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0132  0.0042  0.1040  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0452  0.0142  0.3554  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0194  0.0244  0.0000  0.0661  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0122  0.0154  0.0000  0.0416  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0328  0.0425  0.0000  0.0347  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0206  0.0268  0.0000  0.0218  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0577  0.0431  0.0000  0.0092  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0363  0.0271  0.0000  0.0058  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0965  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1658  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1787  0.0000  0.0133 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1052  0.0000  0.0079 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0133  0.0000  0.1787 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0078  0.0000  0.1052 </r>
+       </set>
+      </set>
+      <set comment="kpoint 2">
+       <set comment="band 1">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0002  0.0006  0.1107  0.0015  0.8641 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0013  0.0009  0.8641  0.0001  0.1106 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3270  0.3107  0.0000  0.3401  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4708  0.4841  0.0017  0.0207  0.0006 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1786  0.1814  0.0006  0.6156  0.0017 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4272  0.0001  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1637  0.0001  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2919  0.0017  0.0017  0.0017  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5351  0.0004  0.0004  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2343  0.1216  0.0470  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0565  0.0293  0.0113  0.0000  0.0000  0.0003  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0343  0.1470  0.2216  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0083  0.0354  0.0534  0.0000  0.0001  0.0003  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0051  0.1313  0.1313  0.1313  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0130  0.0322  0.0322  0.0322  0.0002  0.0002  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0108  0.0376  0.0376  0.0376  0.0010  0.0010  0.0000  0.0010  0.0000 </r>
+        <r>  0.0113  0.1236  0.1236  0.1236  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0118  0.0546  0.0480  0.0004  0.0003  0.0042  0.0001  0.0017 </r>
+        <r>  0.0000  0.0410  0.1896  0.1669  0.0001  0.0000  0.0023  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0645  0.0217  0.0282  0.0001  0.0002  0.0017  0.0004  0.0042 </r>
+        <r>  0.0000  0.2240  0.0754  0.0981  0.0000  0.0000  0.0009  0.0001  0.0023 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0007  0.0001  0.0001  0.0001  0.0306  0.0306  0.0000  0.0306  0.0000 </r>
+        <r>  0.0006  0.0048  0.0048  0.0048  0.0201  0.0201  0.0000  0.0201  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0102  0.0393  0.0000  0.0600  0.0001 </r>
+        <r>  0.0000  0.0023  0.0004  0.0015  0.0064  0.0246  0.0000  0.0375  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0628  0.0337  0.0001  0.0130  0.0000 </r>
+        <r>  0.0000  0.0005  0.0024  0.0013  0.0393  0.0211  0.0000  0.0082  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0832  0.0047  0.0047  0.0047  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.1466  0.0100  0.0100  0.0100  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0023  0.0001  0.0001  0.0001  0.0053  0.0053  0.0000  0.0053  0.0000 </r>
+        <r>  0.0043  0.0011  0.0011  0.0011  0.0027  0.0027  0.0000  0.0027  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0013  0.0015  0.0036  0.0000  0.0000  0.0649  0.0000  0.1222 </r>
+        <r>  0.0000  0.0032  0.0036  0.0086  0.0000  0.0000  0.0378  0.0000  0.0713 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0029  0.0028  0.0007  0.0000  0.0000  0.1222  0.0000  0.0649 </r>
+        <r>  0.0000  0.0071  0.0067  0.0016  0.0000  0.0000  0.0712  0.0000  0.0378 </r>
+       </set>
+      </set>
+      <set comment="kpoint 3">
+       <set comment="band 1">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.0104  0.0393  0.0090  0.9175 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0127  0.0029  0.9175  0.0043  0.0393 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3257  0.3260  0.0000  0.3260  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2374  0.6265  0.0074  0.0941  0.0126 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4015  0.0121  0.0126  0.5445  0.0074 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4352  0.0003  0.0003  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1578  0.0005  0.0005  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2671  0.0053  0.0053  0.0053  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5144  0.0013  0.0013  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1215  0.2573  0.0260  0.0001  0.0000  0.0003  0.0001  0.0000 </r>
+        <r>  0.0000  0.0273  0.0578  0.0058  0.0003  0.0000  0.0024  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1484  0.0126  0.2438  0.0000  0.0001  0.0000  0.0001  0.0003 </r>
+        <r>  0.0000  0.0333  0.0028  0.0547  0.0000  0.0003  0.0001  0.0002  0.0024 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0162  0.1243  0.1243  0.1243  0.0003  0.0003  0.0000  0.0003  0.0000 </r>
+        <r>  0.0441  0.0300  0.0300  0.0300  0.0006  0.0006  0.0000  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0288  0.0335  0.0335  0.0335  0.0022  0.0022  0.0000  0.0022  0.0000 </r>
+        <r>  0.0279  0.1021  0.1021  0.1021  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0278  0.0647  0.0077  0.0012  0.0001  0.0153  0.0005  0.0005 </r>
+        <r>  0.0000  0.1027  0.2393  0.0286  0.0001  0.0000  0.0076  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0390  0.0021  0.0591  0.0000  0.0011  0.0005  0.0007  0.0153 </r>
+        <r>  0.0000  0.1444  0.0077  0.2185  0.0000  0.0001  0.0002  0.0001  0.0076 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0039  0.0015  0.0015  0.0015  0.0234  0.0234  0.0000  0.0234  0.0000 </r>
+        <r>  0.0020  0.0100  0.0100  0.0100  0.0165  0.0165  0.0000  0.0165  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0003  0.0000  0.0006  0.0049  0.0683  0.0001  0.0367  0.0009 </r>
+        <r>  0.0000  0.0034  0.0004  0.0062  0.0029  0.0414  0.0000  0.0223  0.0002 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0003  0.0006  0.0000  0.0684  0.0050  0.0009  0.0365  0.0001 </r>
+        <r>  0.0000  0.0033  0.0063  0.0005  0.0415  0.0030  0.0002  0.0221  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0571  0.0126  0.0126  0.0126  0.0012  0.0012  0.0000  0.0012  0.0000 </r>
+        <r>  0.1053  0.0207  0.0207  0.0207  0.0003  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0085  0.0010  0.0010  0.0010  0.0114  0.0114  0.0000  0.0114  0.0000 </r>
+        <r>  0.0190  0.0106  0.0107  0.0106  0.0054  0.0054  0.0000  0.0054  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0082  0.0079  0.0015  0.0000  0.0000  0.1211  0.0000  0.0589 </r>
+        <r>  0.0000  0.0202  0.0194  0.0037  0.0001  0.0000  0.0683  0.0001  0.0332 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0035  0.0038  0.0103  0.0000  0.0001  0.0589  0.0000  0.1211 </r>
+        <r>  0.0000  0.0086  0.0094  0.0252  0.0000  0.0001  0.0332  0.0000  0.0683 </r>
+       </set>
+      </set>
+      <set comment="kpoint 4">
+       <set comment="band 1">
+        <r>  0.0000  0.0000  0.0002  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0305  0.0087  0.8992  0.0081  0.0299 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0010  0.0228  0.0299  0.0235  0.8992 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3258  0.3260  0.0000  0.3260  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3324  0.5619  0.0254  0.0366  0.0220 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2883  0.0586  0.0221  0.5839  0.0254 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4504  0.0005  0.0005  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1467  0.0011  0.0011  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2333  0.0089  0.0089  0.0089  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.4961  0.0021  0.0021  0.0021  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0737  0.2711  0.0647  0.0002  0.0000  0.0005  0.0001  0.0000 </r>
+        <r>  0.0000  0.0144  0.0531  0.0127  0.0006  0.0001  0.0054  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1993  0.0019  0.2083  0.0000  0.0002  0.0000  0.0002  0.0005 </r>
+        <r>  0.0000  0.0390  0.0004  0.0408  0.0000  0.0005  0.0000  0.0005  0.0054 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0261  0.1159  0.1159  0.1159  0.0005  0.0005  0.0000  0.0005  0.0000 </r>
+        <r>  0.0796  0.0271  0.0271  0.0271  0.0012  0.0012  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0448  0.0305  0.0305  0.0305  0.0029  0.0029  0.0000  0.0029  0.0000 </r>
+        <r>  0.0389  0.0876  0.0876  0.0876  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0216  0.0551  0.0077  0.0018  0.0002  0.0223  0.0007  0.0005 </r>
+        <r>  0.0000  0.0909  0.2323  0.0325  0.0000  0.0000  0.0097  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0347  0.0012  0.0485  0.0000  0.0016  0.0005  0.0011  0.0223 </r>
+        <r>  0.0000  0.1462  0.0049  0.2046  0.0000  0.0000  0.0002  0.0000  0.0097 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0074  0.0054  0.0054  0.0054  0.0190  0.0190  0.0000  0.0190  0.0000 </r>
+        <r>  0.0017  0.0134  0.0134  0.0134  0.0142  0.0142  0.0000  0.0142  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0005  0.0006  0.0022  0.0207  0.0743  0.0006  0.0166  0.0016 </r>
+        <r>  0.0000  0.0022  0.0027  0.0097  0.0118  0.0424  0.0001  0.0095  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0017  0.0016  0.0000  0.0537  0.0001  0.0016  0.0578  0.0006 </r>
+        <r>  0.0000  0.0075  0.0070  0.0000  0.0306  0.0000  0.0003  0.0330  0.0001 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0410  0.0219  0.0219  0.0219  0.0017  0.0017  0.0000  0.0017  0.0000 </r>
+        <r>  0.0814  0.0303  0.0303  0.0303  0.0005  0.0005  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0063  0.0159  0.0044  0.0002  0.0000  0.1596  0.0001  0.0179 </r>
+        <r>  0.0000  0.0155  0.0395  0.0108  0.0001  0.0000  0.0849  0.0001  0.0095 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0114  0.0018  0.0133  0.0000  0.0001  0.0179  0.0001  0.1597 </r>
+        <r>  0.0000  0.0284  0.0044  0.0331  0.0000  0.0001  0.0095  0.0001  0.0850 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0052  0.0015  0.0015  0.0015  0.0170  0.0170  0.0000  0.0170  0.0000 </r>
+        <r>  0.0166  0.0199  0.0199  0.0199  0.0064  0.0064  0.0000  0.0064  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 5">
+       <set comment="band 1">
+        <r>  0.0000  0.0000  0.0002  0.0002  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0329  0.0362  0.6338  0.0014  0.2717 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0141  0.0107  0.2718  0.0455  0.6339 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3261  0.3264  0.0000  0.3252  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2116  0.0981  0.0248  0.5984  0.0459 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3936  0.5067  0.0459  0.0078  0.0248 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4752  0.0008  0.0008  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1283  0.0020  0.0020  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1921  0.0115  0.0115  0.0115  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.4898  0.0023  0.0023  0.0023  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1617  0.0890  0.1678  0.0001  0.0002  0.0002  0.0001  0.0005 </r>
+        <r>  0.0000  0.0249  0.0137  0.0259  0.0003  0.0006  0.0030  0.0005  0.0064 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1173  0.1900  0.1112  0.0002  0.0001  0.0005  0.0001  0.0002 </r>
+        <r>  0.0000  0.0181  0.0293  0.0171  0.0006  0.0004  0.0064  0.0004  0.0030 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0311  0.1082  0.1082  0.1082  0.0008  0.0008  0.0000  0.0008  0.0000 </r>
+        <r>  0.1118  0.0236  0.0236  0.0236  0.0019  0.0019  0.0000  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0592  0.0276  0.0276  0.0276  0.0033  0.0033  0.0000  0.0033  0.0000 </r>
+        <r>  0.0441  0.0789  0.0789  0.0789  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0077  0.0433  0.0153  0.0022  0.0008  0.0262  0.0004  0.0006 </r>
+        <r>  0.0000  0.0412  0.2315  0.0819  0.0000  0.0000  0.0090  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0366  0.0009  0.0289  0.0000  0.0015  0.0006  0.0019  0.0262 </r>
+        <r>  0.0000  0.1953  0.0049  0.1545  0.0000  0.0000  0.0002  0.0000  0.0090 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0104  0.0119  0.0119  0.0119  0.0163  0.0163  0.0000  0.0163  0.0000 </r>
+        <r>  0.0007  0.0162  0.0162  0.0162  0.0127  0.0127  0.0000  0.0127  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0039  0.0006  0.0023  0.0099  0.0387  0.0005  0.0668  0.0032 </r>
+        <r>  0.0000  0.0109  0.0016  0.0063  0.0051  0.0198  0.0000  0.0343  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0006  0.0039  0.0023  0.0670  0.0383  0.0032  0.0101  0.0005 </r>
+        <r>  0.0000  0.0017  0.0109  0.0062  0.0344  0.0196  0.0003  0.0052  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0240  0.0354  0.0354  0.0354  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0612  0.0485  0.0485  0.0485  0.0007  0.0007  0.0000  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0117  0.0203  0.0014  0.0006  0.0000  0.1624  0.0003  0.0157 </r>
+        <r>  0.0000  0.0290  0.0504  0.0034  0.0000  0.0000  0.0791  0.0000  0.0077 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0105  0.0020  0.0208  0.0001  0.0006  0.0157  0.0003  0.1625 </r>
+        <r>  0.0000  0.0262  0.0049  0.0518  0.0000  0.0000  0.0077  0.0000  0.0791 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0006  0.0006  0.0006  0.0274  0.0275  0.0000  0.0275  0.0000 </r>
+        <r>  0.0043  0.0200  0.0201  0.0201  0.0055  0.0055  0.0000  0.0055  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 6">
+       <set comment="band 1">
+        <r>  0.0000  0.0003  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0306  0.0064  0.4756  0.0487  0.4143 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0002  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0267  0.0507  0.4142  0.0083  0.4757 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3261  0.3260  0.0000  0.3256  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2424  0.1134  0.0351  0.5373  0.0510 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3527  0.4820  0.0510  0.0584  0.0350 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5145  0.0009  0.0009  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0988  0.0032  0.0032  0.0032  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1405  0.0131  0.0132  0.0131  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5011  0.0020  0.0020  0.0020  0.0002  0.0002  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1162  0.2782  0.0390  0.0002  0.0000  0.0007  0.0001  0.0000 </r>
+        <r>  0.0000  0.0118  0.0282  0.0040  0.0012  0.0002  0.0135  0.0005  0.0005 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1728  0.0107  0.2499  0.0000  0.0002  0.0000  0.0001  0.0007 </r>
+        <r>  0.0000  0.0175  0.0011  0.0253  0.0000  0.0010  0.0005  0.0007  0.0135 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0296  0.1037  0.1037  0.1037  0.0009  0.0009  0.0000  0.0009  0.0000 </r>
+        <r>  0.1400  0.0192  0.0192  0.0192  0.0024  0.0024  0.0000  0.0024  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0737  0.0234  0.0234  0.0234  0.0037  0.0037  0.0000  0.0037  0.0000 </r>
+        <r>  0.0424  0.0751  0.0751  0.0751  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0262  0.0171  0.0016  0.0015  0.0001  0.0165  0.0023  0.0124 </r>
+        <r>  0.0000  0.2126  0.1387  0.0132  0.0000  0.0000  0.0037  0.0000  0.0028 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0037  0.0128  0.0283  0.0011  0.0025  0.0124  0.0003  0.0165 </r>
+        <r>  0.0000  0.0303  0.1043  0.2298  0.0000  0.0000  0.0028  0.0000  0.0037 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0121  0.0203  0.0203  0.0203  0.0143  0.0143  0.0000  0.0143  0.0000 </r>
+        <r>  0.0001  0.0184  0.0184  0.0184  0.0119  0.0119  0.0000  0.0119  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0041  0.0058  0.0002  0.0709  0.0022  0.0046  0.0498  0.0007 </r>
+        <r>  0.0000  0.0096  0.0136  0.0004  0.0303  0.0009  0.0002  0.0213  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0026  0.0009  0.0065  0.0110  0.0797  0.0007  0.0321  0.0046 </r>
+        <r>  0.0000  0.0062  0.0021  0.0153  0.0047  0.0341  0.0000  0.0137  0.0002 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0015  0.0463  0.0468  0.0463  0.0064  0.0066  0.0000  0.0067  0.0000 </r>
+        <r>  0.0223  0.0672  0.0675  0.0671  0.0021  0.0022  0.0000  0.0022  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0323  0.0060  0.0106  0.0015  0.0021  0.0248  0.0063  0.1208 </r>
+        <r>  0.0000  0.0661  0.0119  0.0221  0.0005  0.0006  0.0115  0.0022  0.0546 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0002  0.0245  0.0213  0.0035  0.0043  0.1316  0.0000  0.0240 </r>
+        <r>  0.0000  0.0008  0.0545  0.0440  0.0010  0.0012  0.0573  0.0000  0.0112 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0072  0.0009  0.0008  0.0013  0.0367  0.0459  0.0024  0.0375  0.0019 </r>
+        <r>  0.0028  0.0055  0.0055  0.0059  0.0040  0.0012  0.0005  0.0046  0.0003 </r>
+       </set>
+      </set>
+      <set comment="kpoint 7">
+       <set comment="band 1">
+        <r>  0.0000  0.0004  0.0002  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0290  0.0069  0.4046  0.0586  0.4763 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0003  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0341  0.0562  0.4760  0.0043  0.4046 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3261  0.3258  0.0000  0.3257  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1334  0.1786  0.0215  0.5726  0.0733 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4559  0.4110  0.0737  0.0173  0.0215 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5720  0.0006  0.0006  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0549  0.0045  0.0045  0.0045  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0748  0.0144  0.0144  0.0144  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5334  0.0011  0.0011  0.0011  0.0003  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2795  0.0437  0.1297  0.0000  0.0001  0.0001  0.0001  0.0004 </r>
+        <r>  0.0000  0.0126  0.0020  0.0059  0.0002  0.0006  0.0027  0.0013  0.0159 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0224  0.2582  0.1722  0.0001  0.0001  0.0004  0.0000  0.0001 </r>
+        <r>  0.0000  0.0010  0.0117  0.0078  0.0012  0.0008  0.0159  0.0001  0.0027 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0204  0.1053  0.1053  0.1053  0.0007  0.0007  0.0000  0.0007  0.0000 </r>
+        <r>  0.1688  0.0123  0.0123  0.0124  0.0028  0.0028  0.0000  0.0028  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0909  0.0156  0.0156  0.0156  0.0043  0.0043  0.0000  0.0043  0.0000 </r>
+        <r>  0.0302  0.0768  0.0768  0.0768  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0083  0.0123  0.0004  0.0026  0.0001  0.0266  0.0018  0.0037 </r>
+        <r>  0.0000  0.1511  0.2234  0.0071  0.0000  0.0000  0.0027  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0057  0.0017  0.0136  0.0004  0.0029  0.0037  0.0012  0.0266 </r>
+        <r>  0.0000  0.1033  0.0309  0.2473  0.0000  0.0000  0.0004  0.0000  0.0027 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0115  0.0310  0.0310  0.0310  0.0122  0.0122  0.0000  0.0122  0.0000 </r>
+        <r>  0.0000  0.0189  0.0189  0.0189  0.0118  0.0118  0.0000  0.0118  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0062  0.0011  0.0039  0.0132  0.0484  0.0011  0.0768  0.0064 </r>
+        <r>  0.0000  0.0168  0.0029  0.0106  0.0039  0.0143  0.0000  0.0227  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0013  0.0064  0.0035  0.0791  0.0438  0.0065  0.0155  0.0011 </r>
+        <r>  0.0000  0.0034  0.0172  0.0096  0.0234  0.0130  0.0001  0.0046  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0049  0.0362  0.0362  0.0362  0.0185  0.0185  0.0000  0.0185  0.0000 </r>
+        <r>  0.0022  0.0594  0.0594  0.0595  0.0043  0.0043  0.0000  0.0043  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0087  0.0118  0.0325  0.0138  0.0383  0.0000  0.0102  0.0001 </r>
+        <r>  0.0000  0.0048  0.0065  0.0179  0.0160  0.0443  0.0004  0.0118  0.0009 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0266  0.0234  0.0028  0.0277  0.0032  0.0001  0.0315  0.0001 </r>
+        <r>  0.0000  0.0145  0.0127  0.0016  0.0321  0.0037  0.0008  0.0363  0.0004 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0022  0.0035  0.0045  0.0011  0.0018  0.1339  0.0007  0.1317 </r>
+        <r>  0.0000  0.0165  0.0271  0.0349  0.0029  0.0042  0.0319  0.0019  0.0314 </r>
+       </set>
+      </set>
+      <set comment="kpoint 8">
+       <set comment="band 1">
+        <r>  0.0000  0.0002  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0621  0.0054  0.8302  0.0309  0.0465 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0035  0.0602  0.0465  0.0347  0.8302 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3259  0.3259  0.0000  0.3259  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3124  0.5356  0.0526  0.0327  0.0463 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2748  0.0515  0.0463  0.5544  0.0526 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6314  0.0001  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0085  0.0057  0.0057  0.0057  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0113  0.0154  0.0154  0.0154  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5741  0.0002  0.0002  0.0002  0.0003  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1710  0.0162  0.2817  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0010  0.0001  0.0016  0.0001  0.0014  0.0011  0.0008  0.0207 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1416  0.2964  0.0309  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0008  0.0017  0.0002  0.0014  0.0001  0.0207  0.0007  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0041  0.1146  0.1146  0.1146  0.0001  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.2004  0.0024  0.0024  0.0024  0.0031  0.0031  0.0000  0.0031  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.1109  0.0031  0.0031  0.0031  0.0049  0.0050  0.0000  0.0049  0.0000 </r>
+        <r>  0.0062  0.0842  0.0842  0.0842  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0007  0.0018  0.0002  0.0031  0.0004  0.0303  0.0013  0.0008 </r>
+        <r>  0.0000  0.1055  0.2575  0.0333  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0011  0.0000  0.0016  0.0001  0.0028  0.0008  0.0019  0.0303 </r>
+        <r>  0.0000  0.1587  0.0068  0.2309  0.0000  0.0000  0.0000  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0054  0.0509  0.0509  0.0509  0.0059  0.0059  0.0000  0.0059  0.0000 </r>
+        <r>  0.0001  0.0107  0.0107  0.0107  0.0142  0.0142  0.0000  0.0142  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0002  0.0022  0.0024  0.0817  0.0908  0.0075  0.0077  0.0035 </r>
+        <r>  0.0000  0.0019  0.0197  0.0219  0.0063  0.0070  0.0000  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0030  0.0010  0.0008  0.0385  0.0293  0.0035  0.1124  0.0075 </r>
+        <r>  0.0000  0.0271  0.0093  0.0071  0.0030  0.0023  0.0000  0.0087  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0169  0.0147  0.0147  0.0147  0.0271  0.0271  0.0000  0.0271  0.0000 </r>
+        <r>  0.0000  0.0618  0.0618  0.0618  0.0027  0.0027  0.0000  0.0027  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0080  0.0348  0.0122  0.0142  0.0050  0.0010  0.0032  0.0001 </r>
+        <r>  0.0000  0.0010  0.0044  0.0015  0.0660  0.0231  0.0001  0.0151  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0287  0.0018  0.0245  0.0007  0.0099  0.0001  0.0117  0.0010 </r>
+        <r>  0.0000  0.0036  0.0002  0.0031  0.0035  0.0464  0.0000  0.0544  0.0001 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0013  0.0001  0.0041  0.0003  0.0001  0.0167  0.0007  0.3242 </r>
+        <r>  0.0001  0.0397  0.0034  0.0696  0.0001  0.0010  0.0012  0.0006  0.0202 </r>
+       </set>
+      </set>
+      <set comment="kpoint 9">
+       <set comment="band 1">
+        <r>  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9769  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9772 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9778  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.2108  0.0000  0.7671  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.7671  0.0000  0.2108  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4279  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1631  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2896  0.0000  0.0059  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5333  0.0000  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1815  0.0000  0.2125  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0467  0.0000  0.0547  0.0000  0.0002  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2125  0.0000  0.1815  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0547  0.0000  0.0467  0.0000  0.0002  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0057  0.0000  0.4115  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0163  0.0000  0.0848  0.0000  0.0000  0.0000  0.0017  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0116  0.0000  0.0829  0.0000  0.0000  0.0000  0.0105  0.0000  0.0000 </r>
+        <r>  0.0099  0.0000  0.3722  0.0000  0.0000  0.0000  0.0051  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0904  0.0000  0.0398  0.0000  0.0022  0.0000  0.0010  0.0000 </r>
+        <r>  0.0000  0.2747  0.0000  0.1209  0.0000  0.0003  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0398  0.0000  0.0904  0.0000  0.0010  0.0000  0.0022  0.0000 </r>
+        <r>  0.0000  0.1209  0.0000  0.2747  0.0000  0.0001  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0931  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0609  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0001  0.0000  0.0025  0.0000  0.1055  0.0000 </r>
+        <r>  0.0000  0.0004  0.0000  0.0175  0.0000  0.0016  0.0000  0.0662  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.1055  0.0000  0.0025  0.0000 </r>
+        <r>  0.0000  0.0175  0.0000  0.0004  0.0000  0.0662  0.0000  0.0016  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0757  0.0000  0.0043  0.0000  0.0000  0.0000  0.0327  0.0000  0.0000 </r>
+        <r>  0.1326  0.0000  0.0088  0.0000  0.0000  0.0000  0.0189  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0170  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0082  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1926 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1127 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0102  0.0000  0.0210  0.0000  0.0000  0.0000  0.1516  0.0000  0.0000 </r>
+        <r>  0.0191  0.0000  0.0488  0.0000  0.0000  0.0000  0.0872  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 10">
+       <set comment="band 1">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0009  0.0013  0.9730  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0072  0.0000  0.0072  0.9627 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9361  0.0206  0.0003  0.0207  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0407  0.4675  0.0032  0.4666  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4814  0.0000  0.4823  0.0144 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4342  0.0001  0.0006  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1586  0.0001  0.0011  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2718  0.0015  0.0105  0.0015  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5192  0.0004  0.0024  0.0004  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1937  0.0000  0.1937  0.0000  0.0002  0.0000  0.0002  0.0001 </r>
+        <r>  0.0000  0.0507  0.0000  0.0507  0.0000  0.0005  0.0000  0.0005  0.0006 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0021  0.1890  0.0064  0.1890  0.0001  0.0002  0.0001  0.0002  0.0000 </r>
+        <r>  0.0047  0.0499  0.0009  0.0499  0.0003  0.0004  0.0005  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0099  0.0017  0.4172  0.0017  0.0000  0.0001  0.0002  0.0001  0.0000 </r>
+        <r>  0.0350  0.0006  0.0651  0.0006  0.0000  0.0002  0.0037  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0205  0.0002  0.0544  0.0002  0.0000  0.0004  0.0145  0.0004  0.0000 </r>
+        <r>  0.0128  0.0002  0.3571  0.0002  0.0000  0.0000  0.0058  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0048  0.0647  0.0002  0.0647  0.0020  0.0022  0.0029  0.0022  0.0000 </r>
+        <r>  0.0059  0.1754  0.0034  0.1754  0.0004  0.0002  0.0014  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0653  0.0000  0.0653  0.0000  0.0024  0.0000  0.0024  0.0056 </r>
+        <r>  0.0000  0.1855  0.0000  0.1856  0.0000  0.0002  0.0000  0.0002  0.0031 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0004  0.0000  0.0001  0.0000  0.0794  0.0004  0.0001  0.0004  0.0000 </r>
+        <r>  0.0003  0.0082  0.0000  0.0082  0.0542  0.0005  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0018  0.0005  0.0015  0.0005  0.0059  0.0494  0.0000  0.0494  0.0000 </r>
+        <r>  0.0012  0.0089  0.0022  0.0089  0.0031  0.0306  0.0000  0.0306  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0540  0.0000  0.0540  0.0011 </r>
+        <r>  0.0000  0.0134  0.0000  0.0134  0.0000  0.0330  0.0000  0.0330  0.0004 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0601  0.0058  0.0044  0.0058  0.0001  0.0001  0.0447  0.0001  0.0000 </r>
+        <r>  0.1094  0.0134  0.0088  0.0134  0.0000  0.0001  0.0249  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0032  0.0000  0.0032  0.0000  0.0001  0.0000  0.0001  0.1875 </r>
+        <r>  0.0000  0.0082  0.0000  0.0082  0.0000  0.0001  0.0000  0.0001  0.1081 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0235  0.0042  0.0005  0.0042  0.0000 </r>
+        <r>  0.0004  0.0016  0.0001  0.0016  0.0106  0.0019  0.0003  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0117  0.0000  0.0342  0.0000  0.0000  0.0001  0.1362  0.0001  0.0000 </r>
+        <r>  0.0235  0.0000  0.0794  0.0000  0.0000  0.0000  0.0755  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 11">
+       <set comment="band 1">
+        <r>  0.0001  0.0000  0.0003  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0077  0.0047  0.9590  0.0047  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0246  0.0000  0.0247  0.9275 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8366  0.0696  0.0021  0.0694  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1334  0.4026  0.0151  0.4272  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4768  0.0000  0.4522  0.0494 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4469  0.0002  0.0010  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1495  0.0005  0.0019  0.0005  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2428  0.0048  0.0137  0.0048  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5025  0.0012  0.0027  0.0012  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1917  0.0000  0.1917  0.0000  0.0003  0.0000  0.0003  0.0003 </r>
+        <r>  0.0000  0.0488  0.0000  0.0488  0.0000  0.0007  0.0000  0.0007  0.0023 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0066  0.1766  0.0206  0.1766  0.0004  0.0002  0.0002  0.0002  0.0000 </r>
+        <r>  0.0141  0.0466  0.0017  0.0466  0.0009  0.0005  0.0020  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0122  0.0044  0.4175  0.0044  0.0000  0.0002  0.0000  0.0002  0.0000 </r>
+        <r>  0.0596  0.0019  0.0385  0.0019  0.0000  0.0007  0.0061  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0309  0.0008  0.0269  0.0008  0.0000  0.0012  0.0161  0.0012  0.0000 </r>
+        <r>  0.0121  0.0005  0.3522  0.0005  0.0000  0.0000  0.0044  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0120  0.0609  0.0002  0.0609  0.0043  0.0019  0.0076  0.0019  0.0000 </r>
+        <r>  0.0159  0.1495  0.0106  0.1495  0.0005  0.0000  0.0032  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0606  0.0000  0.0606  0.0000  0.0026  0.0000  0.0026  0.0151 </r>
+        <r>  0.0000  0.1732  0.0000  0.1732  0.0000  0.0001  0.0000  0.0001  0.0078 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0028  0.0009  0.0006  0.0009  0.0669  0.0009  0.0006  0.0009  0.0000 </r>
+        <r>  0.0011  0.0172  0.0001  0.0172  0.0476  0.0011  0.0002  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0035  0.0016  0.0059  0.0016  0.0154  0.0438  0.0000  0.0438  0.0000 </r>
+        <r>  0.0013  0.0044  0.0069  0.0044  0.0078  0.0261  0.0000  0.0260  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0018  0.0000  0.0018  0.0000  0.0552  0.0000  0.0552  0.0036 </r>
+        <r>  0.0000  0.0136  0.0000  0.0136  0.0000  0.0316  0.0000  0.0316  0.0010 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0430  0.0168  0.0053  0.0168  0.0005  0.0000  0.0469  0.0000  0.0000 </r>
+        <r>  0.0848  0.0337  0.0092  0.0337  0.0001  0.0000  0.0244  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0089  0.0000  0.0089  0.0000  0.0003  0.0000  0.0003  0.1791 </r>
+        <r>  0.0000  0.0233  0.0000  0.0233  0.0000  0.0003  0.0000  0.0003  0.0996 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0002  0.0000  0.0004  0.0000  0.0261  0.0111  0.0032  0.0110  0.0000 </r>
+        <r>  0.0012  0.0069  0.0006  0.0069  0.0106  0.0044  0.0016  0.0044  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0093  0.0002  0.0445  0.0002  0.0001  0.0005  0.1312  0.0005  0.0000 </r>
+        <r>  0.0214  0.0004  0.1044  0.0004  0.0000  0.0001  0.0683  0.0001  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 12">
+       <set comment="band 1">
+        <r>  0.0001  0.0000  0.0004  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0202  0.0081  0.9392  0.0081  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0388  0.0000  0.0388  0.8989 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7113  0.1316  0.0032  0.1317  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2464  0.3499  0.0334  0.3488  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4500  0.0000  0.4509  0.0778 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4682  0.0005  0.0013  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1339  0.0012  0.0028  0.0012  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2052  0.0081  0.0150  0.0081  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.4934  0.0019  0.0025  0.0019  0.0001  0.0001  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1916  0.0000  0.1916  0.0000  0.0003  0.0000  0.0003  0.0007 </r>
+        <r>  0.0000  0.0451  0.0000  0.0451  0.0000  0.0009  0.0000  0.0009  0.0050 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0112  0.1629  0.0418  0.1629  0.0007  0.0002  0.0004  0.0002  0.0000 </r>
+        <r>  0.0214  0.0414  0.0013  0.0414  0.0018  0.0004  0.0048  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0105  0.0078  0.4082  0.0078  0.0001  0.0002  0.0001  0.0002  0.0000 </r>
+        <r>  0.0872  0.0040  0.0109  0.0040  0.0002  0.0013  0.0083  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0435  0.0018  0.0042  0.0018  0.0001  0.0023  0.0159  0.0023  0.0000 </r>
+        <r>  0.0076  0.0010  0.3517  0.0010  0.0000  0.0000  0.0017  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0170  0.0564  0.0000  0.0564  0.0052  0.0013  0.0115  0.0013  0.0000 </r>
+        <r>  0.0245  0.1333  0.0212  0.1333  0.0002  0.0000  0.0038  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0544  0.0000  0.0544  0.0000  0.0025  0.0000  0.0025  0.0220 </r>
+        <r>  0.0000  0.1666  0.0000  0.1666  0.0000  0.0000  0.0000  0.0000  0.0103 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0056  0.0051  0.0022  0.0051  0.0597  0.0011  0.0010  0.0011  0.0000 </r>
+        <r>  0.0010  0.0212  0.0006  0.0212  0.0427  0.0015  0.0002  0.0015  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0040  0.0025  0.0124  0.0025  0.0229  0.0401  0.0005  0.0401  0.0000 </r>
+        <r>  0.0006  0.0021  0.0132  0.0021  0.0105  0.0225  0.0000  0.0225  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0039  0.0000  0.0039  0.0000  0.0577  0.0000  0.0577  0.0058 </r>
+        <r>  0.0000  0.0135  0.0000  0.0135  0.0000  0.0294  0.0000  0.0294  0.0011 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0278  0.0290  0.0093  0.0290  0.0004  0.0001  0.0452  0.0001  0.0000 </r>
+        <r>  0.0640  0.0512  0.0126  0.0512  0.0000  0.0000  0.0210  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0139  0.0000  0.0140  0.0000  0.0007  0.0000  0.0007  0.1738 </r>
+        <r>  0.0000  0.0356  0.0000  0.0356  0.0000  0.0002  0.0000  0.0002  0.0911 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0012  0.0000  0.0295  0.0184  0.0064  0.0185  0.0000 </r>
+        <r>  0.0007  0.0119  0.0010  0.0119  0.0096  0.0051  0.0029  0.0050  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0031  0.0008  0.0558  0.0008  0.0003  0.0031  0.1309  0.0031  0.0000 </r>
+        <r>  0.0118  0.0010  0.1268  0.0010  0.0000  0.0000  0.0629  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 13">
+       <set comment="band 1">
+        <r>  0.0002  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0338  0.0106  0.9202  0.0106  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0463  0.0000  0.0464  0.8833 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.5905  0.1922  0.0029  0.1922  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3538  0.2866  0.0523  0.2862  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4429  0.0000  0.4432  0.0931 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5021  0.0006  0.0015  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1086  0.0022  0.0039  0.0022  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1579  0.0108  0.0154  0.0108  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.4990  0.0020  0.0019  0.0020  0.0001  0.0002  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1942  0.0000  0.1942  0.0000  0.0003  0.0000  0.0003  0.0011 </r>
+        <r>  0.0000  0.0393  0.0000  0.0393  0.0000  0.0010  0.0000  0.0010  0.0085 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0146  0.1471  0.0775  0.1471  0.0009  0.0003  0.0003  0.0003  0.0000 </r>
+        <r>  0.0215  0.0338  0.0001  0.0338  0.0024  0.0002  0.0089  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0059  0.0152  0.3629  0.0152  0.0003  0.0001  0.0010  0.0001  0.0000 </r>
+        <r>  0.1154  0.0076  0.0004  0.0076  0.0004  0.0020  0.0084  0.0020  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0583  0.0039  0.0042  0.0039  0.0002  0.0037  0.0134  0.0037  0.0000 </r>
+        <r>  0.0023  0.0033  0.3300  0.0033  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0181  0.0502  0.0006  0.0502  0.0056  0.0007  0.0153  0.0007  0.0000 </r>
+        <r>  0.0315  0.1226  0.0407  0.1226  0.0000  0.0001  0.0031  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0472  0.0000  0.0472  0.0000  0.0025  0.0000  0.0025  0.0260 </r>
+        <r>  0.0000  0.1660  0.0000  0.1660  0.0000  0.0000  0.0000  0.0000  0.0101 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0077  0.0121  0.0048  0.0121  0.0566  0.0009  0.0013  0.0009  0.0000 </r>
+        <r>  0.0003  0.0235  0.0012  0.0235  0.0394  0.0017  0.0002  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0040  0.0033  0.0204  0.0033  0.0282  0.0380  0.0013  0.0380  0.0000 </r>
+        <r>  0.0001  0.0012  0.0204  0.0012  0.0109  0.0198  0.0000  0.0198  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0057  0.0000  0.0057  0.0000  0.0621  0.0000  0.0622  0.0077 </r>
+        <r>  0.0000  0.0144  0.0000  0.0144  0.0000  0.0260  0.0000  0.0260  0.0008 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0080  0.0416  0.0259  0.0418  0.0002  0.0040  0.0299  0.0041  0.0000 </r>
+        <r>  0.0368  0.0681  0.0331  0.0682  0.0000  0.0014  0.0105  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0206  0.0000  0.0205  0.0000  0.0031  0.0000  0.0030  0.1559 </r>
+        <r>  0.0000  0.0454  0.0000  0.0453  0.0000  0.0002  0.0000  0.0002  0.0763 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0062  0.0004  0.0089  0.0001  0.0252  0.0414  0.0147  0.0475  0.0001 </r>
+        <r>  0.0011  0.0044  0.0416  0.0046  0.0060  0.0002  0.0081  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0007  0.0001  0.0495  0.0006  0.0108  0.0012  0.0999  0.0015  0.0022 </r>
+        <r>  0.0003  0.0076  0.0589  0.0061  0.0014  0.0034  0.0457  0.0159  0.0005 </r>
+       </set>
+      </set>
+      <set comment="kpoint 14">
+       <set comment="band 1">
+        <r>  0.0002  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0459  0.0122  0.9045  0.0122  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0489  0.0000  0.0489  0.8778 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4890  0.2434  0.0018  0.2435  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4434  0.2336  0.0688  0.2334  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4405  0.0000  0.4407  0.0982 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5535  0.0006  0.0012  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0698  0.0035  0.0050  0.0035  0.0000  0.0000  0.0006  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0970  0.0129  0.0153  0.0129  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5242  0.0016  0.0009  0.0016  0.0002  0.0003  0.0001  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2003  0.0000  0.2003  0.0000  0.0002  0.0000  0.0002  0.0013 </r>
+        <r>  0.0000  0.0311  0.0000  0.0311  0.0000  0.0010  0.0000  0.0010  0.0126 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0158  0.1192  0.1518  0.1192  0.0008  0.0003  0.0001  0.0003  0.0000 </r>
+        <r>  0.0098  0.0216  0.0029  0.0216  0.0024  0.0000  0.0148  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0033  0.0393  0.2498  0.0393  0.0006  0.0000  0.0030  0.0000  0.0000 </r>
+        <r>  0.1434  0.0144  0.0158  0.0144  0.0012  0.0025  0.0041  0.0025  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0759  0.0098  0.0297  0.0098  0.0010  0.0049  0.0072  0.0049  0.0000 </r>
+        <r>  0.0007  0.0155  0.2510  0.0155  0.0000  0.0001  0.0014  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0113  0.0383  0.0075  0.0383  0.0053  0.0001  0.0207  0.0001  0.0000 </r>
+        <r>  0.0364  0.1080  0.0914  0.1080  0.0001  0.0004  0.0013  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0381  0.0000  0.0381  0.0000  0.0024  0.0000  0.0024  0.0282 </r>
+        <r>  0.0000  0.1706  0.0000  0.1707  0.0000  0.0001  0.0000  0.0001  0.0080 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0083  0.0208  0.0082  0.0208  0.0563  0.0005  0.0017  0.0005  0.0000 </r>
+        <r>  0.0000  0.0248  0.0014  0.0248  0.0368  0.0018  0.0001  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0036  0.0046  0.0294  0.0046  0.0334  0.0370  0.0024  0.0370  0.0000 </r>
+        <r>  0.0000  0.0006  0.0279  0.0006  0.0091  0.0175  0.0000  0.0175  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0059  0.0000  0.0059  0.0000  0.0716  0.0000  0.0716  0.0100 </r>
+        <r>  0.0000  0.0169  0.0000  0.0169  0.0000  0.0197  0.0000  0.0197  0.0004 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0016  0.0313  0.0461  0.0313  0.0027  0.0229  0.0064  0.0229  0.0000 </r>
+        <r>  0.0051  0.0522  0.0636  0.0522  0.0000  0.0080  0.0007  0.0080  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0302  0.0000  0.0302  0.0000  0.0245  0.0000  0.0245  0.0107 </r>
+        <r>  0.0000  0.0239  0.0000  0.0239  0.0000  0.0270  0.0000  0.0270  0.0091 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0067  0.0236  0.0171  0.0239  0.0223  0.0139  0.0148  0.0145  0.0001 </r>
+        <r>  0.0115  0.0277  0.0135  0.0293  0.0231  0.0092  0.0137  0.0099  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0018  0.0000  0.0013  0.0002  0.0061  0.0001  0.0069  0.2283 </r>
+        <r>  0.0000  0.0258  0.0000  0.0240  0.0001  0.0159  0.0000  0.0144  0.0715 </r>
+       </set>
+      </set>
+      <set comment="kpoint 15">
+       <set comment="band 1">
+        <r>  0.0002  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0558  0.0131  0.8927  0.0131  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0484  0.0000  0.0483  0.8786 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4059  0.2854  0.0009  0.2855  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.5167  0.1906  0.0814  0.1906  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4412  0.0000  0.4412  0.0971 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6165  0.0002  0.0005  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0213  0.0050  0.0057  0.0050  0.0000  0.0000  0.0007  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0286  0.0146  0.0152  0.0146  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5652  0.0006  0.0001  0.0006  0.0003  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0141  0.0690  0.2600  0.0690  0.0003  0.0004  0.0002  0.0004  0.0000 </r>
+        <r>  0.0000  0.0071  0.0230  0.0071  0.0014  0.0002  0.0183  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2106  0.0000  0.2106  0.0000  0.0001  0.0000  0.0001  0.0012 </r>
+        <r>  0.0000  0.0203  0.0000  0.0203  0.0000  0.0010  0.0000  0.0010  0.0170 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0035  0.0926  0.1017  0.0926  0.0009  0.0000  0.0039  0.0000  0.0000 </r>
+        <r>  0.1630  0.0207  0.0235  0.0207  0.0026  0.0024  0.0000  0.0024  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0937  0.0222  0.0334  0.0222  0.0037  0.0049  0.0003  0.0049  0.0000 </r>
+        <r>  0.0031  0.0611  0.1040  0.0611  0.0001  0.0000  0.0035  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0262  0.0000  0.0262  0.0000  0.0024  0.0000  0.0024  0.0296 </r>
+        <r>  0.0000  0.1800  0.0000  0.1800  0.0000  0.0001  0.0000  0.0001  0.0048 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0002  0.0164  0.0410  0.0164  0.0033  0.0004  0.0266  0.0004  0.0000 </r>
+        <r>  0.0348  0.0661  0.2047  0.0662  0.0001  0.0007  0.0001  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0063  0.0320  0.0145  0.0320  0.0561  0.0000  0.0027  0.0000  0.0000 </r>
+        <r>  0.0000  0.0229  0.0005  0.0229  0.0338  0.0027  0.0000  0.0027  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0016  0.0095  0.0436  0.0095  0.0458  0.0308  0.0030  0.0308  0.0000 </r>
+        <r>  0.0000  0.0000  0.0276  0.0000  0.0050  0.0167  0.0000  0.0167  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0014  0.0000  0.0014  0.0000  0.0961  0.0000  0.0961  0.0127 </r>
+        <r>  0.0000  0.0235  0.0000  0.0235  0.0000  0.0040  0.0000  0.0039  0.0002 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0118  0.0134  0.0297  0.0134  0.0034  0.0359  0.0024  0.0359  0.0000 </r>
+        <r>  0.0002  0.0418  0.0736  0.0418  0.0002  0.0084  0.0000  0.0084  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0294  0.0000  0.0294  0.0000  0.0053  0.0000  0.0053  0.0003 </r>
+        <r>  0.0000  0.0028  0.0000  0.0028  0.0000  0.0527  0.0000  0.0528  0.0004 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0002  0.0228  0.0139  0.0228  0.0582  0.0017  0.0031  0.0017  0.0000 </r>
+        <r>  0.0005  0.0219  0.0001  0.0219  0.0534  0.0089  0.0007  0.0089  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0069  0.0000  0.0043  0.0002  0.0010  0.0034  0.0002  0.2765 </r>
+        <r>  0.0003  0.0521  0.0005  0.0394  0.0000  0.0050  0.0002  0.0044  0.0576 </r>
+       </set>
+      </set>
+      <set comment="kpoint 16">
+       <set comment="band 1">
+        <r>  0.0002  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0631  0.0134  0.8848  0.0134  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0454  0.0000  0.0454  0.8844 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3373  0.3201  0.0003  0.3201  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.5781  0.1561  0.0900  0.1552  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4438  0.0000  0.4446  0.0912 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6425  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0009  0.0059  0.0054  0.0059  0.0000  0.0000  0.0008  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0013  0.0155  0.0146  0.0155  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5838  0.0000  0.0002  0.0000  0.0003  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0116  0.0334  0.3079  0.0334  0.0001  0.0006  0.0010  0.0006  0.0000 </r>
+        <r>  0.0063  0.0010  0.0517  0.0010  0.0006  0.0008  0.0156  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2240  0.0000  0.2240  0.0000  0.0000  0.0000  0.0000  0.0007 </r>
+        <r>  0.0000  0.0083  0.0000  0.0083  0.0000  0.0010  0.0000  0.0010  0.0207 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0017  0.1408  0.0289  0.1409  0.0007  0.0000  0.0030  0.0000  0.0000 </r>
+        <r>  0.1659  0.0144  0.0164  0.0144  0.0037  0.0019  0.0017  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0956  0.0195  0.0166  0.0195  0.0065  0.0036  0.0015  0.0036  0.0000 </r>
+        <r>  0.0039  0.1098  0.0217  0.1098  0.0002  0.0000  0.0021  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0124  0.0000  0.0124  0.0000  0.0022  0.0000  0.0022  0.0308 </r>
+        <r>  0.0000  0.1920  0.0000  0.1920  0.0000  0.0001  0.0000  0.0001  0.0015 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0039  0.0036  0.0845  0.0036  0.0013  0.0019  0.0252  0.0019  0.0000 </r>
+        <r>  0.0275  0.0285  0.2634  0.0285  0.0001  0.0006  0.0024  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0002  0.0472  0.0438  0.0472  0.0206  0.0093  0.0041  0.0093  0.0000 </r>
+        <r>  0.0000  0.0007  0.0132  0.0007  0.0162  0.0125  0.0000  0.0125  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0183  0.0004  0.0062  0.0004  0.0585  0.0131  0.0003  0.0131  0.0000 </r>
+        <r>  0.0000  0.0624  0.0377  0.0624  0.0133  0.0045  0.0000  0.0045  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0032  0.0000  0.0032  0.0000  0.0846  0.0000  0.0846  0.0087 </r>
+        <r>  0.0000  0.0194  0.0000  0.0194  0.0000  0.0096  0.0000  0.0096  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0014  0.0165  0.0228  0.0165  0.0667  0.0429  0.0057  0.0429  0.0000 </r>
+        <r>  0.0000  0.0000  0.0546  0.0000  0.0014  0.0042  0.0000  0.0042  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0261  0.0000  0.0261  0.0000  0.0173  0.0000  0.0173  0.0055 </r>
+        <r>  0.0000  0.0039  0.0000  0.0039  0.0000  0.0487  0.0000  0.0486  0.0002 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0018  0.0110  0.0330  0.0110  0.0238  0.0014  0.0034  0.0014  0.0000 </r>
+        <r>  0.0000  0.0159  0.0068  0.0159  0.0644  0.0142  0.0004  0.0142  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0021  0.0003  0.0076  0.0003  0.0000  0.0019  0.2347  0.0019  0.0800 </r>
+        <r>  0.0100  0.0230  0.0579  0.0209  0.0006  0.0032  0.0210  0.0032  0.0015 </r>
+       </set>
+      </set>
+      <set comment="kpoint 17">
+       <set comment="band 1">
+        <r>  0.0002  0.0001  0.0004  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0685  0.0129  0.8805  0.0130  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0404  0.0000  0.0404  0.8943 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2754  0.3512  0.0000  0.3512  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4494  0.0000  0.4488  0.0812 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6347  0.1246  0.0949  0.1252  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5963  0.0006  0.0002  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0368  0.0054  0.0039  0.0054  0.0000  0.0000  0.0006  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0501  0.0153  0.0127  0.0153  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5516  0.0005  0.0011  0.0005  0.0003  0.0003  0.0001  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0097  0.0189  0.3175  0.0189  0.0000  0.0006  0.0012  0.0006  0.0000 </r>
+        <r>  0.0111  0.0000  0.0721  0.0000  0.0003  0.0013  0.0114  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2355  0.0000  0.2355  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0005  0.0000  0.0005  0.0000  0.0009  0.0000  0.0009  0.0222 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0002  0.1743  0.0089  0.1743  0.0001  0.0001  0.0014  0.0001  0.0000 </r>
+        <r>  0.1653  0.0021  0.0102  0.0021  0.0042  0.0015  0.0041  0.0015  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0931  0.0041  0.0088  0.0041  0.0077  0.0026  0.0045  0.0026  0.0000 </r>
+        <r>  0.0000  0.1380  0.0040  0.1380  0.0001  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0017  0.0000  0.0017  0.0000  0.0020  0.0000  0.0020  0.0315 </r>
+        <r>  0.0000  0.2014  0.0000  0.2014  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0073  0.0007  0.1098  0.0007  0.0007  0.0029  0.0226  0.0029  0.0000 </r>
+        <r>  0.0221  0.0151  0.2690  0.0151  0.0001  0.0003  0.0052  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0086  0.0242  0.0369  0.0242  0.0001  0.0218  0.0022  0.0218  0.0000 </r>
+        <r>  0.0000  0.0073  0.0398  0.0073  0.0025  0.0173  0.0002  0.0173  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0050  0.0000  0.0050  0.0000  0.0674  0.0000  0.0674  0.0055 </r>
+        <r>  0.0000  0.0127  0.0000  0.0127  0.0000  0.0208  0.0000  0.0208  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0049  0.0012  0.0002  0.0012  0.1676  0.0051  0.0103  0.0051  0.0000 </r>
+        <r>  0.0000  0.0413  0.0010  0.0413  0.0038  0.0003  0.0001  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0038  0.0492  0.0063  0.0492  0.0012  0.0159  0.0000  0.0159  0.0000 </r>
+        <r>  0.0004  0.0232  0.0400  0.0232  0.0529  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0002  0.0001  0.0711  0.0001  0.0032  0.0164  0.0053  0.0164  0.0000 </r>
+        <r>  0.0022  0.0052  0.0609  0.0052  0.0344  0.0132  0.0036  0.0132  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0242  0.0000  0.0239  0.0000  0.0345  0.0000  0.0351  0.0061 </r>
+        <r>  0.0000  0.0100  0.0000  0.0100  0.0000  0.0374  0.0000  0.0373  0.0003 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0092  0.0004  0.0037  0.0006  0.0003  0.0128  0.2216  0.0125  0.0003 </r>
+        <r>  0.0102  0.0087  0.0376  0.0116  0.0047  0.0079  0.0578  0.0077  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 18">
+       <set comment="band 1">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0334  0.0000  0.0335  0.9085 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0002  0.0001  0.0003  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0713  0.0117  0.8806  0.0117  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2148  0.3814  0.0001  0.3814  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4561  0.0000  0.4558  0.0672 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6925  0.0957  0.0951  0.0960  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5346  0.0011  0.0004  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0841  0.0042  0.0024  0.0042  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1186  0.0147  0.0103  0.0147  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5137  0.0015  0.0017  0.0015  0.0003  0.0002  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0076  0.0122  0.3235  0.0122  0.0000  0.0007  0.0011  0.0007  0.0000 </r>
+        <r>  0.0114  0.0002  0.0856  0.0002  0.0002  0.0015  0.0076  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2374  0.0000  0.2374  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0030  0.0000  0.0030  0.0000  0.0007  0.0000  0.0007  0.0201 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0077  0.1881  0.0038  0.1881  0.0002  0.0003  0.0003  0.0003  0.0000 </r>
+        <r>  0.1490  0.0026  0.0059  0.0026  0.0041  0.0012  0.0047  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0811  0.0015  0.0050  0.0015  0.0075  0.0017  0.0065  0.0017  0.0000 </r>
+        <r>  0.0071  0.1472  0.0007  0.1472  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0013  0.0000  0.0013  0.0000  0.0015  0.0000  0.0015  0.0314 </r>
+        <r>  0.0000  0.2019  0.0000  0.2019  0.0000  0.0000  0.0000  0.0000  0.0016 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0076  0.0001  0.1254  0.0001  0.0004  0.0036  0.0200  0.0036  0.0000 </r>
+        <r>  0.0174  0.0097  0.2700  0.0097  0.0000  0.0001  0.0069  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0101  0.0146  0.0239  0.0146  0.0003  0.0232  0.0017  0.0232  0.0000 </r>
+        <r>  0.0001  0.0077  0.0443  0.0077  0.0015  0.0180  0.0004  0.0180  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0040  0.0000  0.0040  0.0000  0.0609  0.0000  0.0609  0.0036 </r>
+        <r>  0.0000  0.0089  0.0000  0.0089  0.0000  0.0260  0.0000  0.0260  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0020  0.0127  0.0003  0.0127  0.1148  0.0082  0.0072  0.0082  0.0000 </r>
+        <r>  0.0000  0.0145  0.0067  0.0145  0.0382  0.0019  0.0003  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0418  0.0284  0.0418  0.0267  0.0038  0.0169  0.0038  0.0000 </r>
+        <r>  0.0108  0.0522  0.0579  0.0522  0.0180  0.0001  0.0047  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0063  0.0062  0.0424  0.0062  0.0259  0.0008  0.0684  0.0008  0.0000 </r>
+        <r>  0.0082  0.0066  0.0619  0.0065  0.0192  0.0010  0.0366  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0293  0.0005  0.0329  0.0001  0.0140  0.0052  0.0409  0.0313 </r>
+        <r>  0.0000  0.0288  0.0001  0.0492  0.0012  0.0135  0.0014  0.0220  0.0221 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0006  0.0091  0.0128  0.0011  0.0092  0.0325  0.1281  0.0095  0.0023 </r>
+        <r>  0.0002  0.0231  0.0004  0.0150  0.0215  0.0252  0.0367  0.0059  0.0003 </r>
+       </set>
+      </set>
+      <set comment="kpoint 19">
+       <set comment="band 1">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0243  0.0000  0.0241  0.9272 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0001  0.0002  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0702  0.0093  0.8870  0.0093  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1538  0.4127  0.0005  0.4108  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4651  0.0000  0.4651  0.0486 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7545  0.0668  0.0887  0.0690  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4895  0.0011  0.0004  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1181  0.0030  0.0013  0.0030  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1745  0.0140  0.0075  0.0140  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.4950  0.0023  0.0017  0.0023  0.0002  0.0001  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0052  0.0080  0.3336  0.0080  0.0000  0.0006  0.0007  0.0006  0.0000 </r>
+        <r>  0.0090  0.0004  0.0948  0.0004  0.0001  0.0014  0.0045  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2306  0.0000  0.2306  0.0000  0.0001  0.0000  0.0001  0.0003 </r>
+        <r>  0.0000  0.0139  0.0000  0.0139  0.0000  0.0005  0.0000  0.0005  0.0154 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0175  0.1875  0.0028  0.1875  0.0007  0.0003  0.0000  0.0003  0.0000 </r>
+        <r>  0.1209  0.0150  0.0033  0.0150  0.0035  0.0008  0.0037  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0641  0.0132  0.0027  0.0132  0.0065  0.0011  0.0071  0.0011  0.0000 </r>
+        <r>  0.0196  0.1453  0.0003  0.1453  0.0000  0.0000  0.0014  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0105  0.0000  0.0105  0.0000  0.0010  0.0000  0.0010  0.0301 </r>
+        <r>  0.0000  0.1954  0.0000  0.1954  0.0000  0.0000  0.0000  0.0000  0.0051 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0062  0.0000  0.1365  0.0000  0.0002  0.0043  0.0166  0.0043  0.0000 </r>
+        <r>  0.0124  0.0065  0.2764  0.0065  0.0000  0.0000  0.0072  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0088  0.0082  0.0123  0.0082  0.0008  0.0243  0.0016  0.0243  0.0000 </r>
+        <r>  0.0007  0.0057  0.0491  0.0057  0.0013  0.0191  0.0005  0.0191  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0024  0.0000  0.0024  0.0000  0.0579  0.0000  0.0579  0.0021 </r>
+        <r>  0.0000  0.0058  0.0000  0.0058  0.0000  0.0293  0.0000  0.0292  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0023  0.0109  0.0003  0.0109  0.1061  0.0060  0.0051  0.0060  0.0000 </r>
+        <r>  0.0001  0.0117  0.0055  0.0117  0.0481  0.0023  0.0004  0.0023  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0131  0.0086  0.0457  0.0086  0.0003  0.0002  0.0917  0.0002  0.0000 </r>
+        <r>  0.0362  0.0109  0.0886  0.0109  0.0005  0.0000  0.0437  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0011  0.0468  0.0000  0.0468  0.0158  0.0001  0.0592  0.0001  0.0000 </r>
+        <r>  0.0101  0.0694  0.0009  0.0692  0.0072  0.0004  0.0335  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0012  0.0000  0.0002  0.0000  0.0302  0.0325  0.0003  0.0324  0.0000 </r>
+        <r>  0.0000  0.0100  0.0128  0.0102  0.0008  0.0068  0.0000  0.0068  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0171  0.0000  0.0173  0.0000  0.0004  0.0000  0.0003  0.1904 </r>
+        <r>  0.0000  0.0457  0.0000  0.0448  0.0000  0.0000  0.0000  0.0000  0.0815 </r>
+       </set>
+      </set>
+      <set comment="kpoint 20">
+       <set comment="band 1">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0134  0.0000  0.0135  0.9492 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0001  0.0001  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0621  0.0057  0.9028  0.0057  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0905  0.4433  0.0007  0.4433  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4758  0.0000  0.4757  0.0270 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8257  0.0399  0.0730  0.0400  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4600  0.0009  0.0002  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1397  0.0020  0.0006  0.0020  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2179  0.0124  0.0043  0.0124  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.4944  0.0025  0.0011  0.0025  0.0001  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0028  0.0046  0.3486  0.0046  0.0000  0.0005  0.0003  0.0005  0.0000 </r>
+        <r>  0.0053  0.0005  0.1009  0.0005  0.0000  0.0012  0.0021  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2214  0.0000  0.2214  0.0000  0.0001  0.0000  0.0001  0.0005 </r>
+        <r>  0.0000  0.0264  0.0000  0.0264  0.0000  0.0002  0.0000  0.0002  0.0102 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0211  0.1879  0.0025  0.1879  0.0008  0.0002  0.0000  0.0002  0.0000 </r>
+        <r>  0.0910  0.0272  0.0017  0.0272  0.0027  0.0004  0.0026  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0489  0.0252  0.0014  0.0252  0.0055  0.0006  0.0070  0.0006  0.0000 </r>
+        <r>  0.0260  0.1465  0.0003  0.1465  0.0000  0.0000  0.0024  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0227  0.0000  0.0227  0.0000  0.0006  0.0000  0.0006  0.0278 </r>
+        <r>  0.0000  0.1891  0.0000  0.1891  0.0000  0.0000  0.0000  0.0000  0.0083 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0040  0.0000  0.1445  0.0000  0.0001  0.0052  0.0112  0.0052  0.0000 </r>
+        <r>  0.0072  0.0039  0.2917  0.0039  0.0000  0.0002  0.0056  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0059  0.0035  0.0035  0.0035  0.0011  0.0260  0.0014  0.0260  0.0000 </r>
+        <r>  0.0014  0.0033  0.0569  0.0033  0.0012  0.0207  0.0006  0.0207  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0010  0.0000  0.0010  0.0000  0.0563  0.0000  0.0563  0.0010 </r>
+        <r>  0.0000  0.0032  0.0000  0.0032  0.0000  0.0315  0.0000  0.0315  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0025  0.0081  0.0001  0.0081  0.1047  0.0039  0.0031  0.0039  0.0000 </r>
+        <r>  0.0004  0.0101  0.0043  0.0101  0.0550  0.0019  0.0004  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0227  0.0037  0.0272  0.0037  0.0000  0.0000  0.1032  0.0000  0.0000 </r>
+        <r>  0.0472  0.0056  0.0561  0.0056  0.0000  0.0000  0.0545  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0044  0.0114  0.0004  0.0114  0.0034  0.0184  0.0262  0.0184  0.0000 </r>
+        <r>  0.0070  0.0076  0.0075  0.0076  0.0019  0.0067  0.0140  0.0067  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0110  0.0234  0.0001  0.0233  0.0112  0.0071  0.0459  0.0070  0.0000 </r>
+        <r>  0.0333  0.0672  0.0038  0.0672  0.0010  0.0020  0.0254  0.0020  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0154  0.0000  0.0155  0.0000  0.0001  0.0000  0.0001  0.1832 </r>
+        <r>  0.0000  0.0390  0.0000  0.0391  0.0000  0.0000  0.0000  0.0000  0.0899 </r>
+       </set>
+      </set>
+      <set comment="kpoint 21">
+       <set comment="band 1">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0037  0.0000  0.0037  0.9690 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0435  0.0017  0.9298  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0325  0.4725  0.0004  0.4724  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4853  0.0000  0.4853  0.0075 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9022  0.0147  0.0466  0.0148  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4419  0.0006  0.0001  0.0006  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1530  0.0011  0.0001  0.0011  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2524  0.0096  0.0014  0.0096  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5064  0.0022  0.0004  0.0022  0.0001  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0008  0.0016  0.3671  0.0016  0.0000  0.0004  0.0001  0.0004  0.0000 </r>
+        <r>  0.0017  0.0002  0.1041  0.0002  0.0000  0.0009  0.0005  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2133  0.0000  0.2133  0.0000  0.0000  0.0000  0.0000  0.0005 </r>
+        <r>  0.0000  0.0367  0.0000  0.0367  0.0000  0.0001  0.0000  0.0001  0.0058 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0182  0.1917  0.0015  0.1917  0.0006  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0601  0.0367  0.0006  0.0367  0.0018  0.0001  0.0016  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0350  0.0354  0.0004  0.0354  0.0045  0.0002  0.0065  0.0002  0.0000 </r>
+        <r>  0.0255  0.1547  0.0002  0.1547  0.0001  0.0000  0.0029  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0345  0.0000  0.0345  0.0000  0.0002  0.0000  0.0002  0.0236 </r>
+        <r>  0.0000  0.1875  0.0000  0.1875  0.0000  0.0000  0.0000  0.0000  0.0096 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0015  0.0001  0.1473  0.0001  0.0000  0.0056  0.0042  0.0056  0.0000 </r>
+        <r>  0.0023  0.0014  0.3220  0.0014  0.0000  0.0007  0.0022  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0021  0.0008  0.0001  0.0008  0.0008  0.0299  0.0006  0.0299  0.0000 </r>
+        <r>  0.0010  0.0011  0.0624  0.0011  0.0007  0.0230  0.0003  0.0230  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0556  0.0000  0.0556  0.0003 </r>
+        <r>  0.0000  0.0010  0.0000  0.0010  0.0000  0.0331  0.0000  0.0331  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0028  0.0049  0.0000  0.0049  0.1066  0.0016  0.0013  0.0016  0.0000 </r>
+        <r>  0.0011  0.0088  0.0020  0.0088  0.0613  0.0009  0.0002  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0331  0.0027  0.0094  0.0027  0.0001  0.0000  0.1032  0.0000  0.0000 </r>
+        <r>  0.0624  0.0055  0.0201  0.0055  0.0001  0.0000  0.0576  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0006  0.0013  0.0003  0.0013  0.0026  0.0197  0.0054  0.0197  0.0000 </r>
+        <r>  0.0007  0.0002  0.0062  0.0002  0.0010  0.0083  0.0030  0.0083  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0246  0.0220  0.0000  0.0220  0.0019  0.0007  0.0755  0.0007  0.0000 </r>
+        <r>  0.0523  0.0541  0.0003  0.0541  0.0009  0.0003  0.0426  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0130  0.0000  0.0130  0.0000  0.0000  0.0000  0.0000  0.1787 </r>
+        <r>  0.0000  0.0317  0.0000  0.0317  0.0000  0.0000  0.0000  0.0000  0.0959 </r>
+       </set>
+      </set>
+      <set comment="kpoint 22">
+       <set comment="band 1">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9768 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0167  0.0000  0.9603  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4854  0.0000  0.4924  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4925  0.0000  0.4854  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9613  0.0000  0.0167  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4316  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1606  0.0005  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2782  0.0056  0.0000  0.0056  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.5233  0.0014  0.0000  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.3857  0.0000  0.0000  0.0002  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.1033  0.0000  0.0000  0.0005  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2068  0.0000  0.2068  0.0000  0.0000  0.0000  0.0000  0.0003 </r>
+        <r>  0.0000  0.0441  0.0000  0.0441  0.0000  0.0000  0.0000  0.0000  0.0026 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0110  0.1962  0.0000  0.1962  0.0004  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0309  0.0438  0.0000  0.0438  0.0009  0.0000  0.0008  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0212  0.0455  0.0000  0.0455  0.0032  0.0000  0.0048  0.0000  0.0000 </r>
+        <r>  0.0191  0.1699  0.0000  0.1699  0.0002  0.0000  0.0025  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0459  0.0000  0.0459  0.0000  0.0000  0.0000  0.0000  0.0162 </r>
+        <r>  0.0000  0.1917  0.0000  0.1917  0.0000  0.0000  0.0000  0.0000  0.0078 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.1392  0.0000  0.0000  0.0037  0.0000  0.0037  0.0000 </r>
+        <r>  0.0000  0.0000  0.3688  0.0000  0.0000  0.0006  0.0000  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0381  0.0000  0.0381  0.0000 </r>
+        <r>  0.0000  0.0000  0.0412  0.0000  0.0000  0.0267  0.0000  0.0267  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0553  0.0000  0.0553  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0340  0.0000  0.0340  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0019  0.0016  0.0000  0.0016  0.1088  0.0000  0.0004  0.0000  0.0000 </r>
+        <r>  0.0012  0.0073  0.0000  0.0073  0.0664  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0496  0.0031  0.0000  0.0031  0.0002  0.0000  0.0805  0.0000  0.0000 </r>
+        <r>  0.0891  0.0070  0.0000  0.0070  0.0001  0.0000  0.0464  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0143  0.0000  0.0143  0.0000 </r>
+        <r>  0.0000  0.0000  0.0024  0.0000  0.0000  0.0067  0.0000  0.0067  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0254  0.0130  0.0000  0.0130  0.0004  0.0000  0.1083  0.0000  0.0000 </r>
+        <r>  0.0483  0.0307  0.0000  0.0307  0.0004  0.0000  0.0626  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0088  0.0000  0.0088  0.0000  0.0000  0.0000  0.0000  0.1802 </r>
+        <r>  0.0000  0.0211  0.0000  0.0211  0.0000  0.0000  0.0000  0.0000  0.1021 </r>
+       </set>
+      </set>
+      <set comment="kpoint 23">
+       <set comment="band 1">
+        <r>  0.0002  0.0000  0.0003  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9760  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9773 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9776  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.3508  0.0000  0.6274  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.6274  0.0000  0.3508  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4385  0.0000  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1557  0.0000  0.0018  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2646  0.0000  0.0151  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.5172  0.0000  0.0029  0.0000  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2124  0.0000  0.1615  0.0000  0.0003  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0606  0.0000  0.0461  0.0000  0.0008  0.0000  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1615  0.0000  0.2124  0.0000  0.0002  0.0000  0.0003  0.0000 </r>
+        <r>  0.0000  0.0461  0.0000  0.0606  0.0000  0.0006  0.0000  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0080  0.0000  0.4545  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0521  0.0000  0.0297  0.0000  0.0000  0.0000  0.0076  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0305  0.0000  0.0138  0.0000  0.0000  0.0000  0.0181  0.0000  0.0000 </r>
+        <r>  0.0078  0.0000  0.3802  0.0000  0.0000  0.0000  0.0044  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0103  0.0000  0.1417  0.0000  0.0005  0.0000  0.0072  0.0000 </r>
+        <r>  0.0000  0.0247  0.0000  0.3403  0.0000  0.0000  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.1417  0.0000  0.0103  0.0000  0.0072  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.3403  0.0000  0.0247  0.0000  0.0005  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0789  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0551  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0002  0.0000  0.0004  0.0000  0.0408  0.0000  0.0666  0.0000 </r>
+        <r>  0.0000  0.0174  0.0000  0.0284  0.0000  0.0247  0.0000  0.0402  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0004  0.0000  0.0002  0.0000  0.0666  0.0000  0.0408  0.0000 </r>
+        <r>  0.0000  0.0284  0.0000  0.0174  0.0000  0.0402  0.0000  0.0247  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0623  0.0000  0.0050  0.0000  0.0000  0.0000  0.0555  0.0000  0.0000 </r>
+        <r>  0.1122  0.0000  0.0093  0.0000  0.0000  0.0000  0.0299  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1942 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1117 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0317  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0135  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0113  0.0000  0.0440  0.0000  0.0000  0.0000  0.1304  0.0000  0.0000 </r>
+        <r>  0.0237  0.0000  0.1013  0.0000  0.0000  0.0000  0.0693  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 24">
+       <set comment="band 1">
+        <r>  0.0003  0.0000  0.0004  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.0011  0.9728  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0112  0.0000  0.0112  0.9548 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9660  0.0057  0.0003  0.0057  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0112  0.4824  0.0023  0.4825  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4780  0.0000  0.4780  0.0225 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4489  0.0001  0.0015  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1484  0.0001  0.0027  0.0001  0.0000  0.0000  0.0007  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2447  0.0013  0.0175  0.0013  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.5098  0.0004  0.0029  0.0004  0.0000  0.0000  0.0008  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1821  0.0000  0.1821  0.0000  0.0003  0.0000  0.0003  0.0001 </r>
+        <r>  0.0000  0.0539  0.0000  0.0539  0.0000  0.0009  0.0000  0.0009  0.0006 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0024  0.1787  0.0033  0.1787  0.0001  0.0003  0.0001  0.0003  0.0000 </r>
+        <r>  0.0044  0.0534  0.0001  0.0534  0.0003  0.0008  0.0005  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0030  0.0005  0.4560  0.0005  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+        <r>  0.0723  0.0003  0.0008  0.0003  0.0000  0.0002  0.0118  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0428  0.0001  0.0029  0.0001  0.0000  0.0003  0.0188  0.0003  0.0000 </r>
+        <r>  0.0010  0.0000  0.3936  0.0000  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0040  0.0766  0.0000  0.0766  0.0039  0.0037  0.0025  0.0037  0.0000 </r>
+        <r>  0.0064  0.1583  0.0025  0.1583  0.0013  0.0001  0.0010  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0775  0.0000  0.0775  0.0000  0.0041  0.0000  0.0041  0.0053 </r>
+        <r>  0.0000  0.1734  0.0000  0.1734  0.0000  0.0001  0.0000  0.0001  0.0030 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0005  0.0005  0.0000  0.0005  0.0706  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0004  0.0130  0.0000  0.0130  0.0520  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0040  0.0018  0.0029  0.0018  0.0028  0.0510  0.0007  0.0510  0.0000 </r>
+        <r>  0.0031  0.0174  0.0008  0.0174  0.0011  0.0292  0.0006  0.0292  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0013  0.0000  0.0013  0.0000  0.0550  0.0000  0.0550  0.0035 </r>
+        <r>  0.0000  0.0228  0.0000  0.0228  0.0000  0.0310  0.0000  0.0310  0.0014 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0502  0.0053  0.0050  0.0053  0.0001  0.0009  0.0564  0.0009  0.0000 </r>
+        <r>  0.0968  0.0160  0.0112  0.0160  0.0000  0.0006  0.0284  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0031  0.0000  0.0031  0.0000  0.0004  0.0000  0.0004  0.1876 </r>
+        <r>  0.0000  0.0097  0.0000  0.0097  0.0000  0.0003  0.0000  0.0003  0.1059 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0342  0.0037  0.0001  0.0037  0.0000 </r>
+        <r>  0.0001  0.0017  0.0001  0.0017  0.0134  0.0015  0.0001  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0084  0.0001  0.0520  0.0001  0.0000  0.0002  0.1321  0.0002  0.0000 </r>
+        <r>  0.0198  0.0002  0.1203  0.0002  0.0000  0.0000  0.0655  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 25">
+       <set comment="band 1">
+        <r>  0.0005  0.0000  0.0005  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0042  0.0032  0.9641  0.0032  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0298  0.0000  0.0298  0.9174 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9340  0.0207  0.0023  0.0207  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0394  0.4655  0.0083  0.4653  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4594  0.0000  0.4596  0.0598 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4674  0.0002  0.0019  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1353  0.0006  0.0036  0.0006  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2135  0.0044  0.0178  0.0044  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+        <r>  0.5035  0.0011  0.0023  0.0011  0.0000  0.0001  0.0009  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1792  0.0000  0.1792  0.0000  0.0004  0.0000  0.0004  0.0004 </r>
+        <r>  0.0000  0.0528  0.0000  0.0528  0.0000  0.0010  0.0000  0.0010  0.0021 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0087  0.1665  0.0138  0.1665  0.0004  0.0004  0.0002  0.0004  0.0000 </r>
+        <r>  0.0130  0.0507  0.0000  0.0507  0.0010  0.0008  0.0022  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0001  0.0023  0.3926  0.0023  0.0000  0.0000  0.0025  0.0000  0.0000 </r>
+        <r>  0.0846  0.0015  0.0164  0.0015  0.0000  0.0005  0.0129  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0510  0.0005  0.0508  0.0005  0.0000  0.0012  0.0166  0.0012  0.0000 </r>
+        <r>  0.0013  0.0004  0.3602  0.0004  0.0000  0.0002  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0099  0.0742  0.0003  0.0741  0.0066  0.0026  0.0068  0.0026  0.0000 </r>
+        <r>  0.0190  0.1348  0.0098  0.1348  0.0013  0.0000  0.0021  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0732  0.0000  0.0732  0.0000  0.0036  0.0000  0.0036  0.0147 </r>
+        <r>  0.0000  0.1640  0.0000  0.1640  0.0000  0.0000  0.0000  0.0000  0.0080 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0025  0.0000  0.0003  0.0000  0.0647  0.0000  0.0009  0.0000  0.0000 </r>
+        <r>  0.0013  0.0225  0.0001  0.0225  0.0495  0.0001  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0069  0.0050  0.0098  0.0050  0.0076  0.0473  0.0004  0.0473  0.0000 </r>
+        <r>  0.0032  0.0090  0.0042  0.0090  0.0030  0.0251  0.0007  0.0251  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0038  0.0000  0.0038  0.0000  0.0577  0.0000  0.0577  0.0091 </r>
+        <r>  0.0000  0.0182  0.0000  0.0182  0.0000  0.0286  0.0000  0.0286  0.0028 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0341  0.0161  0.0064  0.0161  0.0005  0.0014  0.0551  0.0014  0.0000 </r>
+        <r>  0.0760  0.0386  0.0147  0.0386  0.0000  0.0004  0.0246  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0089  0.0000  0.0089  0.0000  0.0013  0.0000  0.0013  0.1755 </r>
+        <r>  0.0000  0.0267  0.0000  0.0267  0.0000  0.0006  0.0000  0.0006  0.0957 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0001  0.0002  0.0001  0.0349  0.0116  0.0008  0.0116  0.0000 </r>
+        <r>  0.0002  0.0058  0.0008  0.0058  0.0118  0.0032  0.0003  0.0032  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0019  0.0013  0.0664  0.0013  0.0000  0.0033  0.1276  0.0034  0.0000 </r>
+        <r>  0.0089  0.0008  0.1418  0.0008  0.0000  0.0009  0.0599  0.0010  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 26">
+       <set comment="band 1">
+        <r>  0.0007  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0126  0.0051  0.9513  0.0051  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0408  0.0000  0.0408  0.8950 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8762  0.0479  0.0057  0.0479  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0890  0.4365  0.0171  0.4362  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4485  0.0000  0.4487  0.0819 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4969  0.0004  0.0020  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1141  0.0013  0.0045  0.0013  0.0000  0.0000  0.0017  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1711  0.0077  0.0169  0.0077  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+        <r>  0.5062  0.0017  0.0015  0.0017  0.0001  0.0001  0.0008  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1786  0.0000  0.1786  0.0000  0.0004  0.0000  0.0004  0.0009 </r>
+        <r>  0.0000  0.0500  0.0000  0.0500  0.0000  0.0010  0.0000  0.0010  0.0046 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0166  0.1479  0.0430  0.1479  0.0008  0.0004  0.0001  0.0004  0.0000 </r>
+        <r>  0.0154  0.0441  0.0016  0.0441  0.0018  0.0005  0.0058  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0001  0.0104  0.3021  0.0104  0.0001  0.0000  0.0046  0.0000  0.0000 </r>
+        <r>  0.0958  0.0055  0.0492  0.0055  0.0002  0.0010  0.0095  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0555  0.0027  0.1047  0.0027  0.0002  0.0026  0.0126  0.0026  0.0000 </r>
+        <r>  0.0044  0.0027  0.2986  0.0027  0.0000  0.0003  0.0020  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0125  0.0694  0.0033  0.0694  0.0066  0.0015  0.0114  0.0015  0.0000 </r>
+        <r>  0.0334  0.1210  0.0271  0.1210  0.0004  0.0001  0.0020  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0675  0.0000  0.0675  0.0000  0.0031  0.0000  0.0031  0.0218 </r>
+        <r>  0.0000  0.1590  0.0000  0.1590  0.0000  0.0000  0.0000  0.0000  0.0107 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0046  0.0024  0.0010  0.0024  0.0630  0.0000  0.0015  0.0000  0.0000 </r>
+        <r>  0.0010  0.0243  0.0000  0.0243  0.0478  0.0002  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0071  0.0077  0.0196  0.0077  0.0120  0.0442  0.0000  0.0442  0.0000 </r>
+        <r>  0.0015  0.0052  0.0108  0.0053  0.0040  0.0220  0.0005  0.0220  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0061  0.0000  0.0061  0.0000  0.0629  0.0000  0.0629  0.0121 </r>
+        <r>  0.0000  0.0163  0.0000  0.0163  0.0000  0.0251  0.0000  0.0251  0.0025 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0161  0.0287  0.0142  0.0287  0.0002  0.0038  0.0493  0.0038  0.0000 </r>
+        <r>  0.0519  0.0565  0.0260  0.0564  0.0000  0.0001  0.0172  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0155  0.0000  0.0155  0.0000  0.0031  0.0000  0.0031  0.1617 </r>
+        <r>  0.0000  0.0396  0.0000  0.0396  0.0000  0.0001  0.0000  0.0001  0.0835 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0023  0.0001  0.0005  0.0000  0.0355  0.0287  0.0001  0.0322  0.0000 </r>
+        <r>  0.0002  0.0077  0.0098  0.0080  0.0095  0.0012  0.0002  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0116  0.0031  0.0596  0.0015  0.0017  0.0228  0.0482  0.0132  0.0042 </r>
+        <r>  0.0055  0.0004  0.0702  0.0007  0.0002  0.0260  0.0305  0.0157  0.0010 </r>
+       </set>
+      </set>
+      <set comment="kpoint 27">
+       <set comment="band 1">
+        <r>  0.0008  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0240  0.0064  0.9368  0.0064  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0442  0.0000  0.0441  0.8879 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7832  0.0931  0.0083  0.0932  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1708  0.3900  0.0287  0.3894  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4451  0.0000  0.4458  0.0886 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5420  0.0004  0.0018  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0810  0.0024  0.0052  0.0024  0.0000  0.0000  0.0022  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1156  0.0106  0.0156  0.0106  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+        <r>  0.5248  0.0017  0.0006  0.0017  0.0001  0.0002  0.0006  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1807  0.0000  0.1806  0.0000  0.0003  0.0000  0.0003  0.0014 </r>
+        <r>  0.0000  0.0455  0.0000  0.0455  0.0000  0.0009  0.0000  0.0009  0.0078 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0230  0.0972  0.1464  0.0972  0.0007  0.0005  0.0001  0.0005  0.0000 </r>
+        <r>  0.0017  0.0251  0.0222  0.0252  0.0017  0.0000  0.0123  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0008  0.0525  0.1608  0.0525  0.0006  0.0000  0.0056  0.0000  0.0000 </r>
+        <r>  0.1202  0.0212  0.0534  0.0212  0.0012  0.0016  0.0022  0.0016  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0660  0.0147  0.1166  0.0147  0.0013  0.0042  0.0057  0.0042  0.0000 </r>
+        <r>  0.0010  0.0184  0.2049  0.0184  0.0000  0.0002  0.0054  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0059  0.0540  0.0262  0.0540  0.0054  0.0002  0.0186  0.0002  0.0000 </r>
+        <r>  0.0493  0.0998  0.0871  0.0998  0.0000  0.0006  0.0004  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0611  0.0000  0.0611  0.0000  0.0027  0.0000  0.0027  0.0260 </r>
+        <r>  0.0000  0.1591  0.0000  0.1592  0.0000  0.0001  0.0000  0.0001  0.0110 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0060  0.0080  0.0023  0.0080  0.0634  0.0000  0.0019  0.0000  0.0000 </r>
+        <r>  0.0004  0.0249  0.0000  0.0249  0.0457  0.0003  0.0001  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0062  0.0106  0.0323  0.0106  0.0159  0.0408  0.0001  0.0408  0.0000 </r>
+        <r>  0.0006  0.0032  0.0188  0.0032  0.0039  0.0196  0.0003  0.0196  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0062  0.0000  0.0062  0.0000  0.0742  0.0000  0.0742  0.0139 </r>
+        <r>  0.0000  0.0177  0.0000  0.0177  0.0000  0.0183  0.0000  0.0183  0.0016 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0296  0.0354  0.0296  0.0001  0.0211  0.0218  0.0211  0.0000 </r>
+        <r>  0.0136  0.0519  0.0588  0.0518  0.0001  0.0053  0.0031  0.0053  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0289  0.0000  0.0289  0.0000  0.0143  0.0000  0.0144  0.0683 </r>
+        <r>  0.0000  0.0359  0.0000  0.0360  0.0000  0.0100  0.0000  0.0100  0.0363 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0006  0.0000  0.0005  0.0000  0.0143  0.0000  0.0159  0.1580 </r>
+        <r>  0.0000  0.0088  0.0000  0.0086  0.0000  0.0325  0.0000  0.0323  0.0543 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0318  0.0075  0.0142  0.0076  0.0007  0.0269  0.0487  0.0262  0.0000 </r>
+        <r>  0.0350  0.0149  0.0197  0.0144  0.0024  0.0123  0.0263  0.0115  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 28">
+       <set comment="band 1">
+        <r>  0.0009  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0364  0.0072  0.9227  0.0072  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0424  0.0000  0.0423  0.8911 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6491  0.1602  0.0079  0.1606  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2927  0.3219  0.0431  0.3214  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4472  0.0000  0.4473  0.0851 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6022  0.0002  0.0011  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0356  0.0040  0.0054  0.0040  0.0000  0.0000  0.0027  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0487  0.0131  0.0143  0.0131  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+        <r>  0.5610  0.0011  0.0001  0.0011  0.0002  0.0002  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0191  0.0325  0.2537  0.0325  0.0002  0.0006  0.0013  0.0006  0.0000 </r>
+        <r>  0.0068  0.0052  0.0672  0.0052  0.0006  0.0004  0.0132  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1861  0.0000  0.1861  0.0000  0.0002  0.0000  0.0002  0.0018 </r>
+        <r>  0.0000  0.0387  0.0000  0.0386  0.0000  0.0008  0.0000  0.0008  0.0115 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0079  0.1123  0.0343  0.1123  0.0014  0.0000  0.0047  0.0000  0.0000 </r>
+        <r>  0.1237  0.0370  0.0234  0.0370  0.0029  0.0015  0.0004  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0743  0.0461  0.0536  0.0461  0.0046  0.0042  0.0000  0.0042  0.0000 </r>
+        <r>  0.0067  0.0727  0.0560  0.0727  0.0000  0.0000  0.0061  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0532  0.0000  0.0532  0.0000  0.0023  0.0000  0.0023  0.0283 </r>
+        <r>  0.0000  0.1641  0.0000  0.1641  0.0000  0.0002  0.0000  0.0002  0.0092 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0009  0.0181  0.1080  0.0181  0.0022  0.0008  0.0243  0.0008  0.0000 </r>
+        <r>  0.0490  0.0443  0.2141  0.0443  0.0000  0.0010  0.0010  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0060  0.0155  0.0042  0.0155  0.0649  0.0002  0.0028  0.0002  0.0000 </r>
+        <r>  0.0001  0.0252  0.0000  0.0252  0.0429  0.0005  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0004  0.0264  0.0759  0.0264  0.0203  0.0084  0.0005  0.0084  0.0000 </r>
+        <r>  0.0009  0.0019  0.0008  0.0019  0.0032  0.0271  0.0001  0.0271  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0107  0.0035  0.0047  0.0035  0.0017  0.0617  0.0063  0.0617  0.0000 </r>
+        <r>  0.0005  0.0327  0.0981  0.0327  0.0000  0.0012  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.1016  0.0000  0.1016  0.0127 </r>
+        <r>  0.0000  0.0245  0.0000  0.0245  0.0000  0.0013  0.0000  0.0013  0.0004 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0316  0.0000  0.0316  0.0000  0.0009  0.0000  0.0009  0.0078 </r>
+        <r>  0.0000  0.0022  0.0000  0.0022  0.0000  0.0486  0.0000  0.0487  0.0028 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0061  0.0360  0.0078  0.0360  0.0329  0.0049  0.0060  0.0050  0.0001 </r>
+        <r>  0.0148  0.0463  0.0004  0.0470  0.0255  0.0093  0.0107  0.0095  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0048  0.0000  0.0045  0.0001  0.0006  0.0002  0.0008  0.2446 </r>
+        <r>  0.0000  0.0395  0.0000  0.0401  0.0000  0.0108  0.0000  0.0110  0.0768 </r>
+       </set>
+      </set>
+      <set comment="kpoint 29">
+       <set comment="band 1">
+        <r>  0.0009  0.0001  0.0004  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0489  0.0074  0.9098  0.0075  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0376  0.0000  0.0374  0.9004 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4810  0.2460  0.0051  0.2458  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4485  0.2361  0.0590  0.2355  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4516  0.0000  0.4525  0.0754 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6464  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0012  0.0054  0.0047  0.0054  0.0000  0.0000  0.0029  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0015  0.0149  0.0128  0.0149  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+        <r>  0.5917  0.0002  0.0002  0.0002  0.0003  0.0003  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0148  0.0134  0.2731  0.0134  0.0001  0.0007  0.0016  0.0007  0.0000 </r>
+        <r>  0.0142  0.0009  0.0893  0.0009  0.0002  0.0010  0.0098  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1962  0.0000  0.1962  0.0000  0.0001  0.0000  0.0001  0.0020 </r>
+        <r>  0.0000  0.0290  0.0000  0.0290  0.0000  0.0007  0.0000  0.0007  0.0157 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0109  0.1323  0.0078  0.1323  0.0015  0.0000  0.0039  0.0000  0.0000 </r>
+        <r>  0.1235  0.0355  0.0103  0.0355  0.0037  0.0010  0.0027  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0731  0.0533  0.0183  0.0533  0.0064  0.0028  0.0020  0.0028  0.0000 </r>
+        <r>  0.0179  0.1027  0.0098  0.1027  0.0002  0.0001  0.0038  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0423  0.0000  0.0423  0.0000  0.0019  0.0000  0.0019  0.0298 </r>
+        <r>  0.0000  0.1737  0.0000  0.1737  0.0000  0.0002  0.0000  0.0002  0.0062 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0062  0.0042  0.1551  0.0042  0.0008  0.0026  0.0218  0.0026  0.0000 </r>
+        <r>  0.0360  0.0175  0.2469  0.0175  0.0001  0.0007  0.0040  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0031  0.0262  0.0099  0.0262  0.0628  0.0018  0.0049  0.0018  0.0000 </r>
+        <r>  0.0000  0.0204  0.0013  0.0204  0.0369  0.0019  0.0000  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0126  0.0077  0.0319  0.0077  0.0095  0.0220  0.0021  0.0220  0.0000 </r>
+        <r>  0.0001  0.0294  0.0580  0.0294  0.0039  0.0160  0.0002  0.0159  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0036  0.0000  0.0036  0.0000  0.0801  0.0000  0.0801  0.0060 </r>
+        <r>  0.0000  0.0166  0.0000  0.0166  0.0000  0.0114  0.0000  0.0114  0.0001 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0026  0.0167  0.0442  0.0167  0.0314  0.0441  0.0002  0.0441  0.0000 </r>
+        <r>  0.0006  0.0021  0.0583  0.0021  0.0001  0.0087  0.0000  0.0086  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0256  0.0000  0.0256  0.0000  0.0230  0.0000  0.0230  0.0145 </r>
+        <r>  0.0000  0.0035  0.0000  0.0035  0.0000  0.0426  0.0000  0.0426  0.0011 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0002  0.0258  0.0161  0.0256  0.0639  0.0000  0.0123  0.0000  0.0000 </r>
+        <r>  0.0000  0.0288  0.0045  0.0284  0.0501  0.0062  0.0031  0.0061  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0041  0.0018  0.0081  0.0014  0.0000  0.0042  0.2538  0.0042  0.0118 </r>
+        <r>  0.0296  0.0128  0.0556  0.0096  0.0008  0.0094  0.0244  0.0083  0.0020 </r>
+       </set>
+      </set>
+      <set comment="kpoint 30">
+       <set comment="band 1">
+        <r>  0.0008  0.0001  0.0003  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0606  0.0071  0.8992  0.0071  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0303  0.0000  0.0303  0.9148 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3122  0.3319  0.0018  0.3320  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6058  0.1503  0.0732  0.1500  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4592  0.0000  0.4594  0.0608 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6237  0.0005  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0183  0.0058  0.0031  0.0058  0.0000  0.0000  0.0025  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0255  0.0156  0.0103  0.0156  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+        <r>  0.5762  0.0001  0.0009  0.0001  0.0003  0.0002  0.0002  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0113  0.0072  0.2800  0.0072  0.0000  0.0008  0.0013  0.0008  0.0000 </r>
+        <r>  0.0142  0.0001  0.1005  0.0001  0.0001  0.0014  0.0066  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2115  0.0000  0.2115  0.0000  0.0000  0.0000  0.0000  0.0016 </r>
+        <r>  0.0000  0.0165  0.0000  0.0165  0.0000  0.0005  0.0000  0.0005  0.0196 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0083  0.1480  0.0022  0.1480  0.0012  0.0000  0.0033  0.0000  0.0000 </r>
+        <r>  0.1305  0.0269  0.0051  0.0269  0.0039  0.0007  0.0049  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0774  0.0445  0.0077  0.0445  0.0073  0.0019  0.0040  0.0019  0.0000 </r>
+        <r>  0.0175  0.1201  0.0020  0.1201  0.0004  0.0002  0.0018  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0273  0.0000  0.0273  0.0000  0.0015  0.0000  0.0015  0.0310 </r>
+        <r>  0.0000  0.1876  0.0000  0.1876  0.0000  0.0002  0.0000  0.0002  0.0028 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0070  0.0012  0.1751  0.0012  0.0004  0.0042  0.0188  0.0042  0.0000 </r>
+        <r>  0.0266  0.0096  0.2472  0.0096  0.0001  0.0003  0.0058  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0044  0.0228  0.0293  0.0228  0.0063  0.0213  0.0061  0.0213  0.0000 </r>
+        <r>  0.0002  0.0006  0.0508  0.0006  0.0042  0.0167  0.0007  0.0167  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0041  0.0000  0.0041  0.0000  0.0663  0.0000  0.0663  0.0038 </r>
+        <r>  0.0000  0.0099  0.0000  0.0099  0.0000  0.0206  0.0000  0.0207  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0116  0.0098  0.0001  0.0098  0.0743  0.0029  0.0021  0.0029  0.0000 </r>
+        <r>  0.0000  0.0500  0.0171  0.0500  0.0308  0.0018  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0002  0.0354  0.0263  0.0354  0.0776  0.0250  0.0000  0.0250  0.0000 </r>
+        <r>  0.0021  0.0008  0.0525  0.0008  0.0132  0.0009  0.0008  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0058  0.0510  0.0058  0.0171  0.0030  0.0456  0.0030  0.0000 </r>
+        <r>  0.0060  0.0166  0.0475  0.0166  0.0406  0.0052  0.0132  0.0052  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0233  0.0000  0.0233  0.0000  0.0370  0.0000  0.0370  0.0172 </r>
+        <r>  0.0000  0.0069  0.0000  0.0069  0.0000  0.0345  0.0000  0.0345  0.0006 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0173  0.0000  0.0001  0.0000  0.0021  0.0267  0.1641  0.0269  0.0001 </r>
+        <r>  0.0176  0.0113  0.0143  0.0127  0.0082  0.0160  0.0453  0.0162  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 31">
+       <set comment="band 1">
+        <r>  0.0007  0.0001  0.0002  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0711  0.0059  0.8916  0.0059  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0214  0.0000  0.0214  0.9325 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1740  0.4019  0.0002  0.4019  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4682  0.0000  0.4679  0.0431 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7336  0.0811  0.0831  0.0814  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5633  0.0011  0.0001  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0640  0.0051  0.0016  0.0051  0.0000  0.0000  0.0019  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0909  0.0157  0.0071  0.0157  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+        <r>  0.5371  0.0009  0.0012  0.0009  0.0003  0.0001  0.0006  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0075  0.0041  0.2897  0.0041  0.0000  0.0008  0.0009  0.0008  0.0000 </r>
+        <r>  0.0107  0.0000  0.1074  0.0000  0.0001  0.0017  0.0040  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2296  0.0000  0.2296  0.0000  0.0000  0.0000  0.0000  0.0007 </r>
+        <r>  0.0000  0.0042  0.0000  0.0042  0.0000  0.0004  0.0000  0.0004  0.0220 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.1728  0.0006  0.1728  0.0005  0.0000  0.0022  0.0000  0.0000 </r>
+        <r>  0.1415  0.0120  0.0025  0.0120  0.0041  0.0005  0.0065  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0842  0.0243  0.0032  0.0243  0.0080  0.0012  0.0058  0.0012  0.0000 </r>
+        <r>  0.0077  0.1412  0.0003  0.1412  0.0004  0.0002  0.0004  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0102  0.0000  0.0102  0.0000  0.0010  0.0000  0.0010  0.0320 </r>
+        <r>  0.0000  0.2024  0.0000  0.2025  0.0000  0.0001  0.0000  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0055  0.0004  0.1890  0.0004  0.0002  0.0059  0.0150  0.0059  0.0000 </r>
+        <r>  0.0182  0.0059  0.2449  0.0059  0.0000  0.0000  0.0061  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0078  0.0103  0.0156  0.0103  0.0002  0.0230  0.0045  0.0230  0.0000 </r>
+        <r>  0.0006  0.0026  0.0740  0.0026  0.0005  0.0191  0.0012  0.0191  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0028  0.0000  0.0028  0.0000  0.0609  0.0000  0.0609  0.0022 </r>
+        <r>  0.0000  0.0058  0.0000  0.0058  0.0000  0.0254  0.0000  0.0253  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0045  0.0115  0.0030  0.0115  0.1185  0.0000  0.0142  0.0000  0.0000 </r>
+        <r>  0.0015  0.0587  0.0085  0.0587  0.0121  0.0000  0.0015  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0026  0.0465  0.0068  0.0465  0.0619  0.0078  0.0001  0.0078  0.0000 </r>
+        <r>  0.0029  0.0009  0.0288  0.0009  0.0527  0.0005  0.0013  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0091  0.0023  0.0441  0.0023  0.0009  0.0003  0.0959  0.0003  0.0000 </r>
+        <r>  0.0213  0.0005  0.0663  0.0005  0.0200  0.0003  0.0420  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0021  0.0108  0.0060  0.0265  0.0000  0.0050  0.0248  0.0833  0.0103 </r>
+        <r>  0.0004  0.0004  0.0012  0.0267  0.0043  0.0068  0.0076  0.0457  0.0005 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0061  0.0134  0.0139  0.0022  0.0003  0.0997  0.0570  0.0124  0.0034 </r>
+        <r>  0.0016  0.0324  0.0053  0.0058  0.0117  0.0340  0.0170  0.0006  0.0003 </r>
+       </set>
+      </set>
+      <set comment="kpoint 32">
+       <set comment="band 1">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0119  0.0000  0.0119  0.9516 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0005  0.0001  0.0001  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0789  0.0039  0.8884  0.0039  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0770  0.4505  0.0000  0.4504  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4775  0.0000  0.4774  0.0240 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8228  0.0346  0.0871  0.0346  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5120  0.0014  0.0001  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1022  0.0040  0.0007  0.0040  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1504  0.0155  0.0038  0.0155  0.0000  0.0000  0.0004  0.0000  0.0000 </r>
+        <r>  0.5101  0.0018  0.0009  0.0018  0.0003  0.0001  0.0008  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0039  0.0021  0.3041  0.0021  0.0000  0.0008  0.0004  0.0008  0.0000 </r>
+        <r>  0.0059  0.0000  0.1117  0.0000  0.0000  0.0018  0.0019  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2410  0.0000  0.2410  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0002  0.0000  0.0002  0.0209 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0010  0.2004  0.0002  0.2004  0.0000  0.0000  0.0007  0.0000  0.0000 </r>
+        <r>  0.1437  0.0001  0.0010  0.0001  0.0041  0.0003  0.0067  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0836  0.0024  0.0012  0.0024  0.0082  0.0006  0.0077  0.0006  0.0000 </r>
+        <r>  0.0000  0.1604  0.0000  0.1604  0.0001  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0005  0.0000  0.0005  0.0324 </r>
+        <r>  0.0000  0.2096  0.0000  0.2096  0.0000  0.0000  0.0000  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0031  0.0001  0.1989  0.0001  0.0001  0.0081  0.0095  0.0081  0.0000 </r>
+        <r>  0.0099  0.0033  0.2428  0.0033  0.0000  0.0002  0.0045  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0063  0.0046  0.0037  0.0046  0.0000  0.0219  0.0038  0.0219  0.0000 </r>
+        <r>  0.0013  0.0014  0.0996  0.0014  0.0002  0.0199  0.0015  0.0199  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0013  0.0000  0.0013  0.0000  0.0583  0.0000  0.0583  0.0010 </r>
+        <r>  0.0000  0.0028  0.0000  0.0028  0.0000  0.0284  0.0000  0.0284  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0062  0.0200  0.0003  0.0200  0.1278  0.0026  0.0024  0.0026  0.0000 </r>
+        <r>  0.0007  0.0159  0.0056  0.0159  0.0414  0.0007  0.0000  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0110  0.0075  0.0279  0.0075  0.0064  0.0001  0.1094  0.0001  0.0000 </r>
+        <r>  0.0363  0.0158  0.0578  0.0158  0.0006  0.0001  0.0483  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0045  0.0384  0.0011  0.0384  0.0449  0.0002  0.0168  0.0002  0.0000 </r>
+        <r>  0.0002  0.0400  0.0012  0.0400  0.0383  0.0000  0.0133  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0014  0.0021  0.0003  0.0017  0.0096  0.0389  0.0019  0.0405  0.0000 </r>
+        <r>  0.0005  0.0003  0.0144  0.0005  0.0012  0.0069  0.0009  0.0064  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0169  0.0001  0.0137  0.0001  0.0007  0.0006  0.0001  0.2142 </r>
+        <r>  0.0001  0.0547  0.0000  0.0417  0.0002  0.0001  0.0002  0.0000  0.0721 </r>
+       </set>
+      </set>
+      <set comment="kpoint 33">
+       <set comment="band 1">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0036  0.0000  0.0036  0.9685 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0003  0.0001  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0808  0.0014  0.8923  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0207  0.4797  0.0001  0.4773  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4848  0.0000  0.4864  0.0073 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8770  0.0087  0.0837  0.0094  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4773  0.0012  0.0000  0.0012  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1275  0.0029  0.0002  0.0029  0.0000  0.0000  0.0007  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1955  0.0148  0.0011  0.0148  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.4993  0.0025  0.0003  0.0025  0.0002  0.0000  0.0007  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0010  0.0006  0.3229  0.0006  0.0000  0.0007  0.0001  0.0007  0.0000 </r>
+        <r>  0.0017  0.0000  0.1134  0.0000  0.0000  0.0017  0.0005  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2379  0.0000  0.2379  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0095  0.0000  0.0095  0.0000  0.0001  0.0000  0.0001  0.0162 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0108  0.2054  0.0001  0.2054  0.0004  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1208  0.0089  0.0002  0.0089  0.0036  0.0001  0.0050  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0679  0.0045  0.0003  0.0045  0.0070  0.0002  0.0085  0.0002  0.0000 </r>
+        <r>  0.0100  0.1604  0.0000  0.1604  0.0000  0.0000  0.0016  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0050  0.0000  0.0050  0.0000  0.0001  0.0000  0.0001  0.0311 </r>
+        <r>  0.0000  0.2044  0.0000  0.2044  0.0000  0.0000  0.0000  0.0000  0.0042 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0010  0.0000  0.1988  0.0000  0.0000  0.0105  0.0032  0.0105  0.0000 </r>
+        <r>  0.0028  0.0011  0.2447  0.0011  0.0000  0.0010  0.0017  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0025  0.0012  0.0001  0.0012  0.0001  0.0210  0.0018  0.0210  0.0000 </r>
+        <r>  0.0010  0.0004  0.1322  0.0004  0.0001  0.0204  0.0008  0.0204  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0569  0.0000  0.0569  0.0003 </r>
+        <r>  0.0000  0.0008  0.0000  0.0008  0.0000  0.0306  0.0000  0.0306  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0089  0.0185  0.0003  0.0185  0.1147  0.0008  0.0001  0.0008  0.0000 </r>
+        <r>  0.0031  0.0108  0.0034  0.0108  0.0517  0.0004  0.0005  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0196  0.0016  0.0095  0.0016  0.0051  0.0000  0.1249  0.0000  0.0000 </r>
+        <r>  0.0463  0.0094  0.0198  0.0094  0.0010  0.0000  0.0617  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0020  0.0310  0.0005  0.0310  0.0076  0.0125  0.0236  0.0125  0.0000 </r>
+        <r>  0.0095  0.0408  0.0045  0.0408  0.0060  0.0040  0.0150  0.0040  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0174  0.0002  0.0174  0.0234  0.0193  0.0106  0.0193  0.0000 </r>
+        <r>  0.0064  0.0409  0.0075  0.0409  0.0016  0.0053  0.0075  0.0053  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0156  0.0000  0.0156  0.0000  0.0000  0.0000  0.0000  0.1969 </r>
+        <r>  0.0000  0.0429  0.0000  0.0428  0.0000  0.0000  0.0000  0.0000  0.0842 </r>
+       </set>
+      </set>
+      <set comment="kpoint 34">
+       <set comment="band 1">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9761 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0001  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0702  0.0000  0.9062  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4903  0.0000  0.4875  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4878  0.0000  0.4905  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9081  0.0000  0.0704  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4551  0.0009  0.0000  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1435  0.0019  0.0000  0.0019  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2287  0.0130  0.0000  0.0130  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.4998  0.0026  0.0000  0.0026  0.0001  0.0000  0.0004  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.3448  0.0000  0.0000  0.0006  0.0000  0.0006  0.0000 </r>
+        <r>  0.0000  0.0000  0.1117  0.0000  0.0000  0.0014  0.0000  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2260  0.0000  0.2260  0.0000  0.0000  0.0000  0.0000  0.0004 </r>
+        <r>  0.0000  0.0242  0.0000  0.0242  0.0000  0.0000  0.0000  0.0000  0.0106 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0182  0.1982  0.0000  0.1982  0.0007  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0890  0.0249  0.0000  0.0249  0.0028  0.0000  0.0031  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0498  0.0202  0.0000  0.0202  0.0056  0.0000  0.0080  0.0000  0.0000 </r>
+        <r>  0.0216  0.1549  0.0000  0.1549  0.0000  0.0000  0.0029  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0188  0.0000  0.0188  0.0000  0.0000  0.0000  0.0000  0.0283 </r>
+        <r>  0.0000  0.1945  0.0000  0.1945  0.0000  0.0000  0.0000  0.0000  0.0080 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.1826  0.0000  0.0000  0.0103  0.0000  0.0103  0.0000 </r>
+        <r>  0.0000  0.0000  0.2705  0.0000  0.0000  0.0015  0.0000  0.0015  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0012  0.0000  0.0000  0.0233  0.0000  0.0233  0.0000 </r>
+        <r>  0.0000  0.0000  0.1298  0.0000  0.0000  0.0212  0.0000  0.0212  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0561  0.0000  0.0561  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0321  0.0000  0.0322  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0071  0.0122  0.0000  0.0122  0.1127  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0029  0.0101  0.0000  0.0101  0.0586  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0275  0.0018  0.0000  0.0018  0.0019  0.0000  0.1237  0.0000  0.0000 </r>
+        <r>  0.0552  0.0066  0.0000  0.0066  0.0007  0.0000  0.0661  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0007  0.0000  0.0000  0.0264  0.0000  0.0265  0.0000 </r>
+        <r>  0.0000  0.0000  0.0089  0.0000  0.0000  0.0098  0.0000  0.0098  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0177  0.0339  0.0000  0.0339  0.0050  0.0000  0.0629  0.0000  0.0000 </r>
+        <r>  0.0444  0.0743  0.0000  0.0743  0.0001  0.0000  0.0357  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0151  0.0000  0.0151  0.0000  0.0000  0.0000  0.0000  0.1842 </r>
+        <r>  0.0000  0.0383  0.0000  0.0383  0.0000  0.0000  0.0000  0.0000  0.0908 </r>
+       </set>
+      </set>
+      <set comment="kpoint 35">
+       <set comment="band 1">
+        <r>  0.0007  0.0000  0.0005  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9744  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9775 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9774  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.3934  0.0000  0.5852  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.5852  0.0000  0.3934  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4572  0.0000  0.0020  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1431  0.0000  0.0035  0.0000  0.0000  0.0000  0.0015  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2360  0.0000  0.0194  0.0000  0.0000  0.0000  0.0006  0.0000  0.0000 </r>
+        <r>  0.5146  0.0000  0.0024  0.0000  0.0000  0.0000  0.0014  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.2101  0.0000  0.1405  0.0000  0.0005  0.0000  0.0003  0.0000 </r>
+        <r>  0.0000  0.0676  0.0000  0.0452  0.0000  0.0011  0.0000  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1405  0.0000  0.2101  0.0000  0.0003  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0452  0.0000  0.0676  0.0000  0.0008  0.0000  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0001  0.0000  0.3895  0.0000  0.0000  0.0000  0.0029  0.0000  0.0000 </r>
+        <r>  0.0754  0.0000  0.0244  0.0000  0.0000  0.0000  0.0140  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0490  0.0000  0.0736  0.0000  0.0000  0.0000  0.0174  0.0000  0.0000 </r>
+        <r>  0.0032  0.0000  0.3662  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.1092  0.0000  0.0686  0.0000  0.0061  0.0000  0.0038  0.0000 </r>
+        <r>  0.0000  0.2126  0.0000  0.1335  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0686  0.0000  0.1092  0.0000  0.0038  0.0000  0.0061  0.0000 </r>
+        <r>  0.0000  0.1335  0.0000  0.2126  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0721  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0536  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0008  0.0000  0.0012  0.0000  0.0435  0.0000  0.0699  0.0000 </r>
+        <r>  0.0000  0.0243  0.0000  0.0390  0.0000  0.0232  0.0000  0.0373  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0012  0.0000  0.0008  0.0000  0.0699  0.0000  0.0435  0.0000 </r>
+        <r>  0.0000  0.0390  0.0000  0.0243  0.0000  0.0373  0.0000  0.0232  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0558  0.0000  0.0068  0.0000  0.0000  0.0000  0.0612  0.0000  0.0000 </r>
+        <r>  0.1060  0.0000  0.0133  0.0000  0.0000  0.0000  0.0292  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1976 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1105 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0394  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0143  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0058  0.0000  0.0591  0.0000  0.0000  0.0000  0.1379  0.0000  0.0000 </r>
+        <r>  0.0154  0.0000  0.1378  0.0000  0.0000  0.0000  0.0636  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 36">
+       <set comment="band 1">
+        <r>  0.0011  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0002  0.0006  0.9720  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0104  0.0000  0.0105  0.9565 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9728  0.0022  0.0002  0.0022  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0043  0.4868  0.0012  0.4866  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4789  0.0000  0.4791  0.0210 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4729  0.0000  0.0024  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1328  0.0001  0.0043  0.0001  0.0000  0.0000  0.0025  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2142  0.0012  0.0193  0.0012  0.0000  0.0000  0.0008  0.0000  0.0000 </r>
+        <r>  0.5165  0.0003  0.0017  0.0003  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1708  0.0000  0.1708  0.0000  0.0004  0.0000  0.0004  0.0001 </r>
+        <r>  0.0000  0.0570  0.0000  0.0570  0.0000  0.0010  0.0000  0.0010  0.0005 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0029  0.1670  0.0043  0.1670  0.0001  0.0004  0.0000  0.0004  0.0000 </r>
+        <r>  0.0032  0.0562  0.0001  0.0562  0.0003  0.0009  0.0007  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.0010  0.3143  0.0010  0.0000  0.0000  0.0047  0.0000  0.0000 </r>
+        <r>  0.0731  0.0006  0.0637  0.0006  0.0000  0.0001  0.0123  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0485  0.0002  0.1466  0.0002  0.0000  0.0004  0.0155  0.0004  0.0000 </r>
+        <r>  0.0106  0.0002  0.3187  0.0002  0.0000  0.0001  0.0019  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0024  0.0774  0.0003  0.0774  0.0175  0.0033  0.0020  0.0033  0.0000 </r>
+        <r>  0.0059  0.1177  0.0030  0.1177  0.0099  0.0000  0.0005  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0902  0.0000  0.0902  0.0000  0.0046  0.0000  0.0046  0.0053 </r>
+        <r>  0.0000  0.1673  0.0000  0.1673  0.0000  0.0000  0.0000  0.0000  0.0030 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0012  0.0123  0.0000  0.0123  0.0527  0.0009  0.0007  0.0009  0.0000 </r>
+        <r>  0.0017  0.0475  0.0006  0.0475  0.0431  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0122  0.0049  0.0061  0.0049  0.0018  0.0487  0.0074  0.0486  0.0000 </r>
+        <r>  0.0153  0.0139  0.0001  0.0139  0.0006  0.0234  0.0039  0.0234  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0030  0.0000  0.0030  0.0000  0.0574  0.0000  0.0574  0.0146 </r>
+        <r>  0.0000  0.0239  0.0000  0.0239  0.0000  0.0267  0.0000  0.0267  0.0064 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0360  0.0034  0.0047  0.0034  0.0004  0.0084  0.0534  0.0084  0.0000 </r>
+        <r>  0.0799  0.0255  0.0176  0.0255  0.0001  0.0037  0.0222  0.0037  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0026  0.0000  0.0026  0.0000  0.0031  0.0000  0.0031  0.1805 </r>
+        <r>  0.0000  0.0147  0.0000  0.0147  0.0000  0.0015  0.0000  0.0015  0.0994 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0406  0.0038  0.0000  0.0038  0.0000 </r>
+        <r>  0.0000  0.0017  0.0001  0.0017  0.0131  0.0010  0.0000  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0016  0.0794  0.0019  0.0000  0.0058  0.1158  0.0069  0.0000 </r>
+        <r>  0.0033  0.0006  0.1579  0.0007  0.0000  0.0029  0.0559  0.0035  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 37">
+       <set comment="band 1">
+        <r>  0.0015  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0024  0.0016  0.9670  0.0016  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0253  0.0000  0.0253  0.9266 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9601  0.0078  0.0017  0.0078  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0149  0.4802  0.0039  0.4801  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4642  0.0000  0.4643  0.0508 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4986  0.0002  0.0025  0.0002  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.1154  0.0006  0.0049  0.0006  0.0000  0.0000  0.0036  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1788  0.0042  0.0176  0.0042  0.0000  0.0000  0.0010  0.0000  0.0000 </r>
+        <r>  0.5209  0.0010  0.0009  0.0010  0.0000  0.0001  0.0017  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.1684  0.0000  0.1684  0.0000  0.0003  0.0000  0.0003  0.0005 </r>
+        <r>  0.0000  0.0562  0.0000  0.0562  0.0000  0.0009  0.0000  0.0009  0.0020 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0120  0.1435  0.0398  0.1435  0.0004  0.0004  0.0000  0.0004  0.0000 </r>
+        <r>  0.0035  0.0484  0.0064  0.0484  0.0009  0.0005  0.0042  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0016  0.0148  0.2400  0.0148  0.0001  0.0000  0.0054  0.0000  0.0000 </r>
+        <r>  0.0810  0.0069  0.0811  0.0069  0.0001  0.0006  0.0077  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0488  0.0025  0.1832  0.0025  0.0002  0.0015  0.0128  0.0015  0.0000 </r>
+        <r>  0.0115  0.0025  0.2743  0.0025  0.0001  0.0002  0.0045  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0052  0.0817  0.0048  0.0817  0.0140  0.0021  0.0069  0.0021  0.0000 </r>
+        <r>  0.0216  0.1104  0.0188  0.1104  0.0050  0.0001  0.0008  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0854  0.0000  0.0854  0.0000  0.0037  0.0000  0.0037  0.0149 </r>
+        <r>  0.0000  0.1601  0.0000  0.1601  0.0000  0.0000  0.0000  0.0000  0.0081 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0035  0.0025  0.0000  0.0025  0.0549  0.0005  0.0017  0.0005  0.0000 </r>
+        <r>  0.0031  0.0415  0.0010  0.0415  0.0466  0.0001  0.0003  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0124  0.0109  0.0159  0.0109  0.0051  0.0463  0.0049  0.0463  0.0000 </r>
+        <r>  0.0108  0.0057  0.0012  0.0057  0.0016  0.0209  0.0030  0.0208  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0068  0.0000  0.0068  0.0000  0.0612  0.0000  0.0612  0.0265 </r>
+        <r>  0.0000  0.0154  0.0000  0.0154  0.0000  0.0225  0.0000  0.0225  0.0094 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0205  0.0126  0.0065  0.0126  0.0009  0.0103  0.0522  0.0103  0.0000 </r>
+        <r>  0.0615  0.0462  0.0286  0.0462  0.0001  0.0014  0.0171  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0081  0.0000  0.0081  0.0000  0.0070  0.0000  0.0070  0.1593 </r>
+        <r>  0.0000  0.0339  0.0000  0.0339  0.0000  0.0013  0.0000  0.0014  0.0856 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0008  0.0000  0.0001  0.0001  0.0402  0.0176  0.0000  0.0174  0.0000 </r>
+        <r>  0.0001  0.0050  0.0031  0.0049  0.0109  0.0007  0.0000  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0090  0.0080  0.0236  0.0067  0.0003  0.0369  0.0077  0.0304  0.0303 </r>
+        <r>  0.0043  0.0006  0.0246  0.0006  0.0000  0.0322  0.0090  0.0267  0.0082 </r>
+       </set>
+      </set>
+      <set comment="kpoint 38">
+       <set comment="band 1">
+        <r>  0.0018  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0080  0.0024  0.9590  0.0024  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0322  0.0000  0.0322  0.9124 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9360  0.0180  0.0056  0.0180  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0336  0.4692  0.0073  0.4690  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4574  0.0000  0.4575  0.0647 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5378  0.0002  0.0022  0.0002  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0879  0.0015  0.0051  0.0015  0.0000  0.0000  0.0047  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1296  0.0076  0.0152  0.0076  0.0000  0.0000  0.0010  0.0000  0.0000 </r>
+        <r>  0.5352  0.0015  0.0003  0.0015  0.0001  0.0001  0.0012  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0182  0.0452  0.2047  0.0452  0.0002  0.0004  0.0014  0.0004  0.0000 </r>
+        <r>  0.0079  0.0126  0.0669  0.0126  0.0005  0.0000  0.0107  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1682  0.0000  0.1682  0.0000  0.0003  0.0000  0.0003  0.0010 </r>
+        <r>  0.0000  0.0539  0.0000  0.0539  0.0000  0.0008  0.0000  0.0008  0.0043 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0033  0.1031  0.0562  0.1031  0.0007  0.0001  0.0042  0.0001  0.0000 </r>
+        <r>  0.0876  0.0404  0.0336  0.0404  0.0015  0.0011  0.0001  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0563  0.0246  0.1535  0.0246  0.0025  0.0038  0.0045  0.0038  0.0000 </r>
+        <r>  0.0011  0.0271  0.1701  0.0271  0.0003  0.0001  0.0075  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0008  0.0608  0.0557  0.0608  0.0078  0.0002  0.0173  0.0002  0.0000 </r>
+        <r>  0.0460  0.0864  0.1045  0.0864  0.0011  0.0005  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0795  0.0000  0.0796  0.0000  0.0029  0.0000  0.0029  0.0223 </r>
+        <r>  0.0000  0.1566  0.0000  0.1566  0.0000  0.0001  0.0000  0.0001  0.0111 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0051  0.0003  0.0004  0.0003  0.0588  0.0003  0.0020  0.0003  0.0000 </r>
+        <r>  0.0019  0.0332  0.0004  0.0332  0.0484  0.0001  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0091  0.0161  0.0310  0.0161  0.0087  0.0414  0.0027  0.0413  0.0000 </r>
+        <r>  0.0058  0.0025  0.0055  0.0025  0.0022  0.0196  0.0016  0.0196  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0071  0.0000  0.0071  0.0000  0.0753  0.0000  0.0753  0.0245 </r>
+        <r>  0.0000  0.0157  0.0000  0.0157  0.0000  0.0163  0.0000  0.0163  0.0057 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0019  0.0205  0.0174  0.0205  0.0004  0.0244  0.0361  0.0244  0.0000 </r>
+        <r>  0.0275  0.0518  0.0588  0.0518  0.0000  0.0007  0.0057  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0195  0.0000  0.0195  0.0000  0.0113  0.0000  0.0114  0.1208 </r>
+        <r>  0.0000  0.0390  0.0000  0.0390  0.0000  0.0011  0.0000  0.0011  0.0623 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0040  0.0002  0.0044  0.0000  0.0218  0.0003  0.0168  0.0941 </r>
+        <r>  0.0004  0.0028  0.0002  0.0017  0.0000  0.0435  0.0002  0.0361  0.0336 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0399  0.0011  0.0197  0.0006  0.0032  0.0271  0.0285  0.0329  0.0010 </r>
+        <r>  0.0358  0.0050  0.0207  0.0058  0.0012  0.0156  0.0224  0.0216  0.0003 </r>
+       </set>
+      </set>
+      <set comment="kpoint 39">
+       <set comment="band 1">
+        <r>  0.0019  0.0001  0.0004  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0172  0.0030  0.9486  0.0029  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0317  0.0000  0.0317  0.9130 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8914  0.0376  0.0111  0.0376  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0692  0.4490  0.0121  0.4489  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4580  0.0000  0.4581  0.0637 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5916  0.0002  0.0015  0.0002  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0487  0.0028  0.0048  0.0028  0.0000  0.0000  0.0057  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0680  0.0109  0.0128  0.0109  0.0000  0.0000  0.0011  0.0000  0.0000 </r>
+        <r>  0.5643  0.0014  0.0000  0.0014  0.0001  0.0002  0.0006  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0147  0.0123  0.2444  0.0123  0.0001  0.0004  0.0020  0.0004  0.0000 </r>
+        <r>  0.0188  0.0021  0.0972  0.0021  0.0002  0.0004  0.0087  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1706  0.0000  0.1706  0.0000  0.0002  0.0000  0.0002  0.0016 </r>
+        <r>  0.0000  0.0499  0.0000  0.0499  0.0000  0.0006  0.0000  0.0006  0.0073 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0120  0.1278  0.0087  0.1278  0.0013  0.0001  0.0034  0.0001  0.0000 </r>
+        <r>  0.0865  0.0478  0.0108  0.0478  0.0027  0.0008  0.0012  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0555  0.0684  0.0452  0.0684  0.0067  0.0035  0.0003  0.0035  0.0000 </r>
+        <r>  0.0113  0.0851  0.0288  0.0851  0.0002  0.0000  0.0061  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0734  0.0000  0.0734  0.0000  0.0022  0.0000  0.0022  0.0268 </r>
+        <r>  0.0000  0.1576  0.0000  0.1576  0.0000  0.0002  0.0000  0.0002  0.0116 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0046  0.0145  0.1755  0.0145  0.0018  0.0012  0.0221  0.0012  0.0000 </r>
+        <r>  0.0438  0.0283  0.2318  0.0283  0.0000  0.0008  0.0026  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0060  0.0045  0.0013  0.0045  0.0619  0.0003  0.0024  0.0003  0.0000 </r>
+        <r>  0.0007  0.0298  0.0001  0.0298  0.0475  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0007  0.0268  0.0543  0.0268  0.0025  0.0080  0.0134  0.0080  0.0000 </r>
+        <r>  0.0060  0.0181  0.0419  0.0181  0.0011  0.0195  0.0001  0.0195  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.1044  0.0000  0.1044  0.0092 </r>
+        <r>  0.0000  0.0246  0.0000  0.0246  0.0000  0.0000  0.0000  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0080  0.0050  0.0161  0.0050  0.0104  0.0680  0.0002  0.0680  0.0000 </r>
+        <r>  0.0005  0.0133  0.0562  0.0133  0.0011  0.0063  0.0002  0.0063  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0329  0.0000  0.0330  0.0000  0.0006  0.0000  0.0006  0.0427 </r>
+        <r>  0.0000  0.0025  0.0000  0.0025  0.0000  0.0353  0.0000  0.0353  0.0150 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0012  0.0000  0.0012  0.0000  0.0004  0.0000  0.0004  0.2039 </r>
+        <r>  0.0000  0.0340  0.0000  0.0341  0.0000  0.0223  0.0000  0.0223  0.0785 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0325  0.0163  0.0035  0.0163  0.0003  0.0093  0.0612  0.0093  0.0000 </r>
+        <r>  0.0527  0.0378  0.0022  0.0377  0.0017  0.0128  0.0229  0.0128  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 40">
+       <set comment="band 1">
+        <r>  0.0019  0.0001  0.0003  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0291  0.0031  0.9366  0.0031  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0266  0.0000  0.0266  0.9228 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8017  0.0803  0.0157  0.0803  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1473  0.4069  0.0197  0.4052  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4623  0.0000  0.4640  0.0534 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6435  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0091  0.0044  0.0038  0.0044  0.0000  0.0000  0.0062  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0117  0.0136  0.0103  0.0136  0.0000  0.0000  0.0011  0.0000  0.0000 </r>
+        <r>  0.5985  0.0006  0.0002  0.0006  0.0002  0.0002  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0116  0.0057  0.2506  0.0057  0.0000  0.0005  0.0016  0.0005  0.0000 </r>
+        <r>  0.0173  0.0004  0.1076  0.0004  0.0001  0.0009  0.0061  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1762  0.0000  0.1762  0.0000  0.0001  0.0000  0.0001  0.0022 </r>
+        <r>  0.0000  0.0438  0.0000  0.0438  0.0000  0.0004  0.0000  0.0004  0.0109 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0161  0.1295  0.0022  0.1295  0.0017  0.0001  0.0034  0.0001  0.0000 </r>
+        <r>  0.0951  0.0458  0.0051  0.0458  0.0034  0.0006  0.0030  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0567  0.0751  0.0155  0.0751  0.0073  0.0022  0.0023  0.0022  0.0000 </r>
+        <r>  0.0249  0.1023  0.0049  0.1023  0.0000  0.0002  0.0041  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0660  0.0000  0.0660  0.0000  0.0016  0.0000  0.0016  0.0293 </r>
+        <r>  0.0000  0.1630  0.0000  0.1630  0.0000  0.0002  0.0000  0.0002  0.0101 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0069  0.0038  0.2143  0.0038  0.0006  0.0035  0.0189  0.0035  0.0000 </r>
+        <r>  0.0317  0.0123  0.2438  0.0123  0.0000  0.0005  0.0047  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0055  0.0112  0.0025  0.0112  0.0645  0.0006  0.0035  0.0006  0.0000 </r>
+        <r>  0.0003  0.0287  0.0002  0.0287  0.0448  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0081  0.0108  0.0283  0.0108  0.0017  0.0239  0.0066  0.0239  0.0000 </r>
+        <r>  0.0012  0.0160  0.0744  0.0160  0.0012  0.0172  0.0005  0.0172  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0035  0.0000  0.0035  0.0000  0.0768  0.0000  0.0769  0.0033 </r>
+        <r>  0.0000  0.0134  0.0000  0.0134  0.0000  0.0125  0.0000  0.0125  0.0001 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0022  0.0162  0.0489  0.0162  0.0179  0.0453  0.0028  0.0453  0.0000 </r>
+        <r>  0.0034  0.0037  0.0553  0.0037  0.0005  0.0080  0.0003  0.0080  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0264  0.0000  0.0265  0.0000  0.0276  0.0000  0.0277  0.0372 </r>
+        <r>  0.0000  0.0019  0.0000  0.0018  0.0000  0.0326  0.0000  0.0326  0.0058 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0008  0.0258  0.0011  0.0047  0.0096  0.0006  0.0120  0.0002  0.1682 </r>
+        <r>  0.0089  0.0944  0.0004  0.0085  0.0070  0.0226  0.0009  0.0019  0.0500 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0004  0.0125  0.0006  0.0310  0.0133  0.0003  0.0585  0.0014  0.0779 </r>
+        <r>  0.0263  0.0087  0.0046  0.0897  0.0114  0.0031  0.0000  0.0260  0.0233 </r>
+       </set>
+      </set>
+      <set comment="kpoint 41">
+       <set comment="band 1">
+        <r>  0.0017  0.0001  0.0002  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0432  0.0027  0.9238  0.0027  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0188  0.0000  0.0188  0.9381 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.5873  0.1884  0.0141  0.1884  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3479  0.2983  0.0347  0.2982  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4709  0.0000  0.4710  0.0377 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6482  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0041  0.0056  0.0022  0.0056  0.0000  0.0000  0.0056  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0065  0.0153  0.0071  0.0153  0.0000  0.0000  0.0010  0.0000  0.0000 </r>
+        <r>  0.6024  0.0000  0.0006  0.0000  0.0003  0.0001  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0080  0.0030  0.2574  0.0030  0.0000  0.0007  0.0010  0.0007  0.0000 </r>
+        <r>  0.0122  0.0001  0.1135  0.0001  0.0000  0.0013  0.0037  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1865  0.0000  0.1865  0.0000  0.0001  0.0000  0.0001  0.0024 </r>
+        <r>  0.0000  0.0347  0.0000  0.0347  0.0000  0.0003  0.0000  0.0003  0.0149 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0163  0.1326  0.0007  0.1326  0.0018  0.0000  0.0035  0.0000  0.0000 </r>
+        <r>  0.1055  0.0411  0.0024  0.0411  0.0038  0.0004  0.0046  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0630  0.0715  0.0064  0.0715  0.0075  0.0013  0.0037  0.0013  0.0000 </r>
+        <r>  0.0302  0.1115  0.0010  0.1116  0.0002  0.0002  0.0026  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0552  0.0000  0.0552  0.0000  0.0010  0.0000  0.0010  0.0307 </r>
+        <r>  0.0000  0.1729  0.0000  0.1729  0.0000  0.0002  0.0000  0.0002  0.0072 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0052  0.0013  0.2338  0.0013  0.0003  0.0059  0.0146  0.0059  0.0000 </r>
+        <r>  0.0216  0.0070  0.2361  0.0070  0.0000  0.0001  0.0051  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0016  0.0206  0.0061  0.0206  0.0581  0.0040  0.0076  0.0040  0.0000 </r>
+        <r>  0.0005  0.0216  0.0090  0.0216  0.0355  0.0029  0.0005  0.0029  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0130  0.0012  0.0106  0.0012  0.0126  0.0200  0.0022  0.0200  0.0000 </r>
+        <r>  0.0006  0.0204  0.0857  0.0204  0.0074  0.0160  0.0008  0.0160  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0029  0.0000  0.0029  0.0000  0.0659  0.0000  0.0659  0.0021 </r>
+        <r>  0.0000  0.0068  0.0000  0.0068  0.0000  0.0200  0.0000  0.0200  0.0001 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0017  0.0169  0.0571  0.0170  0.0242  0.0200  0.0336  0.0200  0.0000 </r>
+        <r>  0.0150  0.0013  0.0845  0.0012  0.0000  0.0016  0.0129  0.0016  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0044  0.0332  0.0044  0.0333  0.0678  0.0081  0.0861  0.0081  0.0000 </r>
+        <r>  0.0058  0.0132  0.0079  0.0135  0.0292  0.0003  0.0271  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0248  0.0000  0.0247  0.0000  0.0370  0.0000  0.0366  0.0394 </r>
+        <r>  0.0000  0.0035  0.0000  0.0035  0.0000  0.0276  0.0000  0.0274  0.0029 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0146  0.0035  0.0077  0.0038  0.0152  0.0353  0.0798  0.0367  0.0005 </r>
+        <r>  0.0165  0.0207  0.0013  0.0252  0.0198  0.0200  0.0205  0.0217  0.0001 </r>
+       </set>
+      </set>
+      <set comment="kpoint 42">
+       <set comment="band 1">
+        <r>  0.0014  0.0001  0.0001  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0582  0.0019  0.9113  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0102  0.0000  0.0102  0.9552 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2217  0.3764  0.0040  0.3761  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6987  0.1111  0.0581  0.1111  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4793  0.0000  0.4796  0.0204 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6003  0.0009  0.0000  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0390  0.0056  0.0009  0.0056  0.0000  0.0000  0.0042  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0571  0.0160  0.0037  0.0160  0.0000  0.0000  0.0009  0.0000  0.0000 </r>
+        <r>  0.5702  0.0003  0.0006  0.0003  0.0003  0.0001  0.0009  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0042  0.0014  0.2680  0.0014  0.0000  0.0008  0.0005  0.0008  0.0000 </r>
+        <r>  0.0064  0.0000  0.1173  0.0000  0.0000  0.0017  0.0017  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2029  0.0000  0.2029  0.0000  0.0000  0.0000  0.0000  0.0022 </r>
+        <r>  0.0000  0.0221  0.0000  0.0221  0.0000  0.0001  0.0000  0.0001  0.0189 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0126  0.1428  0.0002  0.1428  0.0015  0.0000  0.0034  0.0000  0.0000 </r>
+        <r>  0.1172  0.0328  0.0010  0.0328  0.0039  0.0002  0.0060  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0715  0.0609  0.0022  0.0609  0.0078  0.0007  0.0047  0.0007  0.0000 </r>
+        <r>  0.0275  0.1234  0.0002  0.1234  0.0005  0.0001  0.0014  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0389  0.0000  0.0389  0.0000  0.0005  0.0000  0.0005  0.0317 </r>
+        <r>  0.0000  0.1871  0.0000  0.1872  0.0000  0.0001  0.0000  0.0001  0.0036 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0027  0.0005  0.2480  0.0005  0.0002  0.0091  0.0088  0.0091  0.0000 </r>
+        <r>  0.0117  0.0037  0.2218  0.0037  0.0000  0.0000  0.0037  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0044  0.0074  0.0040  0.0074  0.0016  0.0206  0.0073  0.0206  0.0000 </r>
+        <r>  0.0016  0.0000  0.1191  0.0000  0.0011  0.0191  0.0021  0.0191  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0015  0.0000  0.0015  0.0000  0.0614  0.0000  0.0614  0.0010 </r>
+        <r>  0.0000  0.0030  0.0000  0.0030  0.0000  0.0243  0.0000  0.0243  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0061  0.0158  0.0007  0.0158  0.0741  0.0007  0.0064  0.0007  0.0000 </r>
+        <r>  0.0005  0.0439  0.0114  0.0439  0.0360  0.0007  0.0005  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0168  0.0068  0.0326  0.0068  0.0216  0.0024  0.0853  0.0024  0.0000 </r>
+        <r>  0.0322  0.0001  0.0634  0.0001  0.0000  0.0000  0.0404  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0415  0.0006  0.0415  0.0899  0.0035  0.0393  0.0035  0.0000 </r>
+        <r>  0.0018  0.0121  0.0002  0.0121  0.0479  0.0000  0.0099  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0237  0.0000  0.0238  0.0000  0.0358  0.0000  0.0380  0.0557 </r>
+        <r>  0.0000  0.0027  0.0000  0.0030  0.0000  0.0219  0.0000  0.0227  0.0011 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0104  0.0007  0.0298  0.0006  0.0017  0.0744  0.0528  0.0739  0.0003 </r>
+        <r>  0.0041  0.0167  0.0096  0.0195  0.0120  0.0173  0.0167  0.0172  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 43">
+       <set comment="band 1">
+        <r>  0.0010  0.0001  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0724  0.0007  0.9004  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0030  0.0000  0.0030  0.9694 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0326  0.4727  0.0001  0.4727  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4865  0.0000  0.4864  0.0061 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8737  0.0156  0.0739  0.0157  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5456  0.0014  0.0000  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0788  0.0049  0.0002  0.0049  0.0001  0.0000  0.0028  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1165  0.0162  0.0010  0.0162  0.0000  0.0000  0.0008  0.0000  0.0000 </r>
+        <r>  0.5355  0.0011  0.0002  0.0011  0.0003  0.0000  0.0013  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0012  0.0004  0.2824  0.0004  0.0000  0.0008  0.0001  0.0008  0.0000 </r>
+        <r>  0.0018  0.0000  0.1192  0.0000  0.0000  0.0019  0.0005  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2246  0.0000  0.2246  0.0000  0.0000  0.0000  0.0000  0.0012 </r>
+        <r>  0.0000  0.0074  0.0000  0.0074  0.0000  0.0000  0.0000  0.0000  0.0217 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0051  0.1661  0.0000  0.1661  0.0008  0.0000  0.0026  0.0000  0.0000 </r>
+        <r>  0.1317  0.0180  0.0002  0.0180  0.0039  0.0001  0.0071  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0811  0.0385  0.0004  0.0385  0.0082  0.0002  0.0060  0.0002  0.0000 </r>
+        <r>  0.0150  0.1422  0.0000  0.1422  0.0006  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0175  0.0000  0.0175  0.0000  0.0001  0.0000  0.0001  0.0326 </r>
+        <r>  0.0000  0.2036  0.0000  0.2036  0.0000  0.0000  0.0000  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0007  0.0001  0.2501  0.0001  0.0000  0.0126  0.0027  0.0126  0.0000 </r>
+        <r>  0.0033  0.0011  0.2048  0.0011  0.0000  0.0006  0.0013  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0024  0.0015  0.0003  0.0015  0.0000  0.0180  0.0030  0.0180  0.0000 </r>
+        <r>  0.0011  0.0001  0.1735  0.0001  0.0001  0.0199  0.0012  0.0199  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0591  0.0000  0.0591  0.0003 </r>
+        <r>  0.0000  0.0008  0.0000  0.0008  0.0000  0.0271  0.0000  0.0271  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0041  0.0205  0.0068  0.0205  0.0256  0.0001  0.0825  0.0001  0.0000 </r>
+        <r>  0.0268  0.0317  0.0175  0.0317  0.0140  0.0002  0.0311  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0260  0.0001  0.0036  0.0001  0.1145  0.0002  0.0254  0.0002  0.0000 </r>
+        <r>  0.0155  0.0241  0.0078  0.0241  0.0036  0.0000  0.0213  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0458  0.0004  0.0458  0.0521  0.0007  0.0316  0.0007  0.0000 </r>
+        <r>  0.0019  0.0035  0.0001  0.0035  0.0715  0.0001  0.0096  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0000  0.0006  0.0005  0.0019  0.0627  0.0005  0.0610  0.0021 </r>
+        <r>  0.0000  0.0032  0.0208  0.0003  0.0014  0.0025  0.0001  0.0028  0.0004 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0018  0.0039  0.0044  0.0005  0.0122  0.0162  0.0005  0.2558 </r>
+        <r>  0.0009  0.0108  0.0013  0.0599  0.0031  0.0056  0.0048  0.0000  0.0326 </r>
+       </set>
+      </set>
+      <set comment="kpoint 44">
+       <set comment="band 1">
+        <r>  0.0006  0.0001  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0821  0.0000  0.8930  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9756 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4890  0.0000  0.4890  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4894  0.0000  0.4894  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8965  0.0000  0.0824  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5046  0.0015  0.0000  0.0015  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1081  0.0039  0.0000  0.0039  0.0000  0.0000  0.0016  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1629  0.0160  0.0000  0.0160  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+        <r>  0.5122  0.0019  0.0000  0.0019  0.0003  0.0000  0.0011  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.3006  0.0000  0.0000  0.0008  0.0000  0.0008  0.0000 </r>
+        <r>  0.0000  0.0000  0.1184  0.0000  0.0000  0.0020  0.0000  0.0020  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2413  0.0000  0.2413  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0212 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0002  0.2001  0.0000  0.2001  0.0000  0.0000  0.0010  0.0000  0.0000 </r>
+        <r>  0.1415  0.0010  0.0000  0.0010  0.0040  0.0000  0.0071  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0843  0.0066  0.0000  0.0066  0.0083  0.0000  0.0078  0.0000  0.0000 </r>
+        <r>  0.0004  0.1635  0.0000  0.1635  0.0002  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0012  0.0000  0.0012  0.0000  0.0000  0.0000  0.0000  0.0328 </r>
+        <r>  0.0000  0.2125  0.0000  0.2125  0.0000  0.0000  0.0000  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2335  0.0000  0.0000  0.0139  0.0000  0.0139  0.0000 </r>
+        <r>  0.0000  0.0000  0.2059  0.0000  0.0000  0.0014  0.0000  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0032  0.0000  0.0000  0.0172  0.0000  0.0172  0.0000 </r>
+        <r>  0.0000  0.0000  0.1926  0.0000  0.0000  0.0199  0.0000  0.0199  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0578  0.0000  0.0578  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0292  0.0000  0.0292  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0267  0.0116  0.0000  0.0116  0.0022  0.0000  0.1120  0.0000  0.0000 </r>
+        <r>  0.0495  0.0040  0.0000  0.0041  0.0042  0.0000  0.0575  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0023  0.0145  0.0000  0.0145  0.1419  0.0000  0.0216  0.0000  0.0000 </r>
+        <r>  0.0009  0.0258  0.0000  0.0258  0.0372  0.0000  0.0043  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0029  0.0429  0.0000  0.0429  0.0432  0.0000  0.0090  0.0000  0.0000 </r>
+        <r>  0.0000  0.0420  0.0000  0.0420  0.0420  0.0000  0.0087  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0004  0.0000  0.0000  0.0395  0.0000  0.0395  0.0000 </r>
+        <r>  0.0000  0.0000  0.0148  0.0000  0.0000  0.0080  0.0000  0.0080  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0007  0.0165  0.0000  0.0100  0.0004  0.0000  0.0030  0.0000  0.2177 </r>
+        <r>  0.0011  0.0601  0.0000  0.0313  0.0010  0.0000  0.0009  0.0000  0.0721 </r>
+       </set>
+      </set>
+      <set comment="kpoint 45">
+       <set comment="band 1">
+        <r>  0.0018  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9720  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9772  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9777 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.3921  0.0000  0.5870  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.5870  0.0000  0.3921  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4858  0.0000  0.0027  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.1255  0.0000  0.0048  0.0000  0.0000  0.0000  0.0042  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2035  0.0000  0.0190  0.0000  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+        <r>  0.5287  0.0000  0.0010  0.0000  0.0000  0.0000  0.0024  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0780  0.0000  0.2524  0.0000  0.0002  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0279  0.0000  0.0903  0.0000  0.0004  0.0000  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.2524  0.0000  0.0780  0.0000  0.0005  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0903  0.0000  0.0279  0.0000  0.0014  0.0000  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0050  0.0000  0.2711  0.0000  0.0000  0.0000  0.0051  0.0000  0.0000 </r>
+        <r>  0.0645  0.0000  0.0907  0.0000  0.0000  0.0000  0.0106  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0443  0.0000  0.2048  0.0000  0.0000  0.0000  0.0154  0.0000  0.0000 </r>
+        <r>  0.0164  0.0000  0.2942  0.0000  0.0000  0.0000  0.0041  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0685  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0536  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0315  0.0000  0.1709  0.0000  0.0015  0.0000  0.0082  0.0000 </r>
+        <r>  0.0000  0.0531  0.0000  0.2876  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.1709  0.0000  0.0315  0.0000  0.0082  0.0000  0.0015  0.0000 </r>
+        <r>  0.0000  0.2876  0.0000  0.0531  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0496  0.0000  0.0088  0.0000  0.0000  0.0000  0.0640  0.0000  0.0000 </r>
+        <r>  0.1025  0.0000  0.0205  0.0000  0.0000  0.0000  0.0248  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.2040 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1096 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0019  0.0000  0.0015  0.0000  0.0707  0.0000  0.0576  0.0000 </r>
+        <r>  0.0000  0.0389  0.0000  0.0317  0.0000  0.0287  0.0000  0.0234  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0015  0.0000  0.0019  0.0000  0.0576  0.0000  0.0707  0.0000 </r>
+        <r>  0.0000  0.0317  0.0000  0.0389  0.0000  0.0234  0.0000  0.0287  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0444  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0130  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0171  0.0011  0.1032  0.0028  0.0000  0.0054  0.0296  0.0120  0.0019 </r>
+        <r>  0.0032  0.0003  0.1280  0.0007  0.0000  0.0028  0.0381  0.0059  0.0004 </r>
+       </set>
+      </set>
+      <set comment="kpoint 46">
+       <set comment="band 1">
+        <r>  0.0024  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0003  0.9701  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9752  0.0009  0.0001  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0071  0.0000  0.0071  0.9634 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0017  0.4887  0.0005  0.4884  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4824  0.0000  0.4828  0.0143 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5077  0.0000  0.0027  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.1121  0.0002  0.0049  0.0002  0.0000  0.0000  0.0059  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1781  0.0012  0.0171  0.0012  0.0000  0.0000  0.0016  0.0000  0.0000 </r>
+        <r>  0.5397  0.0003  0.0004  0.0003  0.0000  0.0000  0.0025  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0082  0.0825  0.1290  0.0825  0.0001  0.0002  0.0015  0.0002  0.0000 </r>
+        <r>  0.0125  0.0293  0.0489  0.0293  0.0001  0.0002  0.0059  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1618  0.0000  0.1618  0.0000  0.0003  0.0000  0.0003  0.0001 </r>
+        <r>  0.0000  0.0596  0.0000  0.0596  0.0000  0.0008  0.0000  0.0008  0.0005 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0005  0.0766  0.1189  0.0766  0.0001  0.0001  0.0033  0.0001  0.0000 </r>
+        <r>  0.0512  0.0299  0.0554  0.0299  0.0001  0.0006  0.0029  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0414  0.0015  0.2352  0.0015  0.0002  0.0006  0.0140  0.0006  0.0000 </r>
+        <r>  0.0157  0.0015  0.2711  0.0015  0.0001  0.0001  0.0062  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0205  0.0018  0.0205  0.0600  0.0004  0.0005  0.0004  0.0000 </r>
+        <r>  0.0016  0.0136  0.0032  0.0136  0.0447  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.1018  0.0000  0.1018  0.0000  0.0041  0.0000  0.0041  0.0054 </r>
+        <r>  0.0000  0.1670  0.0000  0.1670  0.0000  0.0000  0.0000  0.0000  0.0030 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0023  0.0797  0.0016  0.0797  0.0074  0.0033  0.0027  0.0033  0.0000 </r>
+        <r>  0.0075  0.1503  0.0061  0.1503  0.0087  0.0001  0.0003  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0382  0.0090  0.0133  0.0090  0.0003  0.0091  0.0518  0.0091  0.0000 </r>
+        <r>  0.0786  0.0004  0.0160  0.0004  0.0001  0.0044  0.0176  0.0044  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0063  0.0000  0.0063  0.0000  0.0152  0.0000  0.0152  0.1665 </r>
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0053  0.0000  0.0053  0.0833 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0027  0.0001  0.0000  0.0001  0.0015  0.0592  0.0111  0.0593  0.0000 </r>
+        <r>  0.0128  0.0407  0.0126  0.0407  0.0003  0.0169  0.0029  0.0169  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0571  0.0000  0.0571  0.0357 </r>
+        <r>  0.0000  0.0403  0.0000  0.0403  0.0000  0.0164  0.0000  0.0164  0.0213 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0447  0.0054  0.0000  0.0063  0.0002 </r>
+        <r>  0.0000  0.0015  0.0004  0.0016  0.0114  0.0003  0.0000  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0291  0.0053  0.0499  0.0050  0.0002  0.0319  0.0054  0.0309  0.0004 </r>
+        <r>  0.0125  0.0002  0.0494  0.0002  0.0000  0.0246  0.0170  0.0232  0.0001 </r>
+       </set>
+      </set>
+      <set comment="kpoint 47">
+       <set comment="band 1">
+        <r>  0.0028  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0015  0.0007  0.9671  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0160  0.0000  0.0160  0.9455 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9700  0.0030  0.0012  0.0030  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0057  0.4862  0.0015  0.4860  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4738  0.0000  0.4739  0.0321 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5410  0.0001  0.0023  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0905  0.0007  0.0047  0.0007  0.0000  0.0000  0.0077  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1375  0.0042  0.0141  0.0042  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.5539  0.0009  0.0001  0.0009  0.0000  0.0001  0.0020  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0100  0.0090  0.2301  0.0090  0.0000  0.0002  0.0028  0.0002  0.0000 </r>
+        <r>  0.0323  0.0023  0.1041  0.0023  0.0001  0.0001  0.0074  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1604  0.0000  0.1604  0.0000  0.0002  0.0000  0.0002  0.0005 </r>
+        <r>  0.0000  0.0587  0.0000  0.0587  0.0000  0.0006  0.0000  0.0006  0.0019 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0048  0.1415  0.0075  0.1415  0.0005  0.0002  0.0016  0.0002  0.0000 </r>
+        <r>  0.0379  0.0554  0.0074  0.0554  0.0010  0.0007  0.0002  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0344  0.0474  0.1111  0.0474  0.0157  0.0027  0.0019  0.0027  0.0000 </r>
+        <r>  0.0000  0.0424  0.0956  0.0424  0.0080  0.0000  0.0061  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0086  0.0215  0.1399  0.0215  0.0251  0.0001  0.0118  0.0001  0.0000 </r>
+        <r>  0.0223  0.0137  0.1565  0.0137  0.0159  0.0002  0.0021  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0964  0.0000  0.0964  0.0000  0.0030  0.0000  0.0030  0.0154 </r>
+        <r>  0.0000  0.1614  0.0000  0.1614  0.0000  0.0001  0.0000  0.0001  0.0082 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0038  0.0291  0.0084  0.0291  0.0266  0.0010  0.0064  0.0010  0.0000 </r>
+        <r>  0.0147  0.1006  0.0194  0.1006  0.0286  0.0002  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0209  0.0238  0.0281  0.0238  0.0015  0.0096  0.0394  0.0097  0.0000 </r>
+        <r>  0.0495  0.0032  0.0121  0.0032  0.0006  0.0099  0.0091  0.0099  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0146  0.0000  0.0146  0.0000  0.0326  0.0000  0.0326  0.1334 </r>
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0088  0.0000  0.0087  0.0573 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0001  0.0005  0.0000  0.0005  0.0032  0.0670  0.0140  0.0670  0.0000 </r>
+        <r>  0.0107  0.0438  0.0434  0.0438  0.0004  0.0054  0.0018  0.0054  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0020  0.0000  0.0020  0.0000  0.0585  0.0000  0.0586  0.0518 </r>
+        <r>  0.0000  0.0473  0.0000  0.0474  0.0000  0.0038  0.0000  0.0038  0.0317 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0435  0.0003  0.0271  0.0004  0.0025  0.0257  0.0131  0.0261  0.0000 </r>
+        <r>  0.0303  0.0024  0.0242  0.0025  0.0006  0.0241  0.0207  0.0247  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0066  0.0000  0.0065  0.0000  0.0180  0.0000  0.0188  0.0640 </r>
+        <r>  0.0000  0.0011  0.0000  0.0009  0.0000  0.0395  0.0000  0.0379  0.0231 </r>
+       </set>
+      </set>
+      <set comment="kpoint 48">
+       <set comment="band 1">
+        <r>  0.0031  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0055  0.0009  0.9622  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0182  0.0000  0.0182  0.9407 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9603  0.0061  0.0048  0.0061  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0116  0.4827  0.0026  0.4826  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4716  0.0000  0.4718  0.0365 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5867  0.0001  0.0015  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0588  0.0017  0.0039  0.0017  0.0000  0.0000  0.0092  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0841  0.0079  0.0107  0.0079  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.5769  0.0013  0.0000  0.0013  0.0001  0.0001  0.0010  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0092  0.0042  0.2332  0.0042  0.0000  0.0002  0.0020  0.0002  0.0000 </r>
+        <r>  0.0247  0.0007  0.1121  0.0007  0.0000  0.0003  0.0054  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1611  0.0000  0.1611  0.0000  0.0002  0.0000  0.0002  0.0010 </r>
+        <r>  0.0000  0.0565  0.0000  0.0565  0.0000  0.0004  0.0000  0.0004  0.0041 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0114  0.1371  0.0019  0.1371  0.0010  0.0001  0.0020  0.0001  0.0000 </r>
+        <r>  0.0541  0.0544  0.0038  0.0544  0.0020  0.0005  0.0013  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0331  0.0871  0.0259  0.0871  0.0148  0.0024  0.0006  0.0024  0.0000 </r>
+        <r>  0.0123  0.0870  0.0120  0.0870  0.0037  0.0001  0.0043  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0901  0.0000  0.0901  0.0000  0.0020  0.0000  0.0020  0.0233 </r>
+        <r>  0.0000  0.1588  0.0000  0.1588  0.0000  0.0002  0.0000  0.0002  0.0115 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0125  0.0074  0.2438  0.0074  0.0058  0.0018  0.0154  0.0018  0.0000 </r>
+        <r>  0.0258  0.0066  0.2399  0.0066  0.0027  0.0003  0.0045  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0052  0.0019  0.0036  0.0019  0.0475  0.0002  0.0049  0.0002  0.0000 </r>
+        <r>  0.0075  0.0572  0.0098  0.0572  0.0444  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0215  0.0335  0.0215  0.0005  0.0120  0.0263  0.0120  0.0000 </r>
+        <r>  0.0167  0.0174  0.0653  0.0174  0.0004  0.0128  0.0004  0.0128  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0013  0.0000  0.0013  0.0000  0.0980  0.0000  0.0980  0.0004 </r>
+        <r>  0.0000  0.0249  0.0000  0.0249  0.0000  0.0012  0.0000  0.0012  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0088  0.0083  0.0165  0.0083  0.0068  0.0749  0.0023  0.0749  0.0000 </r>
+        <r>  0.0052  0.0098  0.0346  0.0098  0.0008  0.0060  0.0006  0.0060  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0269  0.0000  0.0269  0.0000  0.0107  0.0000  0.0108  0.1369 </r>
+        <r>  0.0000  0.0028  0.0000  0.0028  0.0000  0.0123  0.0000  0.0123  0.0526 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0007  0.0000  0.0007  0.0000  0.0002  0.0000  0.0002  0.1201 </r>
+        <r>  0.0000  0.0263  0.0000  0.0264  0.0000  0.0375  0.0000  0.0375  0.0528 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0487  0.0059  0.0090  0.0059  0.0018  0.0053  0.0395  0.0053  0.0000 </r>
+        <r>  0.0563  0.0312  0.0008  0.0312  0.0005  0.0178  0.0293  0.0178  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 49">
+       <set comment="band 1">
+        <r>  0.0030  0.0001  0.0002  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0132  0.0010  0.9547  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0147  0.0000  0.0146  0.9473 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9438  0.0111  0.0115  0.0112  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0207  0.4756  0.0037  0.4794  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4772  0.0000  0.4733  0.0294 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6367  0.0000  0.0006  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0218  0.0032  0.0026  0.0032  0.0000  0.0000  0.0099  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0285  0.0114  0.0072  0.0114  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.6070  0.0010  0.0001  0.0010  0.0002  0.0001  0.0002  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0070  0.0023  0.2372  0.0023  0.0000  0.0004  0.0012  0.0004  0.0000 </r>
+        <r>  0.0157  0.0002  0.1168  0.0002  0.0000  0.0007  0.0034  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1642  0.0000  0.1642  0.0000  0.0001  0.0000  0.0001  0.0017 </r>
+        <r>  0.0000  0.0527  0.0000  0.0527  0.0000  0.0003  0.0000  0.0003  0.0070 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0166  0.1315  0.0006  0.1315  0.0014  0.0001  0.0026  0.0001  0.0000 </r>
+        <r>  0.0710  0.0518  0.0020  0.0518  0.0029  0.0003  0.0027  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0410  0.0925  0.0102  0.0925  0.0107  0.0015  0.0023  0.0015  0.0000 </r>
+        <r>  0.0256  0.1023  0.0024  0.1023  0.0006  0.0001  0.0035  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0836  0.0000  0.0836  0.0000  0.0012  0.0000  0.0012  0.0282 </r>
+        <r>  0.0000  0.1603  0.0000  0.1603  0.0000  0.0002  0.0000  0.0002  0.0121 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0071  0.0032  0.2755  0.0032  0.0009  0.0043  0.0138  0.0043  0.0000 </r>
+        <r>  0.0213  0.0066  0.2445  0.0066  0.0001  0.0002  0.0045  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0067  0.0014  0.0000  0.0014  0.0582  0.0002  0.0032  0.0002  0.0000 </r>
+        <r>  0.0020  0.0397  0.0010  0.0397  0.0481  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0048  0.0091  0.0166  0.0091  0.0004  0.0254  0.0113  0.0254  0.0000 </r>
+        <r>  0.0037  0.0093  0.0998  0.0093  0.0004  0.0162  0.0007  0.0162  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0029  0.0000  0.0029  0.0000  0.0748  0.0000  0.0751  0.0010 </r>
+        <r>  0.0000  0.0098  0.0000  0.0098  0.0000  0.0127  0.0000  0.0127  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0014  0.0165  0.0434  0.0165  0.0105  0.0460  0.0203  0.0460  0.0000 </r>
+        <r>  0.0134  0.0034  0.0451  0.0034  0.0006  0.0050  0.0011  0.0050  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0288  0.0000  0.0286  0.0000  0.0265  0.0000  0.0263  0.1149 </r>
+        <r>  0.0000  0.0002  0.0000  0.0001  0.0000  0.0147  0.0000  0.0146  0.0312 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0011  0.0001  0.0001  0.0000  0.0057  0.0004  0.0077  0.1619 </r>
+        <r>  0.0001  0.0545  0.0002  0.0404  0.0000  0.0233  0.0006  0.0216  0.0658 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0218  0.0155  0.0025  0.0160  0.0008  0.0045  0.1129  0.0049  0.0001 </r>
+        <r>  0.0602  0.0414  0.0072  0.0459  0.0012  0.0131  0.0189  0.0148  0.0001 </r>
+       </set>
+      </set>
+      <set comment="kpoint 50">
+       <set comment="band 1">
+        <r>  0.0027  0.0001  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0249  0.0007  0.9442  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0084  0.0000  0.0084  0.9594 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9140  0.0212  0.0215  0.0212  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0391  0.4676  0.0049  0.4675  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4814  0.0000  0.4814  0.0169 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6621  0.0001  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0003  0.0048  0.0012  0.0048  0.0000  0.0000  0.0093  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0001  0.0141  0.0038  0.0141  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.6238  0.0003  0.0003  0.0003  0.0002  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0040  0.0011  0.2442  0.0011  0.0000  0.0005  0.0006  0.0005  0.0000 </r>
+        <r>  0.0076  0.0000  0.1201  0.0000  0.0000  0.0011  0.0017  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1706  0.0000  0.1706  0.0000  0.0000  0.0000  0.0000  0.0023 </r>
+        <r>  0.0000  0.0467  0.0000  0.0467  0.0000  0.0001  0.0000  0.0001  0.0105 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0192  0.1286  0.0002  0.1286  0.0018  0.0000  0.0031  0.0000  0.0000 </r>
+        <r>  0.0860  0.0482  0.0009  0.0483  0.0035  0.0001  0.0040  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0503  0.0897  0.0038  0.0897  0.0090  0.0007  0.0035  0.0007  0.0000 </r>
+        <r>  0.0341  0.1098  0.0004  0.1098  0.0000  0.0001  0.0028  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0752  0.0000  0.0752  0.0000  0.0006  0.0000  0.0006  0.0307 </r>
+        <r>  0.0000  0.1656  0.0000  0.1655  0.0000  0.0001  0.0000  0.0001  0.0107 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0031  0.0011  0.2928  0.0011  0.0002  0.0079  0.0084  0.0079  0.0000 </r>
+        <r>  0.0121  0.0040  0.2266  0.0040  0.0000  0.0000  0.0031  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0061  0.0071  0.0004  0.0071  0.0630  0.0003  0.0041  0.0003  0.0000 </r>
+        <r>  0.0009  0.0359  0.0006  0.0359  0.0463  0.0002  0.0001  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0064  0.0033  0.0037  0.0033  0.0009  0.0237  0.0065  0.0237  0.0000 </r>
+        <r>  0.0021  0.0043  0.1379  0.0043  0.0007  0.0184  0.0016  0.0184  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0016  0.0000  0.0016  0.0000  0.0666  0.0000  0.0666  0.0008 </r>
+        <r>  0.0000  0.0037  0.0000  0.0037  0.0000  0.0189  0.0000  0.0189  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0061  0.0111  0.0392  0.0111  0.0096  0.0111  0.0839  0.0111  0.0000 </r>
+        <r>  0.0317  0.0022  0.0600  0.0023  0.0003  0.0003  0.0253  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0284  0.0000  0.0312  0.0000  0.0285  0.0000  0.0270  0.1137 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0141  0.0000  0.0133  0.0195 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0236  0.0310  0.0026  0.0309  0.0351  0.0440  0.0874  0.0422  0.0000 </r>
+        <r>  0.0046  0.0040  0.0014  0.0046  0.0049  0.0079  0.0464  0.0073  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0060  0.0020  0.0039  0.0052  0.0202  0.0021  0.0108  0.1782 </r>
+        <r>  0.0020  0.0605  0.0000  0.0488  0.0028  0.0178  0.0000  0.0131  0.0535 </r>
+       </set>
+      </set>
+      <set comment="kpoint 51">
+       <set comment="band 1">
+        <r>  0.0022  0.0001  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0401  0.0003  0.9309  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0025  0.0000  0.0026  0.9708 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8184  0.0640  0.0318  0.0641  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1198  0.4254  0.0090  0.4246  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4869  0.0000  0.4876  0.0051 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6394  0.0005  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0139  0.0056  0.0003  0.0056  0.0000  0.0000  0.0073  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0222  0.0157  0.0010  0.0157  0.0000  0.0000  0.0015  0.0000  0.0000 </r>
+        <r>  0.6068  0.0000  0.0001  0.0000  0.0003  0.0000  0.0008  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0012  0.0003  0.2539  0.0003  0.0000  0.0006  0.0001  0.0006  0.0000 </r>
+        <r>  0.0020  0.0000  0.1220  0.0000  0.0000  0.0015  0.0004  0.0015  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1818  0.0000  0.1818  0.0000  0.0000  0.0000  0.0000  0.0027 </r>
+        <r>  0.0000  0.0375  0.0000  0.0375  0.0000  0.0000  0.0000  0.0000  0.0145 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0186  0.1305  0.0000  0.1305  0.0018  0.0000  0.0035  0.0000  0.0000 </r>
+        <r>  0.0996  0.0432  0.0002  0.0432  0.0038  0.0000  0.0053  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0601  0.0822  0.0008  0.0822  0.0083  0.0002  0.0043  0.0002  0.0000 </r>
+        <r>  0.0367  0.1164  0.0001  0.1164  0.0002  0.0000  0.0020  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0627  0.0000  0.0627  0.0000  0.0001  0.0000  0.0001  0.0317 </r>
+        <r>  0.0000  0.1746  0.0000  0.1746  0.0000  0.0000  0.0000  0.0000  0.0078 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0007  0.0003  0.2976  0.0003  0.0001  0.0121  0.0026  0.0121  0.0000 </r>
+        <r>  0.0035  0.0012  0.2008  0.0012  0.0000  0.0003  0.0011  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0037  0.0137  0.0001  0.0137  0.0637  0.0012  0.0079  0.0012  0.0000 </r>
+        <r>  0.0012  0.0350  0.0082  0.0350  0.0408  0.0011  0.0007  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0043  0.0000  0.0004  0.0000  0.0046  0.0187  0.0013  0.0186  0.0000 </r>
+        <r>  0.0007  0.0043  0.1840  0.0043  0.0028  0.0186  0.0007  0.0185  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0626  0.0000  0.0626  0.0003 </r>
+        <r>  0.0000  0.0009  0.0000  0.0009  0.0000  0.0226  0.0000  0.0226  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0212  0.0054  0.0120  0.0054  0.0088  0.0009  0.1181  0.0009  0.0000 </r>
+        <r>  0.0440  0.0010  0.0238  0.0010  0.0004  0.0000  0.0483  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0009  0.0569  0.0003  0.0568  0.1071  0.0039  0.0319  0.0039  0.0000 </r>
+        <r>  0.0001  0.0156  0.0001  0.0154  0.0352  0.0002  0.0119  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0300  0.0000  0.0298  0.0000  0.0167  0.0000  0.0195  0.1384 </r>
+        <r>  0.0000  0.0001  0.0000  0.0002  0.0000  0.0080  0.0000  0.0088  0.0108 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0054  0.0001  0.0434  0.0002  0.0037  0.1090  0.0212  0.1014  0.0005 </r>
+        <r>  0.0036  0.0119  0.0111  0.0105  0.0074  0.0199  0.0060  0.0178  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 52">
+       <set comment="band 1">
+        <r>  0.0016  0.0001  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0571  0.0000  0.9158  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9756 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4892  0.0000  0.4892  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9214  0.0000  0.0573  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4896  0.0000  0.4897  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5909  0.0011  0.0000  0.0011  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0472  0.0056  0.0000  0.0056  0.0000  0.0000  0.0048  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0710  0.0163  0.0000  0.0163  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+        <r>  0.5702  0.0004  0.0000  0.0004  0.0003  0.0000  0.0014  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2664  0.0000  0.0000  0.0008  0.0000  0.0008  0.0000 </r>
+        <r>  0.0000  0.0000  0.1220  0.0000  0.0000  0.0018  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1999  0.0000  0.1999  0.0000  0.0000  0.0000  0.0000  0.0024 </r>
+        <r>  0.0000  0.0239  0.0000  0.0239  0.0000  0.0000  0.0000  0.0000  0.0186 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0140  0.1408  0.0000  0.1408  0.0015  0.0000  0.0034  0.0000  0.0000 </r>
+        <r>  0.1137  0.0345  0.0000  0.0345  0.0039  0.0000  0.0063  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0704  0.0672  0.0000  0.0672  0.0081  0.0000  0.0050  0.0000  0.0000 </r>
+        <r>  0.0312  0.1256  0.0000  0.1256  0.0005  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0434  0.0000  0.0434  0.0000  0.0000  0.0000  0.0000  0.0321 </r>
+        <r>  0.0000  0.1878  0.0000  0.1878  0.0000  0.0000  0.0000  0.0000  0.0039 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2826  0.0000  0.0000  0.0144  0.0000  0.0144  0.0000 </r>
+        <r>  0.0000  0.0000  0.1866  0.0000  0.0000  0.0008  0.0000  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0037  0.0000  0.0000  0.0169  0.0000  0.0169  0.0000 </r>
+        <r>  0.0000  0.0000  0.2206  0.0000  0.0000  0.0199  0.0000  0.0199  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0604  0.0000  0.0604  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0253  0.0000  0.0253  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0019  0.0199  0.0000  0.0199  0.0690  0.0000  0.0174  0.0000  0.0000 </r>
+        <r>  0.0033  0.0428  0.0000  0.0428  0.0366  0.0000  0.0033  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0306  0.0022  0.0000  0.0022  0.0188  0.0000  0.1108  0.0000  0.0000 </r>
+        <r>  0.0454  0.0000  0.0000  0.0000  0.0016  0.0000  0.0539  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0003  0.0484  0.0000  0.0484  0.1075  0.0000  0.0244  0.0000  0.0000 </r>
+        <r>  0.0003  0.0135  0.0000  0.0135  0.0504  0.0000  0.0057  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0049  0.0201  0.0046  0.0000  0.0831  0.0000  0.0888  0.1131 </r>
+        <r>  0.0000  0.0034  0.0204  0.0039  0.0000  0.0029  0.0000  0.0037  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0115  0.0139  0.0084  0.0000  0.0582  0.0008  0.0480  0.1642 </r>
+        <r>  0.0000  0.0019  0.0123  0.0054  0.0001  0.0035  0.0002  0.0019  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 53">
+       <set comment="band 1">
+        <r>  0.0032  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9692  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9769  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9779 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4920  0.0000  0.4876  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4876  0.0000  0.4920  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5251  0.0000  0.0025  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.1035  0.0000  0.0046  0.0000  0.0000  0.0000  0.0084  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1647  0.0000  0.0153  0.0000  0.0000  0.0000  0.0021  0.0000  0.0000 </r>
+        <r>  0.5592  0.0000  0.0001  0.0000  0.0000  0.0000  0.0028  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0060  0.0000  0.2322  0.0000  0.0000  0.0000  0.0038  0.0000  0.0000 </r>
+        <r>  0.0506  0.0000  0.1125  0.0000  0.0000  0.0000  0.0064  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.3115  0.0000  0.0040  0.0000  0.0005  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.1207  0.0000  0.0016  0.0000  0.0012  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0040  0.0000  0.3115  0.0000  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0016  0.0000  0.1207  0.0000  0.0000  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0665  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0541  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0343  0.0000  0.2754  0.0000  0.0000  0.0000  0.0145  0.0000  0.0000 </r>
+        <r>  0.0168  0.0000  0.2739  0.0000  0.0000  0.0000  0.0072  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.1651  0.0000  0.0594  0.0000  0.0055  0.0000  0.0020  0.0000 </r>
+        <r>  0.0000  0.2542  0.0000  0.0915  0.0000  0.0001  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0594  0.0000  0.1651  0.0000  0.0020  0.0000  0.0055  0.0000 </r>
+        <r>  0.0000  0.0915  0.0000  0.2542  0.0000  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0428  0.0000  0.0094  0.0000  0.0000  0.0000  0.0669  0.0000  0.0000 </r>
+        <r>  0.1004  0.0000  0.0326  0.0000  0.0000  0.0000  0.0188  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.2160 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1103 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0002  0.0000  0.0036  0.0000  0.0082  0.0000  0.1537  0.0000 </r>
+        <r>  0.0000  0.0036  0.0000  0.0666  0.0000  0.0018  0.0000  0.0333  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0036  0.0000  0.0002  0.0000  0.1536  0.0000  0.0082  0.0000 </r>
+        <r>  0.0000  0.0667  0.0000  0.0036  0.0000  0.0333  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0006  0.0000  0.0008  0.0001  0.0470  0.0001  0.0000  0.0004  0.0006 </r>
+        <r>  0.0002  0.0000  0.0008  0.0000  0.0105  0.0000  0.0003  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0313  0.0003  0.0398  0.0007  0.0000  0.0014  0.0012  0.0033  0.0322 </r>
+        <r>  0.0117  0.0000  0.0424  0.0000  0.0000  0.0008  0.0149  0.0020  0.0091 </r>
+       </set>
+      </set>
+      <set comment="kpoint 54">
+       <set comment="band 1">
+        <r>  0.0038  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0001  0.9678  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9762  0.0003  0.0001  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0034  0.0000  0.0035  0.9709 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0006  0.4813  0.0002  0.4977  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4947  0.0000  0.4783  0.0070 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5517  0.0000  0.0020  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0883  0.0002  0.0038  0.0002  0.0000  0.0000  0.0108  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1364  0.0012  0.0120  0.0012  0.0000  0.0000  0.0025  0.0000  0.0000 </r>
+        <r>  0.5780  0.0003  0.0000  0.0003  0.0000  0.0000  0.0024  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0057  0.0009  0.2257  0.0009  0.0000  0.0000  0.0027  0.0000  0.0000 </r>
+        <r>  0.0376  0.0002  0.1164  0.0002  0.0000  0.0000  0.0046  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1556  0.0000  0.1556  0.0000  0.0002  0.0000  0.0002  0.0001 </r>
+        <r>  0.0000  0.0613  0.0000  0.0613  0.0000  0.0004  0.0000  0.0004  0.0005 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0019  0.1520  0.0005  0.1520  0.0001  0.0002  0.0003  0.0002  0.0000 </r>
+        <r>  0.0088  0.0607  0.0008  0.0607  0.0003  0.0004  0.0002  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0002  0.0088  0.0002  0.0088  0.0645  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0001  0.0022  0.0001  0.0022  0.0511  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0298  0.0351  0.1976  0.0351  0.0009  0.0021  0.0049  0.0021  0.0000 </r>
+        <r>  0.0027  0.0546  0.1624  0.0546  0.0014  0.0000  0.0068  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.1121  0.0000  0.1121  0.0000  0.0027  0.0000  0.0027  0.0056 </r>
+        <r>  0.0000  0.1711  0.0000  0.1711  0.0000  0.0001  0.0000  0.0001  0.0030 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0016  0.0685  0.1049  0.0685  0.0007  0.0008  0.0098  0.0008  0.0000 </r>
+        <r>  0.0174  0.1133  0.1086  0.1133  0.0015  0.0001  0.0011  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0319  0.0076  0.0125  0.0076  0.0000  0.0001  0.0644  0.0001  0.0000 </r>
+        <r>  0.0870  0.0044  0.0402  0.0044  0.0000  0.0013  0.0131  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0053  0.0000  0.0053  0.0000  0.0004  0.0000  0.0004  0.2171 </r>
+        <r>  0.0000  0.0035  0.0000  0.0035  0.0000  0.0005  0.0000  0.0005  0.1056 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0006  0.0013  0.0006  0.0013  0.0012  0.0959  0.0003  0.0959  0.0000 </r>
+        <r>  0.0000  0.0317  0.0111  0.0317  0.0002  0.0085  0.0000  0.0085  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0010  0.0000  0.0010  0.0000  0.1010  0.0000  0.1009  0.0000 </r>
+        <r>  0.0000  0.0332  0.0000  0.0332  0.0000  0.0080  0.0000  0.0080  0.0001 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0474  0.0022  0.0320  0.0022  0.0006  0.0152  0.0039  0.0152  0.0000 </r>
+        <r>  0.0233  0.0019  0.0338  0.0019  0.0001  0.0231  0.0216  0.0234  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0069  0.0000  0.0063  0.0000  0.0166  0.0000  0.0141  0.0485 </r>
+        <r>  0.0000  0.0010  0.0000  0.0010  0.0000  0.0320  0.0000  0.0299  0.0170 </r>
+       </set>
+      </set>
+      <set comment="kpoint 55">
+       <set comment="band 1">
+        <r>  0.0042  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0010  0.0002  0.9661  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9743  0.0009  0.0010  0.0009  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0065  0.0000  0.0065  0.9646 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0017  0.4888  0.0005  0.4889  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4835  0.0000  0.4835  0.0131 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5877  0.0001  0.0012  0.0001  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0653  0.0008  0.0027  0.0008  0.0000  0.0000  0.0127  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0949  0.0044  0.0079  0.0044  0.0000  0.0000  0.0027  0.0000  0.0000 </r>
+        <r>  0.5979  0.0008  0.0001  0.0008  0.0000  0.0000  0.0015  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0049  0.0011  0.2259  0.0011  0.0000  0.0001  0.0016  0.0001  0.0000 </r>
+        <r>  0.0229  0.0002  0.1192  0.0002  0.0000  0.0002  0.0030  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1553  0.0000  0.1553  0.0000  0.0001  0.0000  0.0001  0.0005 </r>
+        <r>  0.0000  0.0603  0.0000  0.0603  0.0000  0.0002  0.0000  0.0002  0.0018 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0071  0.1443  0.0003  0.1443  0.0005  0.0001  0.0010  0.0001  0.0000 </r>
+        <r>  0.0268  0.0589  0.0009  0.0589  0.0011  0.0003  0.0009  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0038  0.0445  0.0020  0.0445  0.0544  0.0003  0.0001  0.0003  0.0000 </r>
+        <r>  0.0032  0.0197  0.0007  0.0197  0.0364  0.0000  0.0006  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.1058  0.0000  0.1058  0.0000  0.0015  0.0000  0.0015  0.0161 </r>
+        <r>  0.0000  0.1662  0.0000  0.1662  0.0000  0.0001  0.0000  0.0001  0.0083 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0220  0.0560  0.0257  0.0560  0.0119  0.0020  0.0007  0.0020  0.0000 </r>
+        <r>  0.0061  0.1258  0.0118  0.1258  0.0163  0.0001  0.0027  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0078  0.0078  0.2960  0.0078  0.0001  0.0009  0.0137  0.0009  0.0000 </r>
+        <r>  0.0191  0.0174  0.2531  0.0174  0.0004  0.0001  0.0042  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0038  0.0146  0.0178  0.0147  0.0001  0.0098  0.0430  0.0098  0.0000 </r>
+        <r>  0.0392  0.0123  0.0810  0.0123  0.0001  0.0070  0.0018  0.0070  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0136  0.0000  0.0136  0.0000  0.0107  0.0000  0.0108  0.1467 </r>
+        <r>  0.0000  0.0176  0.0000  0.0176  0.0000  0.0031  0.0000  0.0031  0.0691 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0024  0.0000  0.0024  0.0000  0.1009  0.0000  0.1010  0.0733 </r>
+        <r>  0.0000  0.0054  0.0000  0.0054  0.0000  0.0001  0.0000  0.0001  0.0255 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0165  0.0069  0.0053  0.0069  0.0024  0.0937  0.0119  0.0934  0.0000 </r>
+        <r>  0.0193  0.0067  0.0244  0.0066  0.0003  0.0010  0.0029  0.0010  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0564  0.0002  0.0198  0.0004  0.0021  0.0001  0.0125  0.0001  0.0001 </r>
+        <r>  0.0393  0.0286  0.0018  0.0265  0.0003  0.0222  0.0331  0.0190  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0002  0.0044  0.0001  0.0043  0.0000  0.0050  0.0000  0.0046  0.0490 </r>
+        <r>  0.0000  0.0200  0.0000  0.0221  0.0000  0.0347  0.0001  0.0364  0.0230 </r>
+       </set>
+      </set>
+      <set comment="kpoint 56">
+       <set comment="band 1">
+        <r>  0.0041  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0043  0.0002  0.9630  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0053  0.0000  0.0053  0.9667 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9705  0.0013  0.0042  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0025  0.4851  0.0006  0.4916  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4880  0.0000  0.4814  0.0107 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6284  0.0000  0.0005  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0360  0.0019  0.0014  0.0019  0.0000  0.0000  0.0135  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0478  0.0083  0.0040  0.0083  0.0000  0.0000  0.0027  0.0000  0.0000 </r>
+        <r>  0.6198  0.0011  0.0001  0.0011  0.0001  0.0000  0.0005  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0031  0.0007  0.2300  0.0007  0.0000  0.0002  0.0007  0.0002  0.0000 </r>
+        <r>  0.0104  0.0001  0.1217  0.0001  0.0000  0.0005  0.0015  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1570  0.0000  0.1570  0.0000  0.0000  0.0000  0.0000  0.0011 </r>
+        <r>  0.0000  0.0580  0.0000  0.0580  0.0000  0.0001  0.0000  0.0001  0.0040 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0133  0.1365  0.0001  0.1365  0.0010  0.0000  0.0017  0.0000  0.0000 </r>
+        <r>  0.0474  0.0562  0.0006  0.0562  0.0020  0.0001  0.0020  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0198  0.0955  0.0034  0.0955  0.0271  0.0006  0.0014  0.0006  0.0000 </r>
+        <r>  0.0173  0.0752  0.0007  0.0752  0.0100  0.0001  0.0021  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0984  0.0000  0.0984  0.0000  0.0007  0.0000  0.0007  0.0245 </r>
+        <r>  0.0000  0.1634  0.0000  0.1634  0.0000  0.0001  0.0000  0.0001  0.0117 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0150  0.0080  0.0058  0.0080  0.0403  0.0006  0.0019  0.0006  0.0000 </r>
+        <r>  0.0053  0.0751  0.0015  0.0751  0.0414  0.0000  0.0008  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0037  0.0021  0.3304  0.0021  0.0000  0.0041  0.0085  0.0041  0.0000 </r>
+        <r>  0.0114  0.0068  0.2477  0.0068  0.0002  0.0000  0.0029  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0017  0.0056  0.0059  0.0056  0.0001  0.0285  0.0138  0.0285  0.0000 </r>
+        <r>  0.0068  0.0048  0.1345  0.0048  0.0001  0.0139  0.0006  0.0139  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0020  0.0000  0.0020  0.0000  0.0744  0.0000  0.0747  0.0001 </r>
+        <r>  0.0000  0.0062  0.0000  0.0062  0.0000  0.0120  0.0000  0.0120  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0021  0.0184  0.0260  0.0181  0.0048  0.0426  0.0680  0.0425  0.0000 </r>
+        <r>  0.0439  0.0009  0.0248  0.0009  0.0004  0.0013  0.0014  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0226  0.0000  0.0227  0.0000  0.0135  0.0000  0.0135  0.2356 </r>
+        <r>  0.0000  0.0074  0.0000  0.0073  0.0000  0.0009  0.0000  0.0009  0.0860 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0635  0.0110  0.0086  0.0102  0.0009  0.0012  0.0167  0.0013  0.0013 </r>
+        <r>  0.0432  0.0479  0.0021  0.0526  0.0002  0.0074  0.0462  0.0092  0.0007 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0002  0.0021  0.0002  0.0026  0.0001  0.0280  0.0082  0.0256  0.0428 </r>
+        <r>  0.0040  0.0373  0.0004  0.0334  0.0000  0.0245  0.0000  0.0228  0.0237 </r>
+       </set>
+      </set>
+      <set comment="kpoint 57">
+       <set comment="band 1">
+        <r>  0.0038  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0115  0.0001  0.9570  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0019  0.0000  0.0019  0.9731 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9640  0.0012  0.0113  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0022  0.4890  0.0004  0.4880  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4876  0.0000  0.4886  0.0038 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6605  0.0000  0.0001  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0093  0.0034  0.0004  0.0034  0.0000  0.0000  0.0128  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0103  0.0118  0.0011  0.0118  0.0000  0.0000  0.0025  0.0000  0.0000 </r>
+        <r>  0.6363  0.0008  0.0001  0.0008  0.0002  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0010  0.0002  0.2363  0.0002  0.0000  0.0003  0.0002  0.0003  0.0000 </r>
+        <r>  0.0025  0.0000  0.1234  0.0000  0.0000  0.0008  0.0004  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1611  0.0000  0.1611  0.0000  0.0000  0.0000  0.0000  0.0018 </r>
+        <r>  0.0000  0.0540  0.0000  0.0540  0.0000  0.0000  0.0000  0.0000  0.0069 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0180  0.1305  0.0000  0.1305  0.0015  0.0000  0.0025  0.0000  0.0000 </r>
+        <r>  0.0668  0.0529  0.0002  0.0529  0.0029  0.0000  0.0032  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0359  0.1032  0.0011  0.1032  0.0138  0.0002  0.0030  0.0002  0.0000 </r>
+        <r>  0.0307  0.1040  0.0001  0.1040  0.0013  0.0000  0.0025  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0899  0.0000  0.0899  0.0000  0.0002  0.0000  0.0002  0.0293 </r>
+        <r>  0.0000  0.1639  0.0000  0.1639  0.0000  0.0000  0.0000  0.0000  0.0124 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0097  0.0003  0.0039  0.0003  0.0554  0.0003  0.0024  0.0003  0.0000 </r>
+        <r>  0.0020  0.0464  0.0013  0.0464  0.0479  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0006  0.0004  0.3395  0.0004  0.0002  0.0085  0.0029  0.0084  0.0000 </r>
+        <r>  0.0038  0.0030  0.2219  0.0030  0.0004  0.0000  0.0009  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0019  0.0012  0.0000  0.0012  0.0001  0.0265  0.0041  0.0266  0.0000 </r>
+        <r>  0.0016  0.0009  0.1879  0.0009  0.0001  0.0172  0.0008  0.0172  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0005  0.0000  0.0005  0.0000  0.0686  0.0000  0.0684  0.0001 </r>
+        <r>  0.0000  0.0012  0.0000  0.0011  0.0000  0.0171  0.0000  0.0171  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0103  0.0106  0.0131  0.0105  0.0051  0.0047  0.1327  0.0047  0.0000 </r>
+        <r>  0.0518  0.0019  0.0200  0.0019  0.0003  0.0000  0.0327  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0289  0.0000  0.0308  0.0000  0.0060  0.0000  0.0050  0.2529 </r>
+        <r>  0.0000  0.0092  0.0000  0.0109  0.0000  0.0011  0.0000  0.0009  0.0736 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0559  0.0336  0.0070  0.0343  0.0103  0.0500  0.0173  0.0542  0.0001 </r>
+        <r>  0.0023  0.0168  0.0009  0.0138  0.0006  0.0038  0.0621  0.0046  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0037  0.0011  0.0067  0.0101  0.0001  0.0882  0.0138  0.0003  0.0351 </r>
+        <r>  0.0113  0.0770  0.0000  0.0042  0.0004  0.0263  0.0020  0.0020  0.0195 </r>
+       </set>
+      </set>
+      <set comment="kpoint 58">
+       <set comment="band 1">
+        <r>  0.0031  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0234  0.0000  0.9466  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9763 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9545  0.0000  0.0235  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4896  0.0000  0.4895  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4899  0.0000  0.4899  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6652  0.0002  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0002  0.0049  0.0000  0.0049  0.0000  0.0000  0.0105  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0009  0.0144  0.0000  0.0144  0.0000  0.0000  0.0021  0.0000  0.0000 </r>
+        <r>  0.6333  0.0002  0.0000  0.0002  0.0002  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2440  0.0000  0.0000  0.0005  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.1238  0.0000  0.0000  0.0012  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1688  0.0000  0.1687  0.0000  0.0000  0.0000  0.0000  0.0024 </r>
+        <r>  0.0000  0.0476  0.0000  0.0476  0.0000  0.0000  0.0000  0.0000  0.0104 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0201  0.1278  0.0000  0.1278  0.0018  0.0000  0.0031  0.0000  0.0000 </r>
+        <r>  0.0839  0.0489  0.0000  0.0489  0.0035  0.0000  0.0043  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0487  0.0956  0.0000  0.0956  0.0098  0.0000  0.0038  0.0000  0.0000 </r>
+        <r>  0.0373  0.1125  0.0000  0.1125  0.0000  0.0000  0.0024  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0788  0.0000  0.0788  0.0000  0.0000  0.0000  0.0000  0.0313 </r>
+        <r>  0.0000  0.1674  0.0000  0.1674  0.0000  0.0000  0.0000  0.0000  0.0109 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.3304  0.0000  0.0000  0.0121  0.0000  0.0121  0.0000 </r>
+        <r>  0.0000  0.0000  0.2001  0.0000  0.0000  0.0003  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0072  0.0054  0.0000  0.0054  0.0626  0.0000  0.0040  0.0000  0.0000 </r>
+        <r>  0.0011  0.0401  0.0000  0.0401  0.0472  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0023  0.0000  0.0000  0.0218  0.0000  0.0219  0.0000 </r>
+        <r>  0.0000  0.0000  0.2233  0.0000  0.0000  0.0190  0.0000  0.0190  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0648  0.0000  0.0648  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0204  0.0000  0.0204  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0215  0.0068  0.0000  0.0068  0.0058  0.0000  0.1385  0.0000  0.0000 </r>
+        <r>  0.0519  0.0017  0.0000  0.0017  0.0004  0.0000  0.0485  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0349  0.0000  0.0341  0.0000  0.0000  0.0000  0.0000  0.2457 </r>
+        <r>  0.0000  0.0058  0.0000  0.0061  0.0000  0.0000  0.0000  0.0000  0.0465 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0168  0.0733  0.0000  0.0734  0.0784  0.0001  0.0196  0.0000  0.0000 </r>
+        <r>  0.0018  0.0239  0.0000  0.0262  0.0174  0.0000  0.0324  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0000  0.0521  0.0000  0.0004  0.1526  0.0051  0.1306  0.0004 </r>
+        <r>  0.0012  0.0011  0.0058  0.0030  0.0000  0.0194  0.0000  0.0160  0.0002 </r>
+       </set>
+      </set>
+      <set comment="kpoint 59">
+       <set comment="band 1">
+        <r>  0.0046  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9666  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9768  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9781 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9305  0.0000  0.0496  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0496  0.0000  0.9305  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5697  0.0000  0.0014  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0808  0.0000  0.0027  0.0000  0.0000  0.0000  0.0136  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1235  0.0000  0.0086  0.0000  0.0000  0.0000  0.0032  0.0000  0.0000 </r>
+        <r>  0.6026  0.0000  0.0001  0.0000  0.0000  0.0000  0.0024  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0035  0.0000  0.2222  0.0000  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.0285  0.0000  0.1205  0.0000  0.0000  0.0000  0.0027  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1383  0.0000  0.1676  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0565  0.0000  0.0684  0.0000  0.0002  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.1676  0.0000  0.1383  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0684  0.0000  0.0565  0.0000  0.0003  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0654  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0546  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0562  0.0000  0.1868  0.0000  0.0009  0.0000  0.0029  0.0000 </r>
+        <r>  0.0000  0.0825  0.0000  0.2743  0.0000  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.1868  0.0000  0.0562  0.0000  0.0029  0.0000  0.0009  0.0000 </r>
+        <r>  0.0000  0.2743  0.0000  0.0825  0.0000  0.0001  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0196  0.0000  0.3399  0.0000  0.0000  0.0000  0.0099  0.0000  0.0000 </r>
+        <r>  0.0094  0.0000  0.2718  0.0000  0.0000  0.0000  0.0066  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.2407 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1160 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0374  0.0000  0.0068  0.0000  0.0000  0.0000  0.0701  0.0000  0.0000 </r>
+        <r>  0.0990  0.0000  0.0522  0.0000  0.0000  0.0000  0.0130  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0019  0.0000  0.0001  0.0000  0.2327  0.0000  0.0159  0.0000 </r>
+        <r>  0.0000  0.0520  0.0000  0.0035  0.0000  0.0059  0.0000  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0001  0.0000  0.0019  0.0000  0.0158  0.0000  0.2322  0.0000 </r>
+        <r>  0.0000  0.0035  0.0000  0.0520  0.0000  0.0004  0.0000  0.0060  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0666  0.0000  0.0368  0.0000  0.0000  0.0001  0.0020  0.0001  0.0000 </r>
+        <r>  0.0263  0.0000  0.0742  0.0000  0.0000  0.0001  0.0287  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0000  0.0003  0.0000  0.0001  0.0000  0.0008  0.0569 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0008  0.0186 </r>
+       </set>
+      </set>
+      <set comment="kpoint 60">
+       <set comment="band 1">
+        <r>  0.0050  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.9659  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9766  0.0001  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0009  0.0000  0.0009  0.9763 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.4903  0.0000  0.4897  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4890  0.0000  0.4895  0.0018 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5934  0.0000  0.0007  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0676  0.0002  0.0014  0.0002  0.0000  0.0000  0.0156  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0988  0.0013  0.0045  0.0013  0.0000  0.0000  0.0036  0.0000  0.0000 </r>
+        <r>  0.6228  0.0003  0.0001  0.0003  0.0000  0.0000  0.0017  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0020  0.0001  0.2232  0.0001  0.0000  0.0000  0.0009  0.0000  0.0000 </r>
+        <r>  0.0145  0.0000  0.1226  0.0000  0.0000  0.0001  0.0013  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1521  0.0000  0.1521  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0623  0.0000  0.0623  0.0000  0.0001  0.0000  0.0001  0.0005 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.1492  0.0000  0.1492  0.0001  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0073  0.0619  0.0001  0.0619  0.0003  0.0001  0.0003  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0060  0.0000  0.0060  0.0647  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0001  0.0007  0.0000  0.0007  0.0527  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.1200  0.0000  0.1200  0.0000  0.0009  0.0000  0.0009  0.0058 </r>
+        <r>  0.0000  0.1768  0.0000  0.1768  0.0000  0.0001  0.0000  0.0001  0.0030 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0069  0.1132  0.0040  0.1132  0.0006  0.0010  0.0006  0.0010  0.0000 </r>
+        <r>  0.0040  0.1727  0.0014  0.1727  0.0017  0.0001  0.0008  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0087  0.0015  0.3648  0.0015  0.0000  0.0005  0.0065  0.0005  0.0000 </r>
+        <r>  0.0064  0.0028  0.2688  0.0028  0.0000  0.0000  0.0038  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0048  0.0000  0.0048  0.0000  0.0003  0.0000  0.0003  0.2476 </r>
+        <r>  0.0000  0.0047  0.0000  0.0047  0.0000  0.0003  0.0000  0.0003  0.1141 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0209  0.0053  0.0068  0.0053  0.0000  0.0043  0.0604  0.0043  0.0000 </r>
+        <r>  0.0739  0.0045  0.0829  0.0045  0.0000  0.0020  0.0063  0.0020  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.1193  0.0000  0.1167  0.0169 </r>
+        <r>  0.0000  0.0077  0.0000  0.0073  0.0000  0.0022  0.0000  0.0023  0.0056 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0308  0.0015  0.0003  0.0018  0.0002  0.0990  0.0123  0.1015  0.0000 </r>
+        <r>  0.0286  0.0030  0.0300  0.0035  0.0000  0.0013  0.0095  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0437  0.0002  0.0208  0.0004  0.0006  0.0346  0.0016  0.0342  0.0000 </r>
+        <r>  0.0175  0.0183  0.0226  0.0215  0.0001  0.0053  0.0238  0.0077  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0029  0.0000  0.0018  0.0000  0.0286  0.0004  0.0283  0.0263 </r>
+        <r>  0.0001  0.0155  0.0001  0.0121  0.0000  0.0116  0.0001  0.0074  0.0108 </r>
+       </set>
+      </set>
+      <set comment="kpoint 61">
+       <set comment="band 1">
+        <r>  0.0050  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0009  0.0000  0.9652  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9759  0.0001  0.0009  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0008  0.0000  0.0008  0.9762 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0002  0.4899  0.0000  0.4900  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4894  0.0000  0.4893  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6200  0.0000  0.0002  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0490  0.0009  0.0004  0.0009  0.0000  0.0000  0.0163  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0668  0.0046  0.0012  0.0046  0.0000  0.0000  0.0036  0.0000  0.0000 </r>
+        <r>  0.6354  0.0008  0.0000  0.0008  0.0000  0.0000  0.0009  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0007  0.0001  0.2267  0.0001  0.0000  0.0001  0.0002  0.0001  0.0000 </r>
+        <r>  0.0036  0.0000  0.1241  0.0000  0.0000  0.0002  0.0004  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1529  0.0000  0.1529  0.0000  0.0000  0.0000  0.0000  0.0005 </r>
+        <r>  0.0000  0.0611  0.0000  0.0611  0.0000  0.0000  0.0000  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0077  0.1427  0.0000  0.1427  0.0005  0.0000  0.0009  0.0000  0.0000 </r>
+        <r>  0.0247  0.0597  0.0001  0.0598  0.0011  0.0000  0.0011  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0015  0.0323  0.0001  0.0323  0.0602  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0023  0.0087  0.0000  0.0087  0.0429  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.1119  0.0000  0.1119  0.0000  0.0002  0.0000  0.0002  0.0167 </r>
+        <r>  0.0000  0.1709  0.0000  0.1709  0.0000  0.0000  0.0000  0.0000  0.0084 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0173  0.0823  0.0015  0.0823  0.0057  0.0003  0.0024  0.0003  0.0000 </r>
+        <r>  0.0127  0.1580  0.0003  0.1580  0.0106  0.0000  0.0014  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0018  0.0006  0.3821  0.0006  0.0000  0.0030  0.0023  0.0030  0.0000 </r>
+        <r>  0.0025  0.0013  0.2569  0.0014  0.0000  0.0000  0.0011  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0020  0.0014  0.0020  0.0000  0.0348  0.0099  0.0349  0.0000 </r>
+        <r>  0.0070  0.0018  0.1638  0.0018  0.0000  0.0106  0.0000  0.0106  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0015  0.0000  0.0015  0.0000  0.0730  0.0000  0.0731  0.0088 </r>
+        <r>  0.0000  0.0034  0.0000  0.0034  0.0000  0.0101  0.0000  0.0101  0.0045 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0124  0.0000  0.0124  0.0000  0.0099  0.0000  0.0099  0.2698 </r>
+        <r>  0.0000  0.0083  0.0000  0.0083  0.0000  0.0003  0.0000  0.0003  0.1116 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0296  0.0195  0.0032  0.0194  0.0008  0.0239  0.1064  0.0233  0.0000 </r>
+        <r>  0.1073  0.0027  0.0044  0.0028  0.0001  0.0001  0.0042  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0815  0.0003  0.0112  0.0002  0.0013  0.0064  0.0231  0.0131  0.0000 </r>
+        <r>  0.0011  0.0283  0.0016  0.0334  0.0001  0.0016  0.0778  0.0020  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0048  0.0019  0.0067  0.0000  0.0000  0.0447  0.0636  0.1618  0.0015 </r>
+        <r>  0.0182  0.0016  0.0316  0.0052  0.0000  0.0002  0.0129  0.0023  0.0010 </r>
+       </set>
+      </set>
+      <set comment="kpoint 62">
+       <set comment="band 1">
+        <r>  0.0046  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0040  0.0000  0.9631  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9773 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9733  0.0000  0.0040  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4899  0.0000  0.4900  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4901  0.0000  0.4900  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6445  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0278  0.0020  0.0000  0.0020  0.0000  0.0000  0.0154  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0347  0.0085  0.0000  0.0085  0.0000  0.0000  0.0032  0.0000  0.0000 </r>
+        <r>  0.6398  0.0010  0.0000  0.0010  0.0001  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2310  0.0000  0.0000  0.0002  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.1245  0.0000  0.0000  0.0005  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1557  0.0000  0.1557  0.0000  0.0000  0.0000  0.0000  0.0011 </r>
+        <r>  0.0000  0.0585  0.0000  0.0584  0.0000  0.0000  0.0000  0.0000  0.0039 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0138  0.1358  0.0000  0.1358  0.0010  0.0000  0.0017  0.0000  0.0000 </r>
+        <r>  0.0460  0.0566  0.0000  0.0566  0.0021  0.0000  0.0021  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0159  0.0936  0.0000  0.0936  0.0331  0.0000  0.0013  0.0000  0.0000 </r>
+        <r>  0.0170  0.0648  0.0000  0.0648  0.0137  0.0000  0.0016  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.1017  0.0000  0.1017  0.0000  0.0000  0.0000  0.0000  0.0250 </r>
+        <r>  0.0000  0.1660  0.0000  0.1660  0.0000  0.0000  0.0000  0.0000  0.0118 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0163  0.0158  0.0000  0.0158  0.0341  0.0000  0.0030  0.0000  0.0000 </r>
+        <r>  0.0089  0.0946  0.0000  0.0946  0.0381  0.0000  0.0006  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.3758  0.0000  0.0000  0.0066  0.0000  0.0067  0.0000 </r>
+        <r>  0.0000  0.0000  0.2355  0.0000  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0330  0.0000  0.0330  0.0000 </r>
+        <r>  0.0000  0.0000  0.2020  0.0000  0.0000  0.0149  0.0000  0.0149  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0722  0.0000  0.0723  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0146  0.0000  0.0146  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0046  0.0148  0.0000  0.0147  0.0030  0.0000  0.1767  0.0000  0.0000 </r>
+        <r>  0.0805  0.0005  0.0000  0.0004  0.0002  0.0000  0.0238  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0226  0.0000  0.0225  0.0000  0.0000  0.0000  0.0000  0.2823 </r>
+        <r>  0.0000  0.0151  0.0000  0.0150  0.0000  0.0000  0.0000  0.0000  0.1036 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.1050  0.0251  0.0000  0.0260  0.0002  0.0003  0.0004  0.0001  0.0000 </r>
+        <r>  0.0302  0.0419  0.0000  0.0401  0.0001  0.0000  0.0820  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0006  0.0302  0.0007  0.0000  0.1526  0.0001  0.1418  0.0005 </r>
+        <r>  0.0000  0.0026  0.0054  0.0027  0.0000  0.0042  0.0001  0.0040  0.0007 </r>
+       </set>
+      </set>
+      <set comment="kpoint 63">
+       <set comment="band 1">
+        <r>  0.0055  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9652  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9767  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9782 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4757  0.0000  0.5046  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.5046  0.0000  0.4757  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6020  0.0000  0.0002  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0655  0.0000  0.0004  0.0000  0.0000  0.0000  0.0174  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0946  0.0000  0.0013  0.0000  0.0000  0.0000  0.0042  0.0000  0.0000 </r>
+        <r>  0.6420  0.0000  0.0000  0.0000  0.0000  0.0000  0.0016  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0005  0.0000  0.2236  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0044  0.0000  0.1243  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1248  0.0000  0.1766  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0522  0.0000  0.0739  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.1766  0.0000  0.1248  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0739  0.0000  0.0522  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0649  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0550  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0822  0.0000  0.1723  0.0000  0.0002  0.0000  0.0003  0.0000 </r>
+        <r>  0.0000  0.1184  0.0000  0.2482  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.1723  0.0000  0.0822  0.0000  0.0003  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.2482  0.0000  0.1184  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0032  0.0000  0.4002  0.0000  0.0000  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.0014  0.0000  0.2741  0.0000  0.0000  0.0000  0.0014  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.2856 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.1308 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0489  0.0000  0.0023  0.0000  0.0000  0.0000  0.0677  0.0000  0.0000 </r>
+        <r>  0.1013  0.0000  0.0633  0.0000  0.0000  0.0000  0.0143  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0457  0.0000  0.0107  0.0000  0.0000  0.0000  0.0084  0.0000  0.0000 </r>
+        <r>  0.0303  0.0000  0.1279  0.0000  0.0000  0.0000  0.0178  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0625  0.0000  0.2911  0.0000 </r>
+        <r>  0.0000  0.0015  0.0000  0.0074  0.0000  0.0018  0.0000  0.0081  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.2917  0.0000  0.0628  0.0000 </r>
+        <r>  0.0000  0.0071  0.0000  0.0014  0.0000  0.0083  0.0000  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0131 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0047 </r>
+       </set>
+      </set>
+      <set comment="kpoint 64">
+       <set comment="band 1">
+        <r>  0.0055  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.9652  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9767  0.0000  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9781 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4971  0.0000  0.4832  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.4832  0.0000  0.4971  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6112  0.0000  0.0000  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0592  0.0002  0.0000  0.0002  0.0000  0.0000  0.0177  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0831  0.0013  0.0000  0.0013  0.0000  0.0000  0.0042  0.0000  0.0000 </r>
+        <r>  0.6459  0.0003  0.0000  0.0003  0.0000  0.0000  0.0013  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2251  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.1249  0.0000  0.0000  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.1509  0.0000  0.1509  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0627  0.0000  0.0627  0.0000  0.0000  0.0000  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0023  0.1482  0.0000  0.1482  0.0001  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0070  0.0622  0.0000  0.0622  0.0003  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0054  0.0000  0.0054  0.0646  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0001  0.0004  0.0000  0.0004  0.0531  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.1232  0.0000  0.1232  0.0000  0.0000  0.0000  0.0000  0.0059 </r>
+        <r>  0.0000  0.1797  0.0000  0.1797  0.0000  0.0000  0.0000  0.0000  0.0030 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0056  0.1186  0.0000  0.1186  0.0004  0.0000  0.0008  0.0000  0.0000 </r>
+        <r>  0.0048  0.1786  0.0000  0.1786  0.0015  0.0000  0.0005  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.4067  0.0000  0.0000  0.0009  0.0000  0.0009  0.0000 </r>
+        <r>  0.0000  0.0000  0.2692  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0045  0.0000  0.0045  0.0000  0.0000  0.0000  0.0000  0.2941 </r>
+        <r>  0.0000  0.0041  0.0000  0.0041  0.0000  0.0000  0.0000  0.0000  0.1307 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0023  0.0000  0.0000  0.0408  0.0000  0.0405  0.0000 </r>
+        <r>  0.0000  0.0000  0.1725  0.0000  0.0000  0.0066  0.0000  0.0066  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0896  0.0000  0.0897  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0080  0.0000  0.0080  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0760  0.0069  0.0000  0.0069  0.0000  0.0001  0.0879  0.0001  0.0000 </r>
+        <r>  0.1331  0.0040  0.0000  0.0041  0.0000  0.0000  0.0224  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0000  0.0089  0.0000  0.0000  0.1544  0.0002  0.1303  0.0000 </r>
+        <r>  0.0000  0.0000  0.0379  0.0000  0.0000  0.0021  0.0001  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0339  0.0011  0.0000  0.0016  0.0002  0.0395  0.0840  0.0437  0.0000 </r>
+        <r>  0.0123  0.0064  0.0000  0.0081  0.0000  0.0002  0.0446  0.0003  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 65">
+       <set comment="band 1">
+        <r>  0.0001  0.0000  0.0003  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0042  0.9701  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0321  0.0009  0.0000  0.9440 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9303  0.0000  0.0000  0.0474  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0474  0.0000  0.0000  0.9308  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9420  0.0051  0.0000  0.0313 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4426  0.0002  0.0010  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1526  0.0005  0.0019  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2535  0.0050  0.0143  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.5094  0.0013  0.0028  0.0000  0.0000  0.0001  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.3653  0.0002  0.0000  0.0000  0.0006  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1081  0.0005  0.0000  0.0000  0.0014  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0034  0.3765  0.0112  0.0000  0.0000  0.0005  0.0001  0.0000  0.0002 </r>
+        <r>  0.0074  0.0931  0.0008  0.0000  0.0000  0.0011  0.0011  0.0000  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0101  0.0053  0.4356  0.0000  0.0000  0.0002  0.0000  0.0000  0.0000 </r>
+        <r>  0.0562  0.0020  0.0341  0.0000  0.0000  0.0007  0.0068  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0308  0.0006  0.0198  0.0000  0.0000  0.0013  0.0171  0.0000  0.0000 </r>
+        <r>  0.0098  0.0005  0.3666  0.0000  0.0000  0.0000  0.0044  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0069  0.1116  0.0001  0.0000  0.0000  0.0043  0.0041  0.0000  0.0074 </r>
+        <r>  0.0083  0.3390  0.0053  0.0000  0.0000  0.0001  0.0017  0.0000  0.0038 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.1601  0.0059  0.0000  0.0000  0.0081  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3221  0.0016  0.0000  0.0000  0.0007  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0013  0.0703  0.0000  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0466  0.0509  0.0000  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0002  0.0070  0.0000  0.0000  0.0951  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0371  0.0032  0.0000  0.0000  0.0589  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0039  0.0057  0.0040  0.0000  0.0000  0.1096  0.0001  0.0000  0.0012 </r>
+        <r>  0.0023  0.0205  0.0029  0.0000  0.0000  0.0626  0.0002  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0373  0.0022  0.0029  0.0000  0.0000  0.0006  0.0360  0.0000  0.0687 </r>
+        <r>  0.0696  0.0063  0.0065  0.0000  0.0000  0.0003  0.0194  0.0000  0.0388 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0139  0.0220  0.0015  0.0000  0.0000  0.0011  0.0164  0.0000  0.1186 </r>
+        <r>  0.0281  0.0570  0.0035  0.0000  0.0000  0.0008  0.0084  0.0000  0.0671 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0003  0.0287  0.0000  0.0000  0.0122  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0044  0.0119  0.0000  0.0000  0.0051  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0103  0.0002  0.0443  0.0000  0.0000  0.0003  0.1311  0.0000  0.0000 </r>
+        <r>  0.0225  0.0003  0.1026  0.0000  0.0000  0.0000  0.0689  0.0000  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 66">
+       <set comment="band 1">
+        <r>  0.0002  0.0000  0.0004  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0031  0.0080  0.9627  0.0012  0.0006 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0530  0.0000  0.0069  0.9168 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8822  0.0118  0.0011  0.0826  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0910  0.0409  0.0044  0.8411  0.0010 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0015  0.8647  0.0073  0.0466  0.0585 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4581  0.0005  0.0014  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1415  0.0012  0.0028  0.0001  0.0000  0.0000  0.0005  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2250  0.0087  0.0162  0.0012  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.5006  0.0020  0.0027  0.0003  0.0000  0.0001  0.0005  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0010  0.0011  0.0009  0.3450  0.0004  0.0000  0.0000  0.0007  0.0001 </r>
+        <r>  0.0017  0.0002  0.0000  0.1097  0.0009  0.0000  0.0002  0.0017  0.0004 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0058  0.3665  0.0271  0.0003  0.0001  0.0005  0.0002  0.0000  0.0003 </r>
+        <r>  0.0111  0.0804  0.0005  0.0001  0.0002  0.0012  0.0030  0.0000  0.0023 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0064  0.0127  0.4302  0.0003  0.0000  0.0002  0.0002  0.0000  0.0000 </r>
+        <r>  0.0822  0.0047  0.0043  0.0003  0.0000  0.0014  0.0097  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0440  0.0013  0.0000  0.0001  0.0000  0.0025  0.0172  0.0003  0.0001 </r>
+        <r>  0.0034  0.0017  0.3739  0.0000  0.0000  0.0001  0.0015  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0102  0.0931  0.0000  0.0002  0.0005  0.0036  0.0066  0.0000  0.0104 </r>
+        <r>  0.0124  0.3183  0.0117  0.0001  0.0000  0.0000  0.0020  0.0000  0.0048 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0011  0.0001  0.0000  0.1717  0.0084  0.0000  0.0008  0.0083  0.0029 </r>
+        <r>  0.0025  0.0018  0.0010  0.2800  0.0019  0.0000  0.0004  0.0004  0.0016 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0015  0.0007  0.0002  0.0007  0.0620  0.0000  0.0005  0.0000  0.0003 </r>
+        <r>  0.0007  0.0023  0.0000  0.0687  0.0473  0.0001  0.0002  0.0008  0.0002 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0013  0.0001  0.0017  0.0012  0.0114  0.0008  0.0000  0.0892  0.0009 </r>
+        <r>  0.0006  0.0000  0.0012  0.0305  0.0048  0.0005  0.0001  0.0529  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0048  0.0118  0.0081  0.0000  0.0006  0.1103  0.0000  0.0022  0.0023 </r>
+        <r>  0.0017  0.0174  0.0050  0.0026  0.0003  0.0569  0.0001  0.0012  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0267  0.0021  0.0029  0.0093  0.0001  0.0007  0.0330  0.0001  0.0812 </r>
+        <r>  0.0540  0.0056  0.0070  0.0216  0.0000  0.0002  0.0165  0.0002  0.0441 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0110  0.0369  0.0030  0.0000  0.0005  0.0023  0.0199  0.0004  0.0994 </r>
+        <r>  0.0259  0.0874  0.0057  0.0001  0.0001  0.0004  0.0090  0.0002  0.0543 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0002  0.0001  0.0004  0.0309  0.0038  0.0014  0.0192  0.0008 </r>
+        <r>  0.0006  0.0048  0.0005  0.0081  0.0113  0.0011  0.0006  0.0067  0.0004 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0054  0.0012  0.0548  0.0001  0.0000  0.0026  0.1310  0.0002  0.0004 </r>
+        <r>  0.0154  0.0010  0.1234  0.0001  0.0000  0.0002  0.0641  0.0000  0.0001 </r>
+       </set>
+      </set>
+      <set comment="kpoint 67">
+       <set comment="band 1">
+        <r>  0.0003  0.0001  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0120  0.0124  0.9471  0.0030  0.0006 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0587  0.0018  0.0192  0.8966 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8002  0.0448  0.0032  0.1296  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1639  0.1243  0.0176  0.6722  0.0007 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0018  0.7385  0.0054  0.1546  0.0787 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4835  0.0007  0.0017  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1231  0.0021  0.0037  0.0006  0.0000  0.0000  0.0008  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1864  0.0115  0.0164  0.0040  0.0000  0.0000  0.0002  0.0000  0.0001 </r>
+        <r>  0.4996  0.0023  0.0021  0.0010  0.0000  0.0002  0.0005  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0035  0.0031  0.0032  0.3261  0.0006  0.0000  0.0001  0.0008  0.0003 </r>
+        <r>  0.0055  0.0004  0.0000  0.1074  0.0013  0.0000  0.0006  0.0018  0.0014 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0076  0.3427  0.0654  0.0002  0.0002  0.0005  0.0001  0.0000  0.0003 </r>
+        <r>  0.0086  0.0601  0.0001  0.0001  0.0005  0.0008  0.0066  0.0000  0.0037 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0020  0.0375  0.3585  0.0009  0.0001  0.0000  0.0018  0.0000  0.0000 </r>
+        <r>  0.1069  0.0102  0.0063  0.0012  0.0001  0.0023  0.0092  0.0005  0.0004 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0577  0.0028  0.0231  0.0008  0.0001  0.0042  0.0141  0.0011  0.0002 </r>
+        <r>  0.0000  0.0085  0.3409  0.0001  0.0000  0.0002  0.0000  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0099  0.0734  0.0009  0.0004  0.0012  0.0027  0.0096  0.0000  0.0119 </r>
+        <r>  0.0153  0.3035  0.0285  0.0000  0.0000  0.0001  0.0014  0.0000  0.0044 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0034  0.0000  0.0001  0.1714  0.0069  0.0001  0.0025  0.0067  0.0079 </r>
+        <r>  0.0085  0.0040  0.0036  0.2646  0.0007  0.0000  0.0009  0.0000  0.0041 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0043  0.0036  0.0012  0.0009  0.0593  0.0000  0.0012  0.0002  0.0006 </r>
+        <r>  0.0011  0.0062  0.0000  0.0595  0.0449  0.0002  0.0003  0.0013  0.0003 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0024  0.0002  0.0060  0.0041  0.0154  0.0009  0.0000  0.0871  0.0020 </r>
+        <r>  0.0006  0.0003  0.0044  0.0192  0.0061  0.0007  0.0001  0.0474  0.0005 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0038  0.0160  0.0113  0.0000  0.0018  0.1124  0.0001  0.0052  0.0046 </r>
+        <r>  0.0005  0.0171  0.0078  0.0046  0.0007  0.0498  0.0000  0.0020  0.0006 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0177  0.0039  0.0050  0.0277  0.0001  0.0005  0.0316  0.0006  0.0764 </r>
+        <r>  0.0424  0.0067  0.0096  0.0599  0.0000  0.0000  0.0140  0.0003  0.0391 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0034  0.0547  0.0111  0.0001  0.0002  0.0105  0.0131  0.0002  0.0842 </r>
+        <r>  0.0149  0.1078  0.0153  0.0002  0.0001  0.0013  0.0041  0.0002  0.0448 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0000  0.0001  0.0004  0.0344  0.0157  0.0009  0.0273  0.0000 </r>
+        <r>  0.0001  0.0071  0.0031  0.0114  0.0098  0.0009  0.0003  0.0063  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0015  0.0018  0.0543  0.0000  0.0001  0.0255  0.0973  0.0001  0.0200 </r>
+        <r>  0.0000  0.0006  0.0926  0.0000  0.0000  0.0198  0.0464  0.0000  0.0058 </r>
+       </set>
+      </set>
+      <set comment="kpoint 68">
+       <set comment="band 1">
+        <r>  0.0005  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0236  0.0175  0.9196  0.0035  0.0104 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0003  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0007  0.0535  0.0136  0.0305  0.8776 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6860  0.1040  0.0040  0.1835  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2677  0.2203  0.0358  0.4552  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0002  0.5834  0.0018  0.3059  0.0880 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5231  0.0008  0.0017  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0939  0.0032  0.0047  0.0014  0.0000  0.0000  0.0011  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1358  0.0134  0.0159  0.0072  0.0000  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.5130  0.0019  0.0012  0.0015  0.0001  0.0003  0.0004  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0068  0.0050  0.0073  0.3105  0.0007  0.0000  0.0002  0.0008  0.0006 </r>
+        <r>  0.0093  0.0004  0.0001  0.1019  0.0015  0.0001  0.0014  0.0016  0.0029 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0080  0.2426  0.1776  0.0001  0.0001  0.0005  0.0002  0.0000  0.0003 </r>
+        <r>  0.0000  0.0272  0.0098  0.0000  0.0005  0.0001  0.0131  0.0003  0.0038 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0011  0.1459  0.1873  0.0019  0.0003  0.0000  0.0035  0.0000  0.0000 </r>
+        <r>  0.1265  0.0228  0.0264  0.0030  0.0007  0.0032  0.0028  0.0006  0.0022 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0728  0.0111  0.0570  0.0030  0.0007  0.0067  0.0056  0.0018  0.0020 </r>
+        <r>  0.0001  0.0640  0.2214  0.0006  0.0000  0.0002  0.0018  0.0002  0.0005 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0016  0.0432  0.0159  0.0000  0.0014  0.0007  0.0163  0.0006  0.0112 </r>
+        <r>  0.0183  0.2528  0.1035  0.0002  0.0000  0.0004  0.0002  0.0001  0.0029 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0054  0.0000  0.0007  0.1631  0.0052  0.0003  0.0042  0.0050  0.0117 </r>
+        <r>  0.0159  0.0051  0.0080  0.2585  0.0001  0.0000  0.0011  0.0001  0.0054 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0063  0.0089  0.0029  0.0075  0.0592  0.0000  0.0017  0.0004  0.0006 </r>
+        <r>  0.0005  0.0104  0.0002  0.0482  0.0425  0.0003  0.0002  0.0016  0.0003 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0027  0.0003  0.0121  0.0073  0.0184  0.0005  0.0002  0.0878  0.0026 </r>
+        <r>  0.0003  0.0009  0.0090  0.0134  0.0062  0.0008  0.0001  0.0421  0.0004 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0031  0.0171  0.0133  0.0000  0.0033  0.1220  0.0004  0.0082  0.0069 </r>
+        <r>  0.0001  0.0197  0.0119  0.0053  0.0008  0.0389  0.0000  0.0018  0.0005 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0039  0.0217  0.0233  0.0379  0.0001  0.0104  0.0257  0.0042  0.0387 </r>
+        <r>  0.0259  0.0278  0.0327  0.0786  0.0001  0.0067  0.0078  0.0000  0.0169 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0057  0.0331  0.0158  0.0103  0.0002  0.0362  0.0018  0.0000  0.0548 </r>
+        <r>  0.0019  0.0413  0.0169  0.0159  0.0001  0.0244  0.0021  0.0001  0.0305 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0089  0.0115  0.0013  0.0040  0.0056  0.0255  0.0322  0.0039  0.0942 </r>
+        <r>  0.0112  0.0353  0.0063  0.0007  0.0032  0.0140  0.0117  0.0053  0.0323 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0021  0.0018  0.0030  0.0056  0.0202  0.0011  0.0015  0.0885  0.0402 </r>
+        <r>  0.0001  0.0088  0.0122  0.0104  0.0028  0.0174  0.0008  0.0144  0.0103 </r>
+       </set>
+      </set>
+      <set comment="kpoint 69">
+       <set comment="band 1">
+        <r>  0.0006  0.0000  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0334  0.0245  0.8658  0.0022  0.0483 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0034  0.0416  0.0526  0.0391  0.8389 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.5537  0.1891  0.0030  0.2313  0.0007 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.3828  0.3243  0.0530  0.2170  0.0020 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0051  0.3992  0.0002  0.4891  0.0859 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5798  0.0006  0.0012  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0513  0.0046  0.0055  0.0027  0.0000  0.0000  0.0014  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0712  0.0148  0.0153  0.0103  0.0000  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.5449  0.0011  0.0004  0.0014  0.0002  0.0003  0.0002  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0107  0.0060  0.0174  0.2967  0.0007  0.0000  0.0002  0.0008  0.0009 </r>
+        <r>  0.0106  0.0002  0.0010  0.0925  0.0016  0.0002  0.0027  0.0012  0.0047 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0063  0.0989  0.2724  0.0047  0.0000  0.0005  0.0017  0.0001  0.0002 </r>
+        <r>  0.0168  0.0043  0.0435  0.0025  0.0001  0.0002  0.0138  0.0011  0.0025 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0014  0.3072  0.0418  0.0023  0.0005  0.0000  0.0028  0.0000  0.0000 </r>
+        <r>  0.1183  0.0207  0.0191  0.0045  0.0017  0.0032  0.0001  0.0003  0.0059 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0685  0.0198  0.0261  0.0049  0.0028  0.0069  0.0002  0.0007  0.0085 </r>
+        <r>  0.0010  0.2440  0.0385  0.0006  0.0000  0.0000  0.0021  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0104  0.0078  0.0815  0.0032  0.0002  0.0006  0.0196  0.0031  0.0058 </r>
+        <r>  0.0157  0.0889  0.2410  0.0042  0.0000  0.0007  0.0016  0.0004  0.0010 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0061  0.0001  0.0034  0.1492  0.0042  0.0005  0.0063  0.0033  0.0134 </r>
+        <r>  0.0244  0.0052  0.0184  0.2539  0.0000  0.0001  0.0008  0.0005  0.0053 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0067  0.0165  0.0057  0.0170  0.0604  0.0002  0.0024  0.0003  0.0005 </r>
+        <r>  0.0001  0.0135  0.0002  0.0409  0.0399  0.0005  0.0001  0.0018  0.0002 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0019  0.0009  0.0210  0.0106  0.0214  0.0001  0.0005  0.0905  0.0037 </r>
+        <r>  0.0001  0.0032  0.0116  0.0099  0.0052  0.0015  0.0001  0.0357  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0068  0.0032  0.0027  0.0013  0.0008  0.1525  0.0037  0.0000  0.0063 </r>
+        <r>  0.0004  0.0581  0.0623  0.0028  0.0000  0.0021  0.0000  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0492  0.0509  0.0055  0.0063  0.0220  0.0009  0.0263  0.0017 </r>
+        <r>  0.0012  0.0005  0.0041  0.0336  0.0007  0.0575  0.0001  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0009  0.0051  0.0007  0.0617  0.0005  0.0016  0.0107  0.0194  0.0264 </r>
+        <r>  0.0076  0.0001  0.0076  0.0674  0.0002  0.0238  0.0027  0.0165  0.0134 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0091  0.0099  0.0105  0.0033  0.0039  0.0007  0.0046  0.0443  0.0905 </r>
+        <r>  0.0100  0.0002  0.0101  0.0225  0.0053  0.0019  0.0077  0.0435  0.0252 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0013  0.0300  0.0045  0.0094  0.0655  0.0005  0.0126  0.0002  0.0729 </r>
+        <r>  0.0001  0.0578  0.0009  0.0004  0.0360  0.0121  0.0000  0.0000  0.0273 </r>
+       </set>
+      </set>
+      <set comment="kpoint 70">
+       <set comment="band 1">
+        <r>  0.0006  0.0000  0.0004  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0370  0.0326  0.7568  0.0004  0.1473 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0112  0.0256  0.1491  0.0443  0.7451 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4203  0.2957  0.0014  0.2589  0.0016 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4555  0.4243  0.0586  0.0300  0.0109 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0545  0.2005  0.0087  0.6452  0.0706 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6364  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0078  0.0058  0.0055  0.0044  0.0000  0.0000  0.0016  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0106  0.0158  0.0145  0.0129  0.0000  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.5829  0.0002  0.0000  0.0006  0.0003  0.0003  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0164  0.0030  0.0695  0.2554  0.0006  0.0001  0.0000  0.0008  0.0009 </r>
+        <r>  0.0045  0.0000  0.0116  0.0688  0.0014  0.0005  0.0062  0.0004  0.0054 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0022  0.0594  0.2310  0.0433  0.0001  0.0005  0.0028  0.0001  0.0004 </r>
+        <r>  0.0363  0.0003  0.0588  0.0167  0.0000  0.0005  0.0075  0.0021  0.0037 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0003  0.3687  0.0096  0.0034  0.0003  0.0001  0.0017  0.0000  0.0001 </r>
+        <r>  0.1116  0.0032  0.0108  0.0066  0.0023  0.0028  0.0018  0.0002  0.0077 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0614  0.0034  0.0108  0.0064  0.0042  0.0054  0.0024  0.0003  0.0103 </r>
+        <r>  0.0003  0.3072  0.0053  0.0011  0.0000  0.0000  0.0007  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0244  0.0007  0.0988  0.0261  0.0001  0.0013  0.0118  0.0059  0.0075 </r>
+        <r>  0.0050  0.0460  0.2029  0.0383  0.0000  0.0004  0.0051  0.0002  0.0011 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0025  0.0005  0.0238  0.1146  0.0033  0.0013  0.0120  0.0010  0.0113 </r>
+        <r>  0.0370  0.0022  0.0675  0.2242  0.0003  0.0002  0.0000  0.0010  0.0036 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0036  0.0297  0.0132  0.0280  0.0574  0.0041  0.0039  0.0001  0.0008 </r>
+        <r>  0.0000  0.0098  0.0004  0.0316  0.0340  0.0032  0.0000  0.0026  0.0001 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0083  0.0101  0.0244  0.0015  0.0131  0.0663  0.0004  0.0033  0.0027 </r>
+        <r>  0.0000  0.0521  0.0298  0.0069  0.0045  0.0287  0.0000  0.0026  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0057  0.0001  0.0083  0.0072  0.0172  0.0069  0.0021  0.1130  0.0027 </r>
+        <r>  0.0000  0.0004  0.0535  0.0218  0.0012  0.0006  0.0001  0.0188  0.0001 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0002  0.0088  0.0369  0.0282  0.0148  0.0616  0.0003  0.0479  0.0029 </r>
+        <r>  0.0005  0.0015  0.0001  0.0398  0.0001  0.0020  0.0000  0.0199  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0008  0.0361  0.0024  0.0180  0.0031  0.0333  0.0030  0.0028  0.0068 </r>
+        <r>  0.0001  0.0056  0.0197  0.0021  0.0001  0.0503  0.0001  0.0343  0.0012 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0195  0.0156  0.0267  0.0554  0.0002  0.0037  0.0034  0.0093 </r>
+        <r>  0.0008  0.0217  0.0005  0.0302  0.0472  0.0070  0.0019  0.0107  0.0010 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0083  0.0007  0.0009  0.0057  0.0140  0.0007  0.0556  0.0053  0.1819 </r>
+        <r>  0.0169  0.0136  0.0056  0.0496  0.0077  0.0029  0.0047  0.0092  0.0430 </r>
+       </set>
+      </set>
+      <set comment="kpoint 71">
+       <set comment="band 1">
+        <r>  0.0006  0.0000  0.0005  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0033  0.9711  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0368  0.0005  0.0000  0.9400 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9635  0.0000  0.0000  0.0140  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0140  0.0000  0.0000  0.9646  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9385  0.0030  0.0000  0.0372 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4622  0.0002  0.0019  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1394  0.0006  0.0036  0.0000  0.0000  0.0000  0.0013  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.2247  0.0045  0.0186  0.0000  0.0000  0.0000  0.0005  0.0000  0.0000 </r>
+        <r>  0.5087  0.0012  0.0024  0.0000  0.0000  0.0001  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.3421  0.0002  0.0000  0.0000  0.0008  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1137  0.0005  0.0000  0.0000  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0044  0.3538  0.0081  0.0000  0.0000  0.0007  0.0001  0.0000  0.0002 </r>
+        <r>  0.0064  0.1018  0.0000  0.0000  0.0000  0.0017  0.0013  0.0000  0.0010 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.0033  0.3899  0.0000  0.0000  0.0000  0.0027  0.0000  0.0000 </r>
+        <r>  0.0806  0.0018  0.0204  0.0000  0.0000  0.0005  0.0134  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0503  0.0004  0.0622  0.0000  0.0000  0.0013  0.0170  0.0000  0.0000 </r>
+        <r>  0.0022  0.0006  0.3632  0.0000  0.0000  0.0002  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0060  0.1369  0.0001  0.0000  0.0000  0.0062  0.0039  0.0000  0.0073 </r>
+        <r>  0.0100  0.3216  0.0051  0.0000  0.0000  0.0000  0.0011  0.0000  0.0039 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.1719  0.0151  0.0000  0.0000  0.0087  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.2536  0.0068  0.0000  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0155  0.0569  0.0000  0.0000  0.0014  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0927  0.0457  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0013  0.0040  0.0000  0.0000  0.1016  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0580  0.0013  0.0000  0.0000  0.0562  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0083  0.0125  0.0068  0.0000  0.0000  0.1098  0.0021  0.0000  0.0017 </r>
+        <r>  0.0068  0.0238  0.0009  0.0000  0.0000  0.0548  0.0016  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0291  0.0010  0.0030  0.0000  0.0000  0.0038  0.0370  0.0000  0.0781 </r>
+        <r>  0.0599  0.0081  0.0096  0.0000  0.0000  0.0015  0.0172  0.0000  0.0423 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0112  0.0211  0.0019  0.0000  0.0000  0.0051  0.0198  0.0000  0.1112 </r>
+        <r>  0.0260  0.0663  0.0057  0.0000  0.0000  0.0020  0.0087  0.0000  0.0618 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0004  0.0369  0.0000  0.0000  0.0120  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0051  0.0130  0.0000  0.0000  0.0039  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0035  0.0016  0.0628  0.0000  0.0000  0.0035  0.1321  0.0000  0.0003 </r>
+        <r>  0.0119  0.0010  0.1397  0.0000  0.0000  0.0011  0.0615  0.0000  0.0001 </r>
+       </set>
+      </set>
+      <set comment="kpoint 72">
+       <set comment="band 1">
+        <r>  0.0009  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0017  0.0058  0.9643  0.0005  0.0014 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0530  0.0028  0.0068  0.9142 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9473  0.0039  0.0010  0.0252  0.0001 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0285  0.1509  0.0033  0.7958  0.0003 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.7650  0.0024  0.1505  0.0611 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4844  0.0004  0.0022  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1240  0.0013  0.0044  0.0002  0.0000  0.0000  0.0021  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1929  0.0082  0.0180  0.0012  0.0000  0.0000  0.0006  0.0000  0.0000 </r>
+        <r>  0.5104  0.0019  0.0016  0.0003  0.0000  0.0001  0.0013  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0011  0.0007  0.0011  0.3229  0.0004  0.0000  0.0000  0.0008  0.0001 </r>
+        <r>  0.0015  0.0001  0.0000  0.1147  0.0010  0.0000  0.0002  0.0019  0.0003 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0093  0.3278  0.0386  0.0000  0.0001  0.0008  0.0000  0.0000  0.0003 </r>
+        <r>  0.0050  0.0861  0.0025  0.0000  0.0001  0.0012  0.0043  0.0000  0.0020 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0005  0.0257  0.2916  0.0005  0.0000  0.0000  0.0048  0.0000  0.0000 </r>
+        <r>  0.0884  0.0097  0.0554  0.0004  0.0000  0.0012  0.0097  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0531  0.0024  0.1256  0.0003  0.0000  0.0028  0.0136  0.0003  0.0001 </r>
+        <r>  0.0071  0.0051  0.3056  0.0001  0.0000  0.0004  0.0020  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0072  0.1183  0.0023  0.0003  0.0007  0.0043  0.0069  0.0000  0.0104 </r>
+        <r>  0.0174  0.2991  0.0169  0.0000  0.0001  0.0002  0.0010  0.0000  0.0051 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0006  0.0001  0.0001  0.1848  0.0174  0.0001  0.0006  0.0076  0.0026 </r>
+        <r>  0.0023  0.0028  0.0011  0.2214  0.0065  0.0000  0.0002  0.0000  0.0015 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0016  0.0003  0.0001  0.0126  0.0521  0.0000  0.0007  0.0016  0.0005 </r>
+        <r>  0.0011  0.0025  0.0002  0.1111  0.0444  0.0000  0.0002  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0029  0.0006  0.0032  0.0040  0.0066  0.0011  0.0007  0.0957  0.0029 </r>
+        <r>  0.0021  0.0000  0.0005  0.0409  0.0020  0.0007  0.0006  0.0484  0.0012 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0096  0.0209  0.0124  0.0003  0.0002  0.1096  0.0024  0.0039  0.0014 </r>
+        <r>  0.0068  0.0157  0.0020  0.0063  0.0001  0.0472  0.0018  0.0016  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0179  0.0005  0.0021  0.0083  0.0003  0.0080  0.0323  0.0014  0.0876 </r>
+        <r>  0.0451  0.0089  0.0133  0.0242  0.0000  0.0019  0.0130  0.0007  0.0446 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0059  0.0377  0.0049  0.0000  0.0001  0.0125  0.0208  0.0000  0.0902 </r>
+        <r>  0.0204  0.0987  0.0119  0.0001  0.0000  0.0002  0.0069  0.0001  0.0490 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0000  0.0000  0.0004  0.0383  0.0045  0.0001  0.0221  0.0000 </r>
+        <r>  0.0000  0.0017  0.0008  0.0089  0.0114  0.0004  0.0000  0.0046  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0073  0.0078  0.0489  0.0000  0.0000  0.0520  0.0401  0.0002  0.0208 </r>
+        <r>  0.0024  0.0002  0.0666  0.0000  0.0000  0.0439  0.0246  0.0001  0.0060 </r>
+       </set>
+      </set>
+      <set comment="kpoint 73">
+       <set comment="band 1">
+        <r>  0.0012  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0075  0.0082  0.9499  0.0012  0.0062 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.0547  0.0084  0.0171  0.8959 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9124  0.0174  0.0045  0.0430  0.0004 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0562  0.3895  0.0100  0.5198  0.0035 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0012  0.5091  0.0004  0.3979  0.0708 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5190  0.0006  0.0022  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0995  0.0023  0.0050  0.0007  0.0000  0.0000  0.0029  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1481  0.0112  0.0164  0.0039  0.0000  0.0000  0.0007  0.0000  0.0001 </r>
+        <r>  0.5212  0.0020  0.0008  0.0009  0.0000  0.0002  0.0011  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0045  0.0017  0.0057  0.3041  0.0006  0.0000  0.0001  0.0008  0.0003 </r>
+        <r>  0.0044  0.0003  0.0004  0.1114  0.0014  0.0000  0.0009  0.0016  0.0012 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0122  0.1264  0.2116  0.0013  0.0000  0.0007  0.0015  0.0000  0.0003 </r>
+        <r>  0.0103  0.0248  0.0486  0.0007  0.0001  0.0000  0.0119  0.0002  0.0014 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0016  0.2270  0.0755  0.0014  0.0002  0.0001  0.0040  0.0000  0.0002 </r>
+        <r>  0.0903  0.0597  0.0333  0.0014  0.0005  0.0025  0.0005  0.0001  0.0024 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0619  0.0286  0.1213  0.0023  0.0007  0.0063  0.0046  0.0009  0.0023 </r>
+        <r>  0.0014  0.0738  0.1815  0.0007  0.0001  0.0001  0.0050  0.0001  0.0011 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0001  0.0769  0.0435  0.0000  0.0008  0.0008  0.0152  0.0004  0.0102 </r>
+        <r>  0.0296  0.2233  0.1047  0.0004  0.0000  0.0008  0.0000  0.0001  0.0041 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0021  0.0000  0.0013  0.1933  0.0112  0.0002  0.0025  0.0060  0.0074 </r>
+        <r>  0.0098  0.0041  0.0061  0.2353  0.0022  0.0000  0.0005  0.0001  0.0039 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0041  0.0023  0.0005  0.0006  0.0570  0.0000  0.0016  0.0006  0.0007 </r>
+        <r>  0.0015  0.0069  0.0002  0.0777  0.0468  0.0001  0.0002  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0042  0.0013  0.0099  0.0102  0.0089  0.0007  0.0005  0.0947  0.0052 </r>
+        <r>  0.0020  0.0002  0.0028  0.0239  0.0025  0.0010  0.0007  0.0420  0.0016 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0055  0.0228  0.0154  0.0002  0.0013  0.1238  0.0004  0.0076  0.0056 </r>
+        <r>  0.0020  0.0175  0.0062  0.0079  0.0004  0.0389  0.0006  0.0014  0.0005 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0094  0.0054  0.0078  0.0251  0.0003  0.0094  0.0338  0.0051  0.0650 </r>
+        <r>  0.0366  0.0148  0.0260  0.0627  0.0000  0.0002  0.0102  0.0004  0.0308 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0008  0.0473  0.0162  0.0012  0.0000  0.0354  0.0032  0.0000  0.0599 </r>
+        <r>  0.0009  0.0725  0.0220  0.0023  0.0000  0.0145  0.0001  0.0000  0.0329 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0180  0.0017  0.0081  0.0016  0.0036  0.0304  0.0298  0.0033  0.0724 </r>
+        <r>  0.0198  0.0245  0.0089  0.0001  0.0012  0.0394  0.0147  0.0012  0.0269 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0008  0.0011  0.0004  0.0356  0.0015  0.0031  0.0504  0.0123 </r>
+        <r>  0.0005  0.0085  0.0011  0.0126  0.0075  0.0136  0.0011  0.0000  0.0038 </r>
+       </set>
+      </set>
+      <set comment="kpoint 74">
+       <set comment="band 1">
+        <r>  0.0014  0.0001  0.0005  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0165  0.0105  0.9259  0.0015  0.0184 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0017  0.0477  0.0208  0.0239  0.8822 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8451  0.0499  0.0086  0.0731  0.0011 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1094  0.5404  0.0174  0.3045  0.0074 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0053  0.3305  0.0002  0.5762  0.0674 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5693  0.0005  0.0017  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0628  0.0036  0.0053  0.0016  0.0000  0.0000  0.0037  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0894  0.0135  0.0146  0.0073  0.0000  0.0000  0.0007  0.0000  0.0001 </r>
+        <r>  0.5469  0.0015  0.0002  0.0012  0.0001  0.0002  0.0006  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0105  0.0014  0.0282  0.2743  0.0007  0.0000  0.0000  0.0007  0.0005 </r>
+        <r>  0.0041  0.0002  0.0057  0.0991  0.0015  0.0001  0.0029  0.0009  0.0023 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0070  0.0338  0.2373  0.0188  0.0000  0.0006  0.0031  0.0000  0.0002 </r>
+        <r>  0.0367  0.0034  0.0806  0.0094  0.0000  0.0004  0.0086  0.0009  0.0010 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0056  0.3274  0.0082  0.0008  0.0005  0.0002  0.0026  0.0000  0.0004 </r>
+        <r>  0.0746  0.0654  0.0100  0.0016  0.0012  0.0021  0.0009  0.0001  0.0049 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0471  0.0771  0.0234  0.0028  0.0023  0.0061  0.0006  0.0003  0.0103 </r>
+        <r>  0.0058  0.2547  0.0158  0.0001  0.0000  0.0001  0.0029  0.0000  0.0033 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0176  0.0104  0.1537  0.0088  0.0000  0.0011  0.0166  0.0030  0.0045 </r>
+        <r>  0.0215  0.0482  0.2325  0.0089  0.0000  0.0009  0.0039  0.0003  0.0015 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0029  0.0001  0.0089  0.1797  0.0071  0.0005  0.0060  0.0035  0.0103 </r>
+        <r>  0.0223  0.0027  0.0236  0.2384  0.0003  0.0001  0.0003  0.0004  0.0050 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0055  0.0068  0.0015  0.0025  0.0612  0.0001  0.0022  0.0003  0.0005 </r>
+        <r>  0.0007  0.0116  0.0001  0.0543  0.0463  0.0001  0.0001  0.0003  0.0003 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0025  0.0040  0.0231  0.0166  0.0108  0.0009  0.0005  0.0921  0.0067 </r>
+        <r>  0.0014  0.0031  0.0028  0.0136  0.0024  0.0032  0.0004  0.0347  0.0013 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0040  0.0142  0.0100  0.0025  0.0006  0.0997  0.0085  0.0083  0.0035 </r>
+        <r>  0.0025  0.0495  0.0711  0.0161  0.0000  0.0124  0.0002  0.0004  0.0005 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0026  0.0323  0.0351  0.0073  0.0026  0.0831  0.0040  0.0271  0.0017 </r>
+        <r>  0.0045  0.0048  0.0000  0.0316  0.0005  0.0321  0.0007  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0041  0.0130  0.0008  0.0392  0.0002  0.0000  0.0117  0.0058  0.0718 </r>
+        <r>  0.0119  0.0003  0.0040  0.0510  0.0000  0.0254  0.0041  0.0039  0.0318 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0112  0.0036  0.0070  0.0012  0.0002  0.0005  0.0024  0.0532  0.0859 </r>
+        <r>  0.0071  0.0022  0.0126  0.0051  0.0004  0.0091  0.0051  0.0540  0.0290 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0164  0.0243  0.0020  0.0020  0.0008  0.0069  0.0482  0.0114  0.0805 </r>
+        <r>  0.0268  0.0788  0.0030  0.0001  0.0020  0.0178  0.0149  0.0005  0.0286 </r>
+       </set>
+      </set>
+      <set comment="kpoint 75">
+       <set comment="band 1">
+        <r>  0.0015  0.0000  0.0004  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0263  0.0126  0.8862  0.0011  0.0464 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0044  0.0361  0.0474  0.0267  0.8612 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7134  0.1304  0.0102  0.1214  0.0024 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2189  0.5825  0.0266  0.1420  0.0090 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0152  0.2172  0.0025  0.6880  0.0569 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6274  0.0002  0.0008  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0191  0.0051  0.0049  0.0031  0.0000  0.0000  0.0043  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0261  0.0153  0.0128  0.0106  0.0000  0.0000  0.0007  0.0000  0.0001 </r>
+        <r>  0.5838  0.0006  0.0000  0.0009  0.0002  0.0002  0.0001  0.0002  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0184  0.0013  0.1924  0.0983  0.0003  0.0005  0.0008  0.0007  0.0002 </r>
+        <r>  0.0033  0.0000  0.0658  0.0296  0.0007  0.0009  0.0086  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0002  0.0217  0.0723  0.1877  0.0005  0.0003  0.0024  0.0001  0.0010 </r>
+        <r>  0.0444  0.0010  0.0338  0.0731  0.0008  0.0002  0.0006  0.0018  0.0042 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0056  0.3574  0.0016  0.0006  0.0007  0.0001  0.0022  0.0000  0.0003 </r>
+        <r>  0.0769  0.0460  0.0048  0.0022  0.0018  0.0017  0.0023  0.0000  0.0069 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0441  0.0609  0.0078  0.0028  0.0031  0.0045  0.0023  0.0001  0.0123 </r>
+        <r>  0.0080  0.2957  0.0019  0.0000  0.0000  0.0003  0.0014  0.0000  0.0022 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0274  0.0014  0.1052  0.0825  0.0015  0.0012  0.0046  0.0065  0.0104 </r>
+        <r>  0.0010  0.0255  0.1218  0.1021  0.0000  0.0003  0.0062  0.0000  0.0034 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0008  0.0845  0.0971  0.0036  0.0023  0.0166  0.0001  0.0056 </r>
+        <r>  0.0425  0.0001  0.1341  0.1524  0.0000  0.0003  0.0005  0.0010  0.0027 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0053  0.0136  0.0033  0.0104  0.0642  0.0008  0.0032  0.0002  0.0004 </r>
+        <r>  0.0003  0.0149  0.0002  0.0425  0.0437  0.0004  0.0000  0.0005  0.0002 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0054  0.0166  0.0250  0.0041  0.0023  0.0703  0.0032  0.0012  0.0024 </r>
+        <r>  0.0005  0.0344  0.0427  0.0027  0.0013  0.0327  0.0000  0.0027  0.0002 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0051  0.0000  0.0079  0.0071  0.0099  0.0022  0.0005  0.1359  0.0045 </r>
+        <r>  0.0002  0.0003  0.0443  0.0306  0.0007  0.0001  0.0001  0.0145  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0001  0.0049  0.0380  0.0352  0.0065  0.0541  0.0040  0.0344  0.0001 </r>
+        <r>  0.0026  0.0025  0.0002  0.0281  0.0006  0.0004  0.0000  0.0287  0.0004 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0363  0.0086  0.0162  0.0022  0.0484  0.0011  0.0001  0.0279 </r>
+        <r>  0.0003  0.0060  0.0200  0.0030  0.0000  0.0468  0.0006  0.0178  0.0057 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0105  0.0113  0.0034  0.0220  0.0064  0.0023  0.0063  0.0091  0.1102 </r>
+        <r>  0.0163  0.0005  0.0007  0.0734  0.0052  0.0005  0.0102  0.0295  0.0341 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0003  0.0283  0.0106  0.0104  0.0715  0.0000  0.0539  0.0003  0.0570 </r>
+        <r>  0.0033  0.0485  0.0096  0.0002  0.0326  0.0066  0.0026  0.0010  0.0227 </r>
+       </set>
+      </set>
+      <set comment="kpoint 76">
+       <set comment="band 1">
+        <r>  0.0014  0.0000  0.0003  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0340  0.0142  0.8170  0.0004  0.1072 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0104  0.0228  0.1037  0.0259  0.8129 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4692  0.3178  0.0064  0.1801  0.0045 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4256  0.4842  0.0387  0.0232  0.0074 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0393  0.1397  0.0074  0.7497  0.0435 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6512  0.0000  0.0001  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0005  0.0060  0.0035  0.0047  0.0000  0.0000  0.0043  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0008  0.0163  0.0104  0.0132  0.0000  0.0000  0.0008  0.0000  0.0001 </r>
+        <r>  0.6006  0.0000  0.0005  0.0002  0.0003  0.0002  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0130  0.0033  0.2581  0.0177  0.0000  0.0007  0.0013  0.0006  0.0000 </r>
+        <r>  0.0121  0.0000  0.1010  0.0031  0.0002  0.0015  0.0066  0.0007  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0051  0.0188  0.0084  0.2673  0.0007  0.0000  0.0014  0.0001  0.0016 </r>
+        <r>  0.0358  0.0002  0.0061  0.0913  0.0012  0.0000  0.0004  0.0012  0.0073 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0031  0.3874  0.0004  0.0007  0.0005  0.0000  0.0017  0.0000  0.0000 </r>
+        <r>  0.0840  0.0196  0.0026  0.0038  0.0023  0.0014  0.0035  0.0000  0.0085 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0472  0.0303  0.0037  0.0038  0.0040  0.0034  0.0033  0.0001  0.0130 </r>
+        <r>  0.0050  0.3259  0.0002  0.0000  0.0000  0.0003  0.0004  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0243  0.0000  0.0185  0.1553  0.0033  0.0001  0.0001  0.0046  0.0168 </r>
+        <r>  0.0088  0.0167  0.0133  0.2308  0.0002  0.0000  0.0034  0.0003  0.0046 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0047  0.0007  0.1846  0.0134  0.0008  0.0050  0.0191  0.0021  0.0004 </r>
+        <r>  0.0331  0.0041  0.2340  0.0321  0.0001  0.0002  0.0044  0.0007  0.0003 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0005  0.0280  0.0116  0.0189  0.0481  0.0172  0.0065  0.0005  0.0007 </r>
+        <r>  0.0003  0.0045  0.0119  0.0238  0.0286  0.0102  0.0002  0.0016  0.0001 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0121  0.0012  0.0070  0.0005  0.0221  0.0504  0.0002  0.0003  0.0005 </r>
+        <r>  0.0001  0.0417  0.0421  0.0168  0.0129  0.0288  0.0002  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0029  0.0000  0.0093  0.0111  0.0009  0.0186  0.0022  0.1111  0.0024 </r>
+        <r>  0.0003  0.0002  0.0200  0.0318  0.0003  0.0014  0.0003  0.0241  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0005  0.0052  0.0436  0.0338  0.0265  0.0117  0.0019  0.0545  0.0031 </r>
+        <r>  0.0029  0.0000  0.0459  0.0038  0.0000  0.0000  0.0006  0.0252  0.0003 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0004  0.0588  0.0059  0.0010  0.0195  0.0511  0.0004  0.0062  0.0136 </r>
+        <r>  0.0013  0.0013  0.0175  0.0074  0.0056  0.0252  0.0011  0.0291  0.0011 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0011  0.0101  0.0241  0.0344  0.0475  0.0013  0.0453  0.0020  0.0154 </r>
+        <r>  0.0014  0.0192  0.0218  0.0291  0.0336  0.0057  0.0173  0.0003  0.0010 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0057  0.0003  0.0004  0.0079  0.0004  0.0241  0.1886  0.0051  0.0317 </r>
+        <r>  0.0338  0.0055  0.0218  0.0266  0.0024  0.0131  0.0226  0.0167  0.0094 </r>
+       </set>
+      </set>
+      <set comment="kpoint 77">
+       <set comment="band 1">
+        <r>  0.0013  0.0000  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0359  0.0137  0.6984  0.0000  0.2251 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0221  0.0106  0.2107  0.0213  0.7109 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1994  0.5784  0.0014  0.1932  0.0057 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.6085  0.2986  0.0453  0.0217  0.0050 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1128  0.0771  0.0180  0.7429  0.0287 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6119  0.0005  0.0000  0.0009  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0298  0.0055  0.0019  0.0055  0.0000  0.0000  0.0035  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0424  0.0161  0.0071  0.0147  0.0000  0.0000  0.0007  0.0000  0.0001 </r>
+        <r>  0.5740  0.0005  0.0009  0.0000  0.0003  0.0001  0.0005  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0084  0.0025  0.2716  0.0063  0.0000  0.0008  0.0009  0.0007  0.0000 </r>
+        <r>  0.0103  0.0000  0.1102  0.0005  0.0001  0.0018  0.0039  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0071  0.0254  0.0019  0.2849  0.0007  0.0000  0.0013  0.0001  0.0018 </r>
+        <r>  0.0331  0.0000  0.0019  0.0811  0.0010  0.0000  0.0010  0.0007  0.0102 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0004  0.4091  0.0001  0.0024  0.0002  0.0000  0.0011  0.0000  0.0001 </r>
+        <r>  0.0918  0.0007  0.0013  0.0071  0.0027  0.0010  0.0042  0.0000  0.0084 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0515  0.0033  0.0019  0.0064  0.0051  0.0022  0.0044  0.0000  0.0124 </r>
+        <r>  0.0009  0.3455  0.0000  0.0004  0.0000  0.0002  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0235  0.0005  0.0047  0.1500  0.0029  0.0000  0.0008  0.0026  0.0185 </r>
+        <r>  0.0163  0.0182  0.0021  0.2639  0.0005  0.0000  0.0021  0.0004  0.0032 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0046  0.0003  0.2101  0.0029  0.0003  0.0074  0.0149  0.0047  0.0000 </r>
+        <r>  0.0212  0.0041  0.2363  0.0115  0.0000  0.0000  0.0053  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0048  0.0129  0.0084  0.0043  0.0012  0.0593  0.0042  0.0001  0.0006 </r>
+        <r>  0.0006  0.0055  0.0650  0.0002  0.0007  0.0403  0.0009  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0020  0.0117  0.0052  0.0264  0.0514  0.0105  0.0068  0.0262  0.0001 </r>
+        <r>  0.0005  0.0340  0.0000  0.0155  0.0256  0.0037  0.0006  0.0103  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0072  0.0040  0.0032  0.0002  0.0259  0.0094  0.0000  0.0697  0.0016 </r>
+        <r>  0.0000  0.0075  0.0253  0.0444  0.0098  0.0012  0.0002  0.0253  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0042  0.0162  0.0405  0.0305  0.0535  0.0055  0.0202  0.0265  0.0013 </r>
+        <r>  0.0128  0.0009  0.0729  0.0002  0.0038  0.0001  0.0115  0.0023  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0013  0.0239  0.0166  0.0188  0.0471  0.0016  0.0759  0.0004  0.0013 </r>
+        <r>  0.0076  0.0091  0.0176  0.0159  0.0411  0.0002  0.0231  0.0007  0.0001 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0107  0.0152  0.0004  0.0086  0.0033  0.0017  0.0448  0.0621  0.0138 </r>
+        <r>  0.0072  0.0002  0.0045  0.0155  0.0066  0.0025  0.0197  0.0516  0.0001 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0041  0.0197  0.0153  0.0080  0.0003  0.0945  0.0577  0.0040  0.0177 </r>
+        <r>  0.0038  0.0290  0.0026  0.0072  0.0070  0.0401  0.0109  0.0004  0.0031 </r>
+       </set>
+      </set>
+      <set comment="kpoint 78">
+       <set comment="band 1">
+        <r>  0.0010  0.0000  0.0001  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0303  0.0095  0.5351  0.0003  0.3985 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0402  0.0029  0.3651  0.0134  0.5542 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0593  0.7570  0.0000  0.1577  0.0040 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4487  0.1902  0.0278  0.3070  0.0053 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4002  0.0186  0.0466  0.5006  0.0132 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5538  0.0009  0.0001  0.0016  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0729  0.0044  0.0007  0.0053  0.0000  0.0000  0.0024  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1060  0.0154  0.0037  0.0158  0.0000  0.0000  0.0006  0.0000  0.0001 </r>
+        <r>  0.5377  0.0014  0.0008  0.0006  0.0003  0.0001  0.0009  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0042  0.0014  0.2850  0.0025  0.0000  0.0008  0.0004  0.0008  0.0000 </r>
+        <r>  0.0058  0.0000  0.1150  0.0001  0.0000  0.0019  0.0018  0.0017  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0073  0.0504  0.0005  0.2976  0.0006  0.0000  0.0011  0.0000  0.0016 </r>
+        <r>  0.0260  0.0011  0.0005  0.0595  0.0006  0.0000  0.0012  0.0003  0.0139 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0003  0.3850  0.0000  0.0144  0.0000  0.0001  0.0006  0.0000  0.0012 </r>
+        <r>  0.0992  0.0094  0.0006  0.0134  0.0030  0.0005  0.0044  0.0000  0.0050 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0571  0.0050  0.0009  0.0147  0.0064  0.0011  0.0058  0.0001  0.0084 </r>
+        <r>  0.0001  0.3227  0.0000  0.0093  0.0000  0.0001  0.0002  0.0000  0.0017 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0193  0.0027  0.0010  0.1215  0.0018  0.0000  0.0009  0.0012  0.0219 </r>
+        <r>  0.0187  0.0375  0.0004  0.2824  0.0007  0.0000  0.0015  0.0002  0.0012 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0026  0.0002  0.2228  0.0008  0.0002  0.0111  0.0091  0.0071  0.0000 </r>
+        <r>  0.0110  0.0029  0.2257  0.0047  0.0000  0.0006  0.0040  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0044  0.0052  0.0005  0.0015  0.0001  0.0562  0.0033  0.0000  0.0003 </r>
+        <r>  0.0011  0.0033  0.0925  0.0000  0.0001  0.0433  0.0011  0.0013  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0017  0.0003  0.0048  0.0072  0.0001  0.0166  0.0029  0.0891  0.0007 </r>
+        <r>  0.0007  0.0013  0.0230  0.0027  0.0003  0.0046  0.0010  0.0418  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0004  0.0202  0.0068  0.0185  0.0735  0.0000  0.0325  0.0014  0.0005 </r>
+        <r>  0.0081  0.0467  0.0204  0.0552  0.0185  0.0001  0.0079  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0188  0.0111  0.0162  0.0139  0.0976  0.0011  0.0274  0.0050  0.0002 </r>
+        <r>  0.0182  0.0099  0.0409  0.0052  0.0059  0.0002  0.0205  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0032  0.0343  0.0078  0.0268  0.0167  0.0012  0.0674  0.0008  0.0016 </r>
+        <r>  0.0085  0.0006  0.0083  0.0016  0.0589  0.0001  0.0261  0.0001  0.0003 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0038  0.0013  0.0119  0.0114  0.0001  0.0035  0.0374  0.0980  0.0308 </r>
+        <r>  0.0003  0.0088  0.0054  0.0172  0.0108  0.0008  0.0151  0.0358  0.0012 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0058  0.0175  0.0005  0.0001  0.0080  0.0171  0.0163  0.0265  0.0927 </r>
+        <r>  0.0092  0.0434  0.0054  0.0043  0.0036  0.0042  0.0069  0.0013  0.0215 </r>
+       </set>
+      </set>
+      <set comment="kpoint 79">
+       <set comment="band 1">
+        <r>  0.0007  0.0000  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0214  0.0031  0.3811  0.0003  0.5684 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0574  0.0003  0.5151  0.0045  0.3988 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0113  0.8450  0.0000  0.1203  0.0012 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0684  0.1296  0.0023  0.7750  0.0035 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8202  0.0000  0.0769  0.0785  0.0034 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5081  0.0010  0.0000  0.0019  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1060  0.0031  0.0002  0.0046  0.0000  0.0000  0.0015  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1592  0.0141  0.0011  0.0167  0.0000  0.0000  0.0005  0.0000  0.0001 </r>
+        <r>  0.5142  0.0022  0.0003  0.0014  0.0003  0.0000  0.0010  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0011  0.0004  0.3019  0.0006  0.0000  0.0008  0.0001  0.0008  0.0000 </r>
+        <r>  0.0017  0.0000  0.1170  0.0000  0.0000  0.0018  0.0005  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0070  0.1686  0.0000  0.2461  0.0005  0.0000  0.0006  0.0000  0.0004 </r>
+        <r>  0.0046  0.0140  0.0000  0.0210  0.0000  0.0000  0.0004  0.0001  0.0176 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0008  0.2462  0.0001  0.1095  0.0000  0.0000  0.0006  0.0000  0.0026 </r>
+        <r>  0.1163  0.0255  0.0002  0.0246  0.0034  0.0001  0.0051  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0742  0.0114  0.0003  0.0582  0.0077  0.0002  0.0073  0.0002  0.0000 </r>
+        <r>  0.0002  0.1380  0.0000  0.1564  0.0001  0.0000  0.0001  0.0000  0.0031 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0001  0.0242  0.0000  0.0375  0.0001  0.0001  0.0001  0.0001  0.0294 </r>
+        <r>  0.0178  0.2028  0.0000  0.1719  0.0005  0.0000  0.0015  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0007  0.0000  0.2210  0.0001  0.0000  0.0158  0.0029  0.0093  0.0000 </r>
+        <r>  0.0030  0.0011  0.2121  0.0012  0.0000  0.0028  0.0014  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0018  0.0012  0.0030  0.0003  0.0000  0.0524  0.0015  0.0003  0.0001 </r>
+        <r>  0.0008  0.0009  0.1262  0.0000  0.0000  0.0440  0.0007  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0010  0.0001  0.0013  0.0019  0.0000  0.0143  0.0015  0.0868  0.0002 </r>
+        <r>  0.0005  0.0002  0.0379  0.0008  0.0001  0.0044  0.0007  0.0470  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0238  0.0138  0.0092  0.0148  0.0063  0.0000  0.0942  0.0010  0.0002 </r>
+        <r>  0.0439  0.0016  0.0250  0.0044  0.0074  0.0001  0.0490  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0010  0.0128  0.0007  0.0099  0.1344  0.0006  0.0321  0.0005  0.0004 </r>
+        <r>  0.0023  0.0282  0.0003  0.0243  0.0336  0.0001  0.0080  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0022  0.0502  0.0001  0.0315  0.0421  0.0000  0.0128  0.0001  0.0076 </r>
+        <r>  0.0002  0.0575  0.0001  0.0324  0.0338  0.0000  0.0113  0.0000  0.0022 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0015  0.0018  0.0004  0.0000  0.0052  0.0377  0.0024  0.0360  0.0070 </r>
+        <r>  0.0012  0.0015  0.0128  0.0013  0.0002  0.0086  0.0010  0.0057  0.0026 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0086  0.0078  0.0002  0.0084  0.0066  0.0029  0.0186  0.0026  0.1429 </r>
+        <r>  0.0133  0.0592  0.0015  0.0084  0.0249  0.0004  0.0065  0.0001  0.0517 </r>
+       </set>
+      </set>
+      <set comment="kpoint 80">
+       <set comment="band 1">
+        <r>  0.0004  0.0001  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0134  0.0000  0.2748  0.0000  0.6867 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0003  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0647  0.0000  0.6248  0.0000  0.2870 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.8810  0.0000  0.0968  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0969  0.0000  0.8817  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9005  0.0000  0.0765  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4775  0.0008  0.0000  0.0017  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1278  0.0020  0.0000  0.0037  0.0000  0.0000  0.0008  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1980  0.0120  0.0000  0.0170  0.0000  0.0000  0.0003  0.0000  0.0001 </r>
+        <r>  0.5033  0.0024  0.0000  0.0022  0.0002  0.0000  0.0008  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.3222  0.0000  0.0000  0.0006  0.0000  0.0008  0.0000 </r>
+        <r>  0.0000  0.0000  0.1158  0.0000  0.0000  0.0014  0.0000  0.0019  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0069  0.3416  0.0000  0.0795  0.0005  0.0000  0.0002  0.0000  0.0002 </r>
+        <r>  0.0059  0.0546  0.0000  0.0003  0.0007  0.0000  0.0001  0.0000  0.0110 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0013  0.0527  0.0000  0.3405  0.0000  0.0000  0.0004  0.0000  0.0017 </r>
+        <r>  0.1069  0.0118  0.0000  0.0097  0.0024  0.0000  0.0048  0.0000  0.0046 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0587  0.0023  0.0000  0.0330  0.0044  0.0000  0.0057  0.0000  0.0085 </r>
+        <r>  0.0001  0.0116  0.0000  0.3410  0.0002  0.0000  0.0001  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0095  0.0640  0.0000  0.0012  0.0026  0.0000  0.0022  0.0000  0.0203 </r>
+        <r>  0.0138  0.3144  0.0000  0.0313  0.0001  0.0000  0.0017  0.0000  0.0042 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2032  0.0000  0.0000  0.0164  0.0000  0.0101  0.0000 </r>
+        <r>  0.0000  0.0000  0.2233  0.0000  0.0000  0.0041  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0072  0.0000  0.0000  0.0533  0.0000  0.0004  0.0000 </r>
+        <r>  0.0000  0.0000  0.1287  0.0000  0.0000  0.0446  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0124  0.0000  0.0869  0.0000 </r>
+        <r>  0.0000  0.0000  0.0470  0.0000  0.0000  0.0042  0.0000  0.0512  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0206  0.0218  0.0000  0.0190  0.0891  0.0000  0.0127  0.0000  0.0007 </r>
+        <r>  0.0183  0.0070  0.0000  0.0020  0.0414  0.0000  0.0108  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0115  0.0003  0.0000  0.0000  0.0331  0.0000  0.1178  0.0000  0.0001 </r>
+        <r>  0.0361  0.0158  0.0000  0.0155  0.0115  0.0000  0.0543  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0040  0.0538  0.0000  0.0107  0.0153  0.0000  0.0292  0.0000  0.0609 </r>
+        <r>  0.0175  0.1152  0.0000  0.0178  0.0010  0.0000  0.0191  0.0000  0.0266 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0006  0.0000  0.0000  0.0355  0.0000  0.0278  0.0000 </r>
+        <r>  0.0000  0.0000  0.0111  0.0000  0.0000  0.0109  0.0000  0.0076  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0010  0.0018  0.0000  0.0547  0.0251  0.0000  0.0011  0.0000  0.1184 </r>
+        <r>  0.0000  0.0004  0.0000  0.0955  0.0185  0.0000  0.0016  0.0000  0.0518 </r>
+       </set>
+      </set>
+      <set comment="kpoint 81">
+       <set comment="band 1">
+        <r>  0.0016  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0017  0.9701  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0308  0.0008  0.0000  0.9458 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9719  0.0000  0.0000  0.0054  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0054  0.0000  0.0000  0.9737  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9466  0.0013  0.0000  0.0313 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.4921  0.0002  0.0026  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.1206  0.0006  0.0048  0.0000  0.0000  0.0000  0.0039  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1912  0.0043  0.0183  0.0000  0.0000  0.0000  0.0011  0.0000  0.0000 </r>
+        <r>  0.5245  0.0011  0.0010  0.0000  0.0000  0.0001  0.0021  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.3221  0.0002  0.0000  0.0000  0.0007  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1185  0.0005  0.0000  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0071  0.3022  0.0368  0.0000  0.0000  0.0008  0.0000  0.0000  0.0002 </r>
+        <r>  0.0004  0.0974  0.0074  0.0000  0.0000  0.0012  0.0032  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0022  0.0332  0.2386  0.0000  0.0000  0.0000  0.0052  0.0000  0.0000 </r>
+        <r>  0.0745  0.0133  0.0818  0.0000  0.0000  0.0008  0.0081  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0469  0.0023  0.1941  0.0000  0.0000  0.0016  0.0139  0.0000  0.0000 </r>
+        <r>  0.0138  0.0034  0.2837  0.0000  0.0000  0.0002  0.0043  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0039  0.1597  0.0023  0.0000  0.0000  0.0062  0.0045  0.0000  0.0074 </r>
+        <r>  0.0124  0.3117  0.0105  0.0000  0.0000  0.0001  0.0005  0.0000  0.0040 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.0998  0.0484  0.0000  0.0000  0.0032  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0831  0.0316  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.1122  0.0205  0.0000  0.0000  0.0068  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.2574  0.0212  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0027  0.0032  0.0000  0.0000  0.1157  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0662  0.0008  0.0000  0.0000  0.0494  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0350  0.0112  0.0118  0.0000  0.0000  0.0191  0.0395  0.0000  0.0327 </r>
+        <r>  0.0640  0.0001  0.0081  0.0000  0.0000  0.0095  0.0160  0.0000  0.0190 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0125  0.0020  0.0000  0.0000  0.0885  0.0018  0.0000  0.0754 </r>
+        <r>  0.0017  0.0178  0.0052  0.0000  0.0000  0.0328  0.0004  0.0000  0.0352 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0065  0.0153  0.0018  0.0000  0.0000  0.0298  0.0195  0.0000  0.0862 </r>
+        <r>  0.0217  0.0874  0.0122  0.0000  0.0000  0.0056  0.0062  0.0000  0.0479 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0000  0.0002  0.0423  0.0000  0.0000  0.0141  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0053  0.0120  0.0000  0.0000  0.0022  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0128  0.0121  0.0345  0.0000  0.0000  0.0681  0.0110  0.0000  0.0226 </r>
+        <r>  0.0057  0.0008  0.0381  0.0000  0.0000  0.0558  0.0125  0.0000  0.0066 </r>
+       </set>
+      </set>
+      <set comment="kpoint 82">
+       <set comment="band 1">
+        <r>  0.0021  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0010  0.0028  0.9648  0.0002  0.0025 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0002  0.0417  0.0035  0.0049  0.9269 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9655  0.0015  0.0008  0.0093  0.0002 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0086  0.5346  0.0022  0.4219  0.0120 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0020  0.3986  0.0001  0.5430  0.0357 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5221  0.0003  0.0025  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.1007  0.0014  0.0050  0.0002  0.0000  0.0000  0.0053  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1541  0.0080  0.0161  0.0011  0.0000  0.0000  0.0013  0.0000  0.0000 </r>
+        <r>  0.5364  0.0017  0.0004  0.0003  0.0000  0.0001  0.0018  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0021  0.0001  0.0075  0.2997  0.0004  0.0000  0.0000  0.0006  0.0001 </r>
+        <r>  0.0003  0.0000  0.0020  0.1161  0.0010  0.0000  0.0006  0.0014  0.0003 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0098  0.0361  0.2307  0.0060  0.0000  0.0004  0.0032  0.0000  0.0001 </r>
+        <r>  0.0334  0.0083  0.0880  0.0028  0.0000  0.0001  0.0092  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0033  0.2967  0.0161  0.0005  0.0001  0.0003  0.0021  0.0000  0.0004 </r>
+        <r>  0.0469  0.0963  0.0126  0.0004  0.0002  0.0018  0.0000  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0509  0.0467  0.1537  0.0015  0.0007  0.0060  0.0045  0.0003  0.0026 </r>
+        <r>  0.0020  0.0866  0.1637  0.0006  0.0002  0.0000  0.0066  0.0000  0.0015 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0002  0.0988  0.0694  0.0000  0.0008  0.0011  0.0144  0.0001  0.0082 </r>
+        <r>  0.0306  0.2098  0.1114  0.0001  0.0002  0.0007  0.0002  0.0000  0.0039 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0003  0.0009  0.1422  0.0405  0.0002  0.0002  0.0033  0.0019 </r>
+        <r>  0.0012  0.0067  0.0015  0.1047  0.0228  0.0000  0.0000  0.0000  0.0011 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0019  0.0000  0.0001  0.0772  0.0265  0.0000  0.0012  0.0048  0.0012 </r>
+        <r>  0.0027  0.0019  0.0013  0.2269  0.0287  0.0000  0.0002  0.0001  0.0007 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0116  0.0037  0.0095  0.0118  0.0037  0.0008  0.0122  0.0741  0.0254 </r>
+        <r>  0.0194  0.0007  0.0014  0.0149  0.0010  0.0016  0.0045  0.0286  0.0121 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0127  0.0056  0.0053  0.0024  0.0014  0.0006  0.0268  0.0455  0.0365 </r>
+        <r>  0.0348  0.0016  0.0148  0.0611  0.0001  0.0020  0.0079  0.0127  0.0203 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0022  0.0249  0.0098  0.0004  0.0005  0.1195  0.0000  0.0007  0.0467 </r>
+        <r>  0.0002  0.0133  0.0068  0.0000  0.0001  0.0331  0.0001  0.0001  0.0171 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0313  0.0068  0.0001  0.0000  0.0536  0.0118  0.0000  0.0625 </r>
+        <r>  0.0072  0.0931  0.0255  0.0004  0.0000  0.0009  0.0014  0.0001  0.0351 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0223  0.0009  0.0156  0.0003  0.0011  0.0322  0.0168  0.0011  0.0498 </r>
+        <r>  0.0202  0.0125  0.0104  0.0000  0.0003  0.0634  0.0134  0.0001  0.0190 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0006  0.0001  0.0004  0.0404  0.0006  0.0002  0.0469  0.0041 </r>
+        <r>  0.0000  0.0018  0.0010  0.0098  0.0090  0.0043  0.0001  0.0003  0.0013 </r>
+       </set>
+      </set>
+      <set comment="kpoint 83">
+       <set comment="band 1">
+        <r>  0.0024  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0049  0.0037  0.9541  0.0005  0.0075 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0012  0.0403  0.0086  0.0108  0.9160 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9509  0.0060  0.0042  0.0154  0.0010 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0167  0.6982  0.0038  0.2455  0.0151 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0038  0.2311  0.0001  0.7073  0.0374 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5656  0.0003  0.0019  0.0001  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0705  0.0026  0.0048  0.0008  0.0000  0.0000  0.0067  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1031  0.0114  0.0133  0.0040  0.0000  0.0000  0.0014  0.0000  0.0001 </r>
+        <r>  0.5578  0.0017  0.0000  0.0008  0.0001  0.0002  0.0012  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0132  0.0038  0.1927  0.0724  0.0002  0.0003  0.0016  0.0004  0.0000 </r>
+        <r>  0.0137  0.0004  0.0795  0.0260  0.0004  0.0004  0.0073  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0096  0.0505  0.2192  0.0004  0.0001  0.0015  0.0002  0.0004 </r>
+        <r>  0.0273  0.0014  0.0261  0.0907  0.0009  0.0001  0.0006  0.0013  0.0012 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0073  0.3200  0.0021  0.0005  0.0003  0.0003  0.0018  0.0000  0.0006 </r>
+        <r>  0.0482  0.0933  0.0043  0.0006  0.0006  0.0014  0.0010  0.0000  0.0033 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0337  0.1220  0.0197  0.0022  0.0023  0.0055  0.0008  0.0001  0.0106 </r>
+        <r>  0.0081  0.2587  0.0092  0.0002  0.0002  0.0003  0.0029  0.0000  0.0047 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0184  0.0100  0.1956  0.0206  0.0007  0.0012  0.0144  0.0027  0.0042 </r>
+        <r>  0.0185  0.0364  0.2195  0.0187  0.0003  0.0006  0.0052  0.0001  0.0017 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0003  0.0251  0.1796  0.0210  0.0007  0.0047  0.0024  0.0050 </r>
+        <r>  0.0151  0.0024  0.0357  0.1664  0.0072  0.0000  0.0000  0.0003  0.0027 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0048  0.0011  0.0000  0.0151  0.0450  0.0000  0.0025  0.0017  0.0014 </r>
+        <r>  0.0037  0.0076  0.0016  0.1325  0.0425  0.0000  0.0002  0.0002  0.0008 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0032  0.0137  0.0277  0.0224  0.0040  0.0120  0.0141  0.0490  0.0187 </r>
+        <r>  0.0142  0.0129  0.0104  0.0013  0.0011  0.0096  0.0020  0.0207  0.0065 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0018  0.0099  0.0026  0.0000  0.0029  0.0462  0.0087  0.0674  0.0001 </r>
+        <r>  0.0034  0.0247  0.0600  0.0412  0.0002  0.0079  0.0001  0.0098  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0124  0.0013  0.0057  0.0136  0.0001  0.0962  0.0106  0.0255  0.0177 </r>
+        <r>  0.0162  0.0166  0.0009  0.0459  0.0001  0.0003  0.0038  0.0000  0.0140 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0002  0.0405  0.0182  0.0050  0.0014  0.0409  0.0002  0.0004  0.0959 </r>
+        <r>  0.0007  0.0002  0.0030  0.0059  0.0002  0.0361  0.0008  0.0000  0.0358 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0050  0.0018  0.0038  0.0062  0.0004  0.0003  0.0001  0.0453  0.0769 </r>
+        <r>  0.0011  0.0096  0.0124  0.0009  0.0001  0.0193  0.0013  0.0505  0.0287 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0317  0.0128  0.0080  0.0000  0.0017  0.0030  0.0385  0.0193  0.0431 </r>
+        <r>  0.0393  0.0669  0.0026  0.0002  0.0006  0.0264  0.0212  0.0059  0.0184 </r>
+       </set>
+      </set>
+      <set comment="kpoint 84">
+       <set comment="band 1">
+        <r>  0.0025  0.0001  0.0003  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0121  0.0042  0.9354  0.0006  0.0183 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0026  0.0316  0.0188  0.0131  0.9103 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9223  0.0182  0.0104  0.0250  0.0018 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0349  0.7582  0.0055  0.1677  0.0129 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0059  0.1669  0.0008  0.7732  0.0331 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6189  0.0002  0.0010  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0317  0.0041  0.0039  0.0019  0.0000  0.0000  0.0077  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0437  0.0141  0.0104  0.0075  0.0000  0.0000  0.0014  0.0000  0.0001 </r>
+        <r>  0.5898  0.0011  0.0000  0.0010  0.0001  0.0002  0.0004  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0112  0.0034  0.2376  0.0120  0.0000  0.0005  0.0017  0.0003  0.0000 </r>
+        <r>  0.0184  0.0001  0.1076  0.0031  0.0001  0.0009  0.0058  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0032  0.0073  0.0057  0.2690  0.0007  0.0000  0.0009  0.0002  0.0008 </r>
+        <r>  0.0229  0.0008  0.0046  0.1095  0.0015  0.0000  0.0002  0.0010  0.0027 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0090  0.3294  0.0004  0.0003  0.0006  0.0002  0.0020  0.0000  0.0007 </r>
+        <r>  0.0563  0.0805  0.0023  0.0009  0.0012  0.0010  0.0021  0.0000  0.0049 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0333  0.1140  0.0065  0.0018  0.0027  0.0037  0.0020  0.0000  0.0127 </r>
+        <r>  0.0129  0.2811  0.0011  0.0000  0.0001  0.0004  0.0017  0.0000  0.0044 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0171  0.0008  0.0496  0.1685  0.0071  0.0004  0.0005  0.0052  0.0123 </r>
+        <r>  0.0009  0.0173  0.0394  0.1796  0.0008  0.0001  0.0039  0.0001  0.0052 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0046  0.0019  0.1959  0.0430  0.0034  0.0040  0.0173  0.0003  0.0008 </r>
+        <r>  0.0340  0.0027  0.2131  0.0552  0.0003  0.0003  0.0030  0.0006  0.0006 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0060  0.0046  0.0004  0.0000  0.0572  0.0002  0.0028  0.0006  0.0007 </r>
+        <r>  0.0017  0.0136  0.0006  0.0736  0.0470  0.0001  0.0001  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0036  0.0162  0.0173  0.0038  0.0005  0.0711  0.0069  0.0003  0.0019 </r>
+        <r>  0.0021  0.0247  0.0598  0.0018  0.0005  0.0325  0.0001  0.0019  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0024  0.0000  0.0003  0.0002  0.0036  0.0019  0.0010  0.1809  0.0036 </r>
+        <r>  0.0000  0.0000  0.0340  0.0476  0.0002  0.0000  0.0000  0.0017  0.0002 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0031  0.0029  0.0343  0.0449  0.0060  0.0436  0.0118  0.0002  0.0081 </r>
+        <r>  0.0109  0.0025  0.0008  0.0078  0.0008  0.0000  0.0003  0.0332  0.0050 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0008  0.0333  0.0176  0.0120  0.0018  0.0549  0.0000  0.0008  0.0920 </r>
+        <r>  0.0006  0.0027  0.0162  0.0094  0.0001  0.0280  0.0030  0.0015  0.0263 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0165  0.0118  0.0003  0.0020  0.0000  0.0112  0.0128  0.0075  0.0763 </r>
+        <r>  0.0205  0.0014  0.0060  0.0460  0.0003  0.0087  0.0076  0.0480  0.0319 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0205  0.0288  0.0041  0.0046  0.0007  0.0007  0.0245  0.0062  0.0878 </r>
+        <r>  0.0225  0.1132  0.0034  0.0019  0.0020  0.0208  0.0228  0.0002  0.0313 </r>
+       </set>
+      </set>
+      <set comment="kpoint 85">
+       <set comment="band 1">
+        <r>  0.0025  0.0000  0.0002  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0217  0.0042  0.9035  0.0004  0.0411 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0052  0.0200  0.0394  0.0117  0.8998 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8529  0.0597  0.0178  0.0446  0.0030 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0892  0.7633  0.0088  0.1097  0.0080 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0090  0.1318  0.0018  0.8131  0.0241 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6572  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0021  0.0055  0.0024  0.0035  0.0000  0.0000  0.0078  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0024  0.0160  0.0072  0.0109  0.0000  0.0000  0.0014  0.0000  0.0001 </r>
+        <r>  0.6155  0.0002  0.0003  0.0005  0.0002  0.0001  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0079  0.0020  0.2460  0.0047  0.0000  0.0007  0.0011  0.0004  0.0000 </r>
+        <r>  0.0129  0.0000  0.1147  0.0008  0.0001  0.0014  0.0036  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0061  0.0091  0.0016  0.2707  0.0008  0.0000  0.0010  0.0001  0.0012 </r>
+        <r>  0.0270  0.0006  0.0018  0.1061  0.0016  0.0000  0.0007  0.0006  0.0046 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0083  0.3461  0.0001  0.0002  0.0007  0.0001  0.0020  0.0000  0.0006 </r>
+        <r>  0.0650  0.0609  0.0012  0.0014  0.0018  0.0007  0.0031  0.0000  0.0067 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0368  0.0927  0.0028  0.0018  0.0032  0.0023  0.0027  0.0000  0.0139 </r>
+        <r>  0.0129  0.3018  0.0001  0.0002  0.0000  0.0004  0.0009  0.0000  0.0032 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0179  0.0000  0.0105  0.1955  0.0059  0.0001  0.0004  0.0031  0.0154 </r>
+        <r>  0.0107  0.0103  0.0048  0.2383  0.0000  0.0000  0.0025  0.0003  0.0058 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0049  0.0010  0.2497  0.0077  0.0007  0.0075  0.0144  0.0030  0.0001 </r>
+        <r>  0.0233  0.0041  0.2344  0.0157  0.0000  0.0000  0.0043  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0053  0.0104  0.0012  0.0053  0.0627  0.0009  0.0040  0.0004  0.0004 </r>
+        <r>  0.0008  0.0181  0.0009  0.0519  0.0452  0.0005  0.0000  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0066  0.0078  0.0066  0.0011  0.0013  0.0667  0.0039  0.0000  0.0006 </r>
+        <r>  0.0010  0.0157  0.0767  0.0019  0.0011  0.0384  0.0007  0.0012  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0016  0.0001  0.0083  0.0099  0.0002  0.0180  0.0042  0.1076  0.0008 </r>
+        <r>  0.0012  0.0004  0.0229  0.0204  0.0002  0.0012  0.0004  0.0247  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0001  0.0051  0.0427  0.0290  0.0145  0.0100  0.0182  0.0573  0.0053 </r>
+        <r>  0.0109  0.0005  0.0454  0.0053  0.0004  0.0000  0.0027  0.0155  0.0012 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0073  0.0204  0.0144  0.0203  0.0000  0.0252  0.0296  0.0151  0.0650 </r>
+        <r>  0.0034  0.0037  0.0308  0.0020  0.0001  0.0134  0.0198  0.0160  0.0103 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0111  0.0289  0.0008  0.0251  0.0142  0.0141  0.0004  0.0001  0.0713 </r>
+        <r>  0.0112  0.0002  0.0000  0.0946  0.0063  0.0046  0.0139  0.0236  0.0230 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0083  0.0181  0.0000  0.0001  0.0127  0.0476  0.1735  0.0107  0.0395 </r>
+        <r>  0.0297  0.0001  0.0120  0.0052  0.0012  0.0145  0.0294  0.0100  0.0135 </r>
+       </set>
+      </set>
+      <set comment="kpoint 86">
+       <set comment="band 1">
+        <r>  0.0022  0.0000  0.0001  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0313  0.0034  0.8468  0.0001  0.0900 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0105  0.0089  0.0832  0.0078  0.8654 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.5141  0.3409  0.0143  0.1039  0.0050 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.4089  0.5117  0.0252  0.0318  0.0012 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0135  0.1138  0.0026  0.8358  0.0139 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6441  0.0003  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0100  0.0060  0.0010  0.0049  0.0000  0.0000  0.0066  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0155  0.0168  0.0038  0.0134  0.0000  0.0000  0.0013  0.0000  0.0001 </r>
+        <r>  0.6066  0.0001  0.0004  0.0000  0.0003  0.0001  0.0005  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0043  0.0010  0.2554  0.0020  0.0000  0.0008  0.0005  0.0005  0.0000 </r>
+        <r>  0.0066  0.0000  0.1188  0.0002  0.0000  0.0017  0.0017  0.0011  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0079  0.0123  0.0005  0.2742  0.0008  0.0000  0.0011  0.0001  0.0017 </r>
+        <r>  0.0309  0.0003  0.0007  0.0986  0.0014  0.0000  0.0012  0.0003  0.0069 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0054  0.3760  0.0000  0.0002  0.0007  0.0000  0.0019  0.0000  0.0003 </r>
+        <r>  0.0746  0.0332  0.0005  0.0027  0.0022  0.0004  0.0039  0.0000  0.0084 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0419  0.0576  0.0010  0.0024  0.0039  0.0012  0.0033  0.0000  0.0146 </r>
+        <r>  0.0090  0.3307  0.0000  0.0003  0.0000  0.0002  0.0003  0.0000  0.0013 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0215  0.0001  0.0030  0.1884  0.0047  0.0000  0.0012  0.0014  0.0167 </r>
+        <r>  0.0176  0.0088  0.0008  0.2595  0.0001  0.0000  0.0019  0.0002  0.0050 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0025  0.0005  0.2684  0.0020  0.0002  0.0124  0.0085  0.0059  0.0000 </r>
+        <r>  0.0123  0.0029  0.2166  0.0061  0.0000  0.0003  0.0032  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0001  0.0152  0.0009  0.0073  0.0219  0.0384  0.0085  0.0000  0.0005 </r>
+        <r>  0.0018  0.0019  0.0695  0.0151  0.0138  0.0269  0.0013  0.0013  0.0001 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0098  0.0031  0.0002  0.0054  0.0468  0.0223  0.0005  0.0008  0.0000 </r>
+        <r>  0.0000  0.0315  0.0386  0.0313  0.0290  0.0155  0.0001  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0024  0.0000  0.0044  0.0044  0.0008  0.0153  0.0026  0.0964  0.0007 </r>
+        <r>  0.0007  0.0000  0.0315  0.0091  0.0004  0.0021  0.0008  0.0344  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0103  0.0059  0.0360  0.0113  0.0127  0.0019  0.0852  0.0125  0.0003 </r>
+        <r>  0.0315  0.0004  0.0631  0.0028  0.0002  0.0000  0.0326  0.0004  0.0002 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0063  0.0197  0.0000  0.0619  0.0647  0.0032  0.0593  0.0288  0.0203 </r>
+        <r>  0.0021  0.0073  0.0008  0.0089  0.0181  0.0001  0.0258  0.0074  0.0009 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0048  0.0465  0.0028  0.0000  0.0320  0.0034  0.0032  0.0481  0.0180 </r>
+        <r>  0.0027  0.0043  0.0003  0.0263  0.0206  0.0018  0.0025  0.0348  0.0011 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0013  0.0126  0.0191  0.0146  0.0000  0.0792  0.0458  0.0219  0.0915 </r>
+        <r>  0.0106  0.0054  0.0034  0.0248  0.0018  0.0223  0.0030  0.0064  0.0134 </r>
+       </set>
+      </set>
+      <set comment="kpoint 87">
+       <set comment="band 1">
+        <r>  0.0017  0.0000  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0364  0.0015  0.7417  0.0000  0.1929 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0214  0.0018  0.1749  0.0028  0.7749 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0365  0.8125  0.0005  0.1268  0.0019 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8643  0.0548  0.0533  0.0056  0.0008 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0200  0.1078  0.0029  0.8440  0.0048 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5943  0.0008  0.0000  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0454  0.0054  0.0002  0.0054  0.0000  0.0000  0.0047  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0675  0.0166  0.0010  0.0151  0.0000  0.0000  0.0011  0.0000  0.0001 </r>
+        <r>  0.5721  0.0007  0.0002  0.0001  0.0003  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0012  0.0003  0.2676  0.0005  0.0000  0.0008  0.0001  0.0006  0.0000 </r>
+        <r>  0.0018  0.0000  0.1209  0.0000  0.0000  0.0020  0.0005  0.0015  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0084  0.0191  0.0001  0.2843  0.0007  0.0000  0.0012  0.0000  0.0020 </r>
+        <r>  0.0327  0.0000  0.0001  0.0861  0.0011  0.0000  0.0015  0.0001  0.0096 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0014  0.4112  0.0000  0.0010  0.0003  0.0000  0.0013  0.0000  0.0000 </r>
+        <r>  0.0851  0.0050  0.0001  0.0057  0.0026  0.0001  0.0044  0.0000  0.0089 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0479  0.0149  0.0002  0.0044  0.0049  0.0003  0.0042  0.0000  0.0142 </r>
+        <r>  0.0028  0.3588  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0245  0.0006  0.0005  0.1705  0.0037  0.0000  0.0016  0.0004  0.0178 </r>
+        <r>  0.0208  0.0110  0.0001  0.2763  0.0005  0.0000  0.0015  0.0001  0.0035 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0006  0.0002  0.2689  0.0004  0.0001  0.0186  0.0025  0.0085  0.0000 </r>
+        <r>  0.0034  0.0010  0.1888  0.0015  0.0000  0.0021  0.0011  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0015  0.0018  0.0041  0.0004  0.0001  0.0523  0.0023  0.0007  0.0001 </r>
+        <r>  0.0009  0.0004  0.1496  0.0003  0.0001  0.0430  0.0008  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0068  0.0020  0.0115  0.0209  0.0113  0.0090  0.0617  0.0000 </r>
+        <r>  0.0019  0.0136  0.0212  0.0091  0.0115  0.0026  0.0019  0.0274  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0038  0.0127  0.0000  0.0076  0.0508  0.0033  0.0052  0.0292  0.0004 </r>
+        <r>  0.0007  0.0236  0.0274  0.0413  0.0251  0.0003  0.0005  0.0134  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0255  0.0022  0.0105  0.0037  0.0175  0.0001  0.1063  0.0013  0.0000 </r>
+        <r>  0.0417  0.0001  0.0229  0.0002  0.0009  0.0001  0.0506  0.0001  0.0001 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0450  0.0000  0.0488  0.1029  0.0009  0.0276  0.0017  0.0034 </r>
+        <r>  0.0003  0.0105  0.0000  0.0139  0.0463  0.0000  0.0073  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0056  0.0058  0.0150  0.0131  0.0012  0.0038  0.0193  0.1058  0.0384 </r>
+        <r>  0.0007  0.0042  0.0048  0.0130  0.0072  0.0002  0.0101  0.0342  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0003  0.0007  0.0115  0.0061  0.0000  0.0466  0.0003  0.0646  0.2027 </r>
+        <r>  0.0054  0.0170  0.0122  0.0116  0.0019  0.0009  0.0020  0.0043  0.0006 </r>
+       </set>
+      </set>
+      <set comment="kpoint 88">
+       <set comment="band 1">
+        <r>  0.0012  0.0000  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0323  0.0000  0.5695  0.0000  0.3717 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0001  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0397  0.0000  0.3349  0.0000  0.6013 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.8619  0.0000  0.1162  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9047  0.0003  0.0698  0.0019  0.0022 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0021  0.1160  0.0002  0.8609  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5448  0.0010  0.0000  0.0018  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0804  0.0043  0.0000  0.0052  0.0000  0.0000  0.0029  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1198  0.0157  0.0000  0.0162  0.0000  0.0000  0.0008  0.0000  0.0001 </r>
+        <r>  0.5384  0.0016  0.0000  0.0007  0.0003  0.0000  0.0014  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2828  0.0000  0.0000  0.0009  0.0000  0.0007  0.0000 </r>
+        <r>  0.0000  0.0000  0.1207  0.0000  0.0000  0.0020  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0076  0.0413  0.0000  0.2993  0.0006  0.0000  0.0011  0.0000  0.0018 </r>
+        <r>  0.0281  0.0007  0.0000  0.0637  0.0007  0.0000  0.0015  0.0000  0.0133 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0001  0.4021  0.0000  0.0097  0.0000  0.0000  0.0007  0.0000  0.0008 </r>
+        <r>  0.0950  0.0057  0.0000  0.0120  0.0029  0.0000  0.0045  0.0000  0.0058 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0544  0.0014  0.0000  0.0118  0.0062  0.0000  0.0056  0.0000  0.0101 </r>
+        <r>  0.0000  0.3440  0.0000  0.0048  0.0000  0.0000  0.0002  0.0000  0.0013 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0220  0.0022  0.0000  0.1348  0.0022  0.0000  0.0013  0.0000  0.0209 </r>
+        <r>  0.0203  0.0269  0.0000  0.2914  0.0007  0.0000  0.0012  0.0000  0.0015 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2504  0.0000  0.0000  0.0213  0.0000  0.0098  0.0000 </r>
+        <r>  0.0000  0.0000  0.1783  0.0000  0.0000  0.0039  0.0000  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0111  0.0000  0.0000  0.0488  0.0000  0.0013  0.0000 </r>
+        <r>  0.0000  0.0000  0.1684  0.0000  0.0000  0.0432  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0136  0.0000  0.0870  0.0000 </r>
+        <r>  0.0000  0.0000  0.0558  0.0000  0.0000  0.0030  0.0000  0.0451  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0099  0.0178  0.0000  0.0186  0.0124  0.0000  0.1032  0.0000  0.0001 </r>
+        <r>  0.0377  0.0201  0.0000  0.0272  0.0101  0.0000  0.0419  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0230  0.0029  0.0000  0.0014  0.1185  0.0000  0.0165  0.0000  0.0002 </r>
+        <r>  0.0105  0.0337  0.0000  0.0291  0.0087  0.0000  0.0159  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0497  0.0000  0.0436  0.0643  0.0000  0.0274  0.0000  0.0021 </r>
+        <r>  0.0007  0.0037  0.0000  0.0047  0.0674  0.0000  0.0081  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0510  0.0000  0.0645  0.0000 </r>
+        <r>  0.0000  0.0000  0.0191  0.0000  0.0000  0.0061  0.0000  0.0016  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0044  0.0134  0.0000  0.0004  0.0011  0.0000  0.0270  0.0001  0.1989 </r>
+        <r>  0.0117  0.0921  0.0000  0.0018  0.0163  0.0000  0.0114  0.0000  0.0415 </r>
+       </set>
+      </set>
+      <set comment="kpoint 89">
+       <set comment="band 1">
+        <r>  0.0030  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0007  0.9683  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9750  0.0000  0.0000  0.0021  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0189  0.0008  0.0000  0.9580 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9599  0.0005  0.0000  0.0192 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0021  0.0000  0.0000  0.9776  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5329  0.0001  0.0024  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0972  0.0007  0.0046  0.0000  0.0000  0.0000  0.0081  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1511  0.0043  0.0147  0.0000  0.0000  0.0000  0.0019  0.0000  0.0000 </r>
+        <r>  0.5562  0.0010  0.0001  0.0000  0.0000  0.0001  0.0024  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0078  0.0075  0.2323  0.0000  0.0000  0.0002  0.0034  0.0000  0.0000 </r>
+        <r>  0.0418  0.0017  0.1090  0.0000  0.0000  0.0001  0.0068  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.3075  0.0002  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1222  0.0005  0.0000  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0027  0.3116  0.0026  0.0000  0.0000  0.0004  0.0008  0.0000  0.0002 </r>
+        <r>  0.0189  0.1143  0.0030  0.0000  0.0000  0.0013  0.0002  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0397  0.0590  0.1838  0.0000  0.0000  0.0050  0.0054  0.0000  0.0021 </r>
+        <r>  0.0032  0.0945  0.1680  0.0000  0.0000  0.0000  0.0071  0.0000  0.0012 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0000  0.0000  0.0391  0.0630  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0126  0.0468  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0009  0.1257  0.0836  0.0000  0.0000  0.0018  0.0118  0.0000  0.0057 </r>
+        <r>  0.0235  0.2239  0.1048  0.0000  0.0000  0.0005  0.0006  0.0000  0.0030 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.1948  0.0040  0.0000  0.0000  0.0072  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3333  0.0066  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0267  0.0044  0.0091  0.0000  0.0000  0.0001  0.0446  0.0000  0.0674 </r>
+        <r>  0.0643  0.0018  0.0217  0.0000  0.0000  0.0012  0.0120  0.0000  0.0345 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0057  0.0371  0.0093  0.0000  0.0000  0.0155  0.0121  0.0000  0.1267 </r>
+        <r>  0.0140  0.0073  0.0037  0.0000  0.0000  0.0118  0.0025  0.0000  0.0599 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0000  0.0000  0.0035  0.0026  0.0000  0.0000  0.1459  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0665  0.0004  0.0000  0.0000  0.0350  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0000  0.0001  0.0000  0.0000  0.1689  0.0037  0.0000  0.0053 </r>
+        <r>  0.0021  0.0865  0.0199  0.0000  0.0000  0.0134  0.0003  0.0000  0.0046 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0243  0.0053  0.0188  0.0000  0.0000  0.0315  0.0069  0.0000  0.0324 </r>
+        <r>  0.0166  0.0060  0.0132  0.0000  0.0000  0.0684  0.0120  0.0000  0.0122 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0107  0.0008  0.0127  0.0017  0.0260  0.0002  0.0002  0.0010  0.0163 </r>
+        <r>  0.0041  0.0002  0.0129  0.0017  0.0057  0.0003  0.0048  0.0057  0.0044 </r>
+       </set>
+      </set>
+      <set comment="kpoint 90">
+       <set comment="band 1">
+        <r>  0.0035  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0006  0.0011  0.9643  0.0001  0.0027 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0273  0.0235  0.0027  0.0016  0.9223 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9455  0.0000  0.0011  0.0041  0.0265 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0015  0.8740  0.0007  0.0861  0.0174 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0022  0.0811  0.0000  0.8879  0.0086 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5688  0.0002  0.0018  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0741  0.0016  0.0039  0.0002  0.0000  0.0000  0.0100  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1102  0.0082  0.0112  0.0012  0.0000  0.0000  0.0022  0.0000  0.0000 </r>
+        <r>  0.5766  0.0015  0.0000  0.0003  0.0000  0.0001  0.0017  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0073  0.0035  0.2295  0.0016  0.0000  0.0002  0.0024  0.0000  0.0000 </r>
+        <r>  0.0310  0.0005  0.1144  0.0004  0.0000  0.0004  0.0050  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0006  0.0011  0.0006  0.2926  0.0004  0.0000  0.0001  0.0003  0.0001 </r>
+        <r>  0.0036  0.0003  0.0006  0.1215  0.0010  0.0000  0.0000  0.0008  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0063  0.3133  0.0006  0.0002  0.0001  0.0003  0.0011  0.0000  0.0004 </r>
+        <r>  0.0288  0.1096  0.0016  0.0002  0.0002  0.0009  0.0008  0.0000  0.0019 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0217  0.1526  0.0144  0.0047  0.0058  0.0045  0.0007  0.0001  0.0091 </r>
+        <r>  0.0075  0.2573  0.0056  0.0008  0.0027  0.0003  0.0023  0.0000  0.0046 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0005  0.0076  0.0001  0.0772  0.0524  0.0004  0.0001  0.0007  0.0026 </r>
+        <r>  0.0001  0.0342  0.0000  0.0285  0.0360  0.0000  0.0000  0.0000  0.0013 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0179  0.0078  0.2670  0.0027  0.0010  0.0016  0.0144  0.0008  0.0014 </r>
+        <r>  0.0190  0.0171  0.2503  0.0059  0.0008  0.0003  0.0059  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0009  0.0001  0.0066  0.1568  0.0080  0.0000  0.0025  0.0042  0.0016 </r>
+        <r>  0.0058  0.0019  0.0103  0.3066  0.0131  0.0000  0.0000  0.0002  0.0009 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0101  0.0126  0.0166  0.0103  0.0002  0.0118  0.0412  0.0013  0.0437 </r>
+        <r>  0.0461  0.0114  0.0461  0.0041  0.0001  0.0078  0.0053  0.0021  0.0201 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0078  0.0162  0.0023  0.0037  0.0001  0.0560  0.0000  0.0025  0.0785 </r>
+        <r>  0.0019  0.0328  0.0190  0.0006  0.0000  0.0107  0.0015  0.0008  0.0398 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0001  0.0004  0.0014  0.0037  0.0002  0.0008  0.1618  0.0021 </r>
+        <r>  0.0007  0.0001  0.0050  0.0661  0.0004  0.0001  0.0002  0.0191  0.0017 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0057  0.0298  0.0137  0.0000  0.0004  0.1408  0.0070  0.0013  0.0607 </r>
+        <r>  0.0079  0.0041  0.0051  0.0001  0.0001  0.0102  0.0008  0.0001  0.0204 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0210  0.0002  0.0082  0.0007  0.0003  0.0004  0.0176  0.0002  0.0617 </r>
+        <r>  0.0245  0.0668  0.0002  0.0000  0.0000  0.0607  0.0144  0.0005  0.0275 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0231  0.0049  0.0115  0.0076  0.0016  0.0007  0.0031  0.0521  0.0153 </r>
+        <r>  0.0129  0.0012  0.0171  0.0007  0.0003  0.0008  0.0105  0.0483  0.0050 </r>
+       </set>
+      </set>
+      <set comment="kpoint 91">
+       <set comment="band 1">
+        <r>  0.0036  0.0001  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0036  0.0012  0.9561  0.0002  0.0076 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0028  0.0190  0.0076  0.0044  0.9433 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9649  0.0015  0.0039  0.0046  0.0024 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0038  0.8692  0.0009  0.0933  0.0123 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0022  0.0887  0.0002  0.8774  0.0115 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6134  0.0001  0.0010  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0431  0.0030  0.0026  0.0009  0.0000  0.0000  0.0113  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0600  0.0119  0.0074  0.0041  0.0000  0.0000  0.0023  0.0000  0.0001 </r>
+        <r>  0.6026  0.0014  0.0001  0.0007  0.0001  0.0001  0.0007  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0060  0.0019  0.2314  0.0017  0.0000  0.0004  0.0014  0.0001  0.0000 </r>
+        <r>  0.0189  0.0001  0.1180  0.0004  0.0000  0.0007  0.0032  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0026  0.0028  0.0005  0.2806  0.0006  0.0000  0.0004  0.0002  0.0003 </r>
+        <r>  0.0105  0.0005  0.0007  0.1188  0.0014  0.0000  0.0003  0.0005  0.0012 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0091  0.3147  0.0001  0.0003  0.0003  0.0001  0.0015  0.0000  0.0007 </r>
+        <r>  0.0402  0.1007  0.0009  0.0004  0.0006  0.0006  0.0017  0.0000  0.0032 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0248  0.1518  0.0047  0.0023  0.0036  0.0027  0.0018  0.0000  0.0123 </r>
+        <r>  0.0137  0.2784  0.0007  0.0000  0.0006  0.0003  0.0016  0.0000  0.0054 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0016  0.0007  0.0035  0.1732  0.0346  0.0000  0.0000  0.0016  0.0070 </r>
+        <r>  0.0014  0.0216  0.0022  0.1142  0.0169  0.0000  0.0007  0.0001  0.0033 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0171  0.0025  0.2382  0.0038  0.0113  0.0045  0.0061  0.0025  0.0012 </r>
+        <r>  0.0070  0.0009  0.1893  0.0255  0.0099  0.0000  0.0051  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0010  0.0000  0.0582  0.0571  0.0187  0.0008  0.0088  0.0004  0.0018 </r>
+        <r>  0.0155  0.0107  0.0628  0.1899  0.0237  0.0001  0.0002  0.0003  0.0011 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0017  0.0128  0.0085  0.0023  0.0001  0.0729  0.0107  0.0000  0.0014 </r>
+        <r>  0.0052  0.0166  0.0819  0.0010  0.0001  0.0302  0.0001  0.0010  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0049  0.0005  0.0101  0.0247  0.0002  0.0283  0.0209  0.0369  0.0300 </r>
+        <r>  0.0213  0.0017  0.0083  0.0307  0.0001  0.0007  0.0014  0.0091  0.0165 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0067  0.0000  0.0031  0.0127  0.0040  0.0006  0.0039  0.1660  0.0342 </r>
+        <r>  0.0074  0.0003  0.0171  0.0149  0.0003  0.0000  0.0009  0.0046  0.0116 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0016  0.0298  0.0271  0.0006  0.0025  0.0589  0.0055  0.0000  0.1290 </r>
+        <r>  0.0005  0.0001  0.0077  0.0137  0.0002  0.0077  0.0042  0.0053  0.0439 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0180  0.0218  0.0000  0.0010  0.0005  0.0208  0.0172  0.0021  0.0107 </r>
+        <r>  0.0239  0.0001  0.0118  0.0275  0.0001  0.0092  0.0061  0.0503  0.0066 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0317  0.0112  0.0074  0.0016  0.0003  0.0035  0.0115  0.0056  0.0700 </r>
+        <r>  0.0224  0.1076  0.0061  0.0006  0.0002  0.0281  0.0289  0.0000  0.0300 </r>
+       </set>
+      </set>
+      <set comment="kpoint 92">
+       <set comment="band 1">
+        <r>  0.0035  0.0001  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0099  0.0010  0.9405  0.0001  0.0176 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0035  0.0104  0.0167  0.0038  0.9422 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9554  0.0039  0.0107  0.0054  0.0023 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0069  0.8746  0.0010  0.0906  0.0061 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0020  0.0894  0.0003  0.8800  0.0083 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6539  0.0000  0.0003  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0121  0.0045  0.0013  0.0021  0.0000  0.0000  0.0115  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0149  0.0148  0.0038  0.0078  0.0000  0.0000  0.0022  0.0000  0.0001 </r>
+        <r>  0.6276  0.0007  0.0002  0.0007  0.0001  0.0001  0.0000  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0036  0.0009  0.2368  0.0011  0.0000  0.0005  0.0006  0.0002  0.0000 </r>
+        <r>  0.0088  0.0000  0.1209  0.0002  0.0000  0.0011  0.0016  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0051  0.0049  0.0002  0.2727  0.0008  0.0000  0.0006  0.0001  0.0008 </r>
+        <r>  0.0179  0.0006  0.0004  0.1146  0.0016  0.0000  0.0006  0.0002  0.0026 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0104  0.3213  0.0000  0.0002  0.0006  0.0001  0.0019  0.0000  0.0008 </r>
+        <r>  0.0509  0.0875  0.0004  0.0007  0.0012  0.0003  0.0026  0.0000  0.0047 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0292  0.1374  0.0017  0.0015  0.0032  0.0013  0.0024  0.0000  0.0141 </r>
+        <r>  0.0163  0.2910  0.0001  0.0001  0.0001  0.0002  0.0011  0.0000  0.0051 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0088  0.0000  0.0034  0.2229  0.0145  0.0000  0.0004  0.0014  0.0126 </r>
+        <r>  0.0086  0.0110  0.0013  0.2148  0.0026  0.0000  0.0015  0.0001  0.0055 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0053  0.0014  0.3086  0.0023  0.0024  0.0104  0.0067  0.0035  0.0000 </r>
+        <r>  0.0097  0.0014  0.2258  0.0009  0.0011  0.0001  0.0031  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0066  0.0023  0.0034  0.0031  0.0500  0.0000  0.0041  0.0001  0.0011 </r>
+        <r>  0.0042  0.0175  0.0060  0.1049  0.0454  0.0000  0.0000  0.0001  0.0006 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0035  0.0052  0.0006  0.0006  0.0002  0.0703  0.0051  0.0001  0.0003 </r>
+        <r>  0.0019  0.0065  0.1092  0.0002  0.0002  0.0377  0.0009  0.0008  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0007  0.0002  0.0055  0.0068  0.0001  0.0159  0.0063  0.1082  0.0000 </r>
+        <r>  0.0028  0.0003  0.0317  0.0116  0.0001  0.0008  0.0004  0.0228  0.0002 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0062  0.0291  0.0261  0.0078  0.0078  0.0600  0.0523  0.0121 </r>
+        <r>  0.0320  0.0010  0.0326  0.0025  0.0004  0.0000  0.0063  0.0046  0.0047 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0221  0.0106  0.0077  0.0263  0.0000  0.0076  0.0152  0.0100  0.1614 </r>
+        <r>  0.0000  0.0003  0.0140  0.0222  0.0000  0.0023  0.0291  0.0011  0.0457 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0009  0.0084  0.0002  0.0003  0.0007  0.0015  0.0646  0.0262  0.0352 </r>
+        <r>  0.0337  0.0014  0.0069  0.0640  0.0002  0.0018  0.0005  0.0427  0.0195 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0430  0.0539  0.0013  0.0024  0.0054  0.0779  0.0417  0.0200  0.0264 </r>
+        <r>  0.0005  0.0131  0.0056  0.0071  0.0006  0.0120  0.0576  0.0002  0.0074 </r>
+       </set>
+      </set>
+      <set comment="kpoint 93">
+       <set comment="band 1">
+        <r>  0.0031  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0194  0.0004  0.9116  0.0000  0.0385 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0058  0.0028  0.0354  0.0015  0.9308 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9408  0.0078  0.0222  0.0049  0.0025 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0109  0.8728  0.0009  0.0930  0.0014 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0012  0.0952  0.0003  0.8803  0.0029 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6653  0.0001  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0001  0.0057  0.0003  0.0037  0.0000  0.0000  0.0101  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0006  0.0166  0.0011  0.0112  0.0000  0.0000  0.0020  0.0000  0.0001 </r>
+        <r>  0.6329  0.0001  0.0001  0.0004  0.0002  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0011  0.0002  0.2448  0.0003  0.0000  0.0006  0.0001  0.0003  0.0000 </r>
+        <r>  0.0022  0.0000  0.1229  0.0000  0.0000  0.0015  0.0004  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0073  0.0073  0.0001  0.2698  0.0008  0.0000  0.0009  0.0000  0.0012 </r>
+        <r>  0.0248  0.0005  0.0001  0.1087  0.0016  0.0000  0.0010  0.0001  0.0044 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0095  0.3381  0.0000  0.0001  0.0008  0.0000  0.0020  0.0000  0.0007 </r>
+        <r>  0.0610  0.0677  0.0001  0.0012  0.0018  0.0001  0.0033  0.0000  0.0065 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0342  0.1115  0.0003  0.0013  0.0034  0.0003  0.0027  0.0000  0.0151 </r>
+        <r>  0.0154  0.3084  0.0000  0.0005  0.0000  0.0001  0.0007  0.0000  0.0037 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0158  0.0001  0.0009  0.2179  0.0078  0.0000  0.0011  0.0004  0.0153 </r>
+        <r>  0.0159  0.0070  0.0002  0.2516  0.0001  0.0000  0.0016  0.0001  0.0058 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0008  0.0003  0.3158  0.0007  0.0001  0.0171  0.0023  0.0062  0.0000 </r>
+        <r>  0.0034  0.0009  0.1999  0.0014  0.0000  0.0009  0.0010  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0067  0.0073  0.0000  0.0022  0.0616  0.0001  0.0041  0.0001  0.0004 </r>
+        <r>  0.0014  0.0229  0.0006  0.0633  0.0467  0.0001  0.0000  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0019  0.0010  0.0031  0.0001  0.0003  0.0613  0.0018  0.0007  0.0001 </r>
+        <r>  0.0008  0.0017  0.1502  0.0001  0.0002  0.0413  0.0006  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0009  0.0000  0.0014  0.0017  0.0001  0.0128  0.0022  0.1019  0.0001 </r>
+        <r>  0.0008  0.0001  0.0503  0.0022  0.0001  0.0011  0.0006  0.0320  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0160  0.0063  0.0124  0.0086  0.0064  0.0007  0.1254  0.0050  0.0001 </r>
+        <r>  0.0465  0.0011  0.0231  0.0028  0.0003  0.0000  0.0417  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0180  0.0005  0.0010  0.0734  0.0153  0.0004  0.0124  0.0316  0.1210 </r>
+        <r>  0.0006  0.0013  0.0002  0.0150  0.0015  0.0001  0.0254  0.0068  0.0226 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0002  0.0025  0.0192  0.0077  0.0011  0.0131  0.0247  0.1220  0.0518 </r>
+        <r>  0.0151  0.0001  0.0005  0.0591  0.0020  0.0006  0.0000  0.0353  0.0167 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0031  0.1022  0.0016  0.0052  0.0571  0.0270  0.0206  0.0003  0.0677 </r>
+        <r>  0.0000  0.0145  0.0004  0.0069  0.0151  0.0050  0.0106  0.0003  0.0137 </r>
+       </set>
+      </set>
+      <set comment="kpoint 94">
+       <set comment="band 1">
+        <r>  0.0025  0.0000  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0302  0.0000  0.8561  0.0000  0.0849 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0106  0.0000  0.0770  0.0000  0.8884 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9375  0.0001  0.0386  0.0000  0.0023 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.8722  0.0000  0.1063  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.1065  0.0000  0.8732  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6383  0.0004  0.0000  0.0007  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0161  0.0059  0.0000  0.0049  0.0000  0.0000  0.0074  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0255  0.0171  0.0000  0.0136  0.0000  0.0000  0.0016  0.0000  0.0001 </r>
+        <r>  0.6094  0.0001  0.0000  0.0000  0.0003  0.0000  0.0009  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2548  0.0000  0.0000  0.0008  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.1232  0.0000  0.0000  0.0018  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0085  0.0111  0.0000  0.2731  0.0008  0.0000  0.0011  0.0000  0.0017 </r>
+        <r>  0.0302  0.0003  0.0000  0.1001  0.0015  0.0000  0.0014  0.0000  0.0067 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0062  0.3709  0.0000  0.0001  0.0007  0.0000  0.0019  0.0000  0.0003 </r>
+        <r>  0.0720  0.0379  0.0000  0.0024  0.0022  0.0000  0.0040  0.0000  0.0083 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0404  0.0687  0.0000  0.0019  0.0039  0.0000  0.0033  0.0000  0.0153 </r>
+        <r>  0.0105  0.3340  0.0000  0.0005  0.0000  0.0000  0.0002  0.0000  0.0016 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0214  0.0003  0.0000  0.1992  0.0052  0.0000  0.0016  0.0000  0.0166 </r>
+        <r>  0.0202  0.0067  0.0000  0.2662  0.0001  0.0000  0.0016  0.0000  0.0050 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2988  0.0000  0.0000  0.0214  0.0000  0.0082  0.0000 </r>
+        <r>  0.0000  0.0000  0.1772  0.0000  0.0000  0.0023  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0103  0.0000  0.0000  0.0540  0.0000  0.0015  0.0000 </r>
+        <r>  0.0000  0.0000  0.1753  0.0000  0.0000  0.0427  0.0000  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0052  0.0133  0.0000  0.0098  0.0677  0.0000  0.0066  0.0000  0.0002 </r>
+        <r>  0.0011  0.0294  0.0000  0.0517  0.0435  0.0000  0.0004  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0002  0.0000  0.0000  0.0125  0.0000  0.0949  0.0000 </r>
+        <r>  0.0000  0.0000  0.0628  0.0000  0.0000  0.0014  0.0000  0.0379  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0255  0.0040  0.0000  0.0055  0.0084  0.0000  0.1290  0.0000  0.0000 </r>
+        <r>  0.0493  0.0004  0.0000  0.0015  0.0006  0.0000  0.0531  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0015  0.0408  0.0000  0.0754  0.0998  0.0000  0.0252  0.0000  0.0199 </r>
+        <r>  0.0001  0.0104  0.0000  0.0212  0.0298  0.0000  0.0133  0.0000  0.0010 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0062  0.0391  0.0000  0.0171  0.0129  0.0000  0.0006  0.0000  0.1477 </r>
+        <r>  0.0000  0.0060  0.0000  0.0030  0.0115  0.0000  0.0045  0.0000  0.0114 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0438  0.0000  0.0000  0.0315  0.0000  0.2405  0.0001 </r>
+        <r>  0.0000  0.0000  0.0099  0.0001  0.0000  0.0010  0.0000  0.0490  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 95">
+       <set comment="band 1">
+        <r>  0.0044  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002  0.9663  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9763  0.0000  0.0000  0.0006  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0075  0.0007  0.0000  0.9697 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9722  0.0002  0.0000  0.0076 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0006  0.0000  0.0000  0.9794  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5786  0.0001  0.0013  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0732  0.0008  0.0027  0.0000  0.0000  0.0000  0.0131  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1092  0.0045  0.0082  0.0000  0.0000  0.0000  0.0030  0.0000  0.0000 </r>
+        <r>  0.6000  0.0009  0.0001  0.0000  0.0000  0.0000  0.0019  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0042  0.0011  0.2241  0.0000  0.0000  0.0001  0.0017  0.0000  0.0000 </r>
+        <r>  0.0257  0.0001  0.1199  0.0000  0.0000  0.0002  0.0028  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.2983  0.0002  0.0000  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1246  0.0005  0.0000  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0037  0.3076  0.0001  0.0000  0.0000  0.0002  0.0005  0.0000  0.0002 </r>
+        <r>  0.0138  0.1192  0.0004  0.0000  0.0000  0.0005  0.0005  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0000  0.0000  0.0243  0.0645  0.0000  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0032  0.0504  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0123  0.1991  0.0087  0.0000  0.0000  0.0036  0.0006  0.0000  0.0078 </r>
+        <r>  0.0054  0.3171  0.0031  0.0000  0.0000  0.0002  0.0014  0.0000  0.0041 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.2279  0.0014  0.0000  0.0000  0.0037  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3543  0.0036  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0142  0.0056  0.3232  0.0000  0.0000  0.0012  0.0115  0.0000  0.0004 </r>
+        <r>  0.0132  0.0118  0.2654  0.0000  0.0000  0.0001  0.0055  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0181  0.0032  0.0066  0.0000  0.0000  0.0040  0.0452  0.0000  0.0769 </r>
+        <r>  0.0590  0.0024  0.0452  0.0000  0.0000  0.0024  0.0065  0.0000  0.0364 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0244  0.0055  0.0000  0.0000  0.0189  0.0091  0.0000  0.1216 </r>
+        <r>  0.0058  0.0267  0.0264  0.0000  0.0000  0.0084  0.0000  0.0000  0.0578 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0145  0.0095  0.0021  0.0000  0.0000  0.1933  0.0109  0.0000  0.0338 </r>
+        <r>  0.0178  0.0078  0.0089  0.0000  0.0000  0.0000  0.0034  0.0000  0.0115 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0024  0.0017  0.0000  0.0000  0.2236  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0550  0.0002  0.0000  0.0000  0.0090  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0338  0.0012  0.0183  0.0001  0.0000  0.0117  0.0043  0.0003  0.0203 </r>
+        <r>  0.0193  0.0557  0.0021  0.0000  0.0000  0.0518  0.0205  0.0002  0.0101 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0208  0.0039  0.0105  0.0045  0.0007  0.0002  0.0003  0.0205  0.0252 </r>
+        <r>  0.0077  0.0003  0.0286  0.0003  0.0001  0.0044  0.0088  0.0150  0.0087 </r>
+       </set>
+      </set>
+      <set comment="kpoint 96">
+       <set comment="band 1">
+        <r>  0.0046  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.0002  0.9633  0.0000  0.0028 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9747  0.0002  0.0004  0.0007  0.0011 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0010  0.0065  0.0030  0.0007  0.9664 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0002  0.9485  0.0001  0.0252  0.0059 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0006  0.0245  0.0000  0.9536  0.0015 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6112  0.0001  0.0006  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0519  0.0018  0.0014  0.0002  0.0000  0.0000  0.0146  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0726  0.0087  0.0042  0.0012  0.0000  0.0000  0.0031  0.0000  0.0000 </r>
+        <r>  0.6208  0.0013  0.0001  0.0002  0.0000  0.0000  0.0010  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0025  0.0007  0.2266  0.0002  0.0000  0.0002  0.0008  0.0000  0.0000 </r>
+        <r>  0.0124  0.0001  0.1222  0.0000  0.0000  0.0005  0.0014  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0009  0.0007  0.0000  0.2874  0.0005  0.0000  0.0001  0.0001  0.0001 </r>
+        <r>  0.0028  0.0002  0.0001  0.1236  0.0010  0.0000  0.0001  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0071  0.3077  0.0000  0.0002  0.0001  0.0001  0.0010  0.0000  0.0005 </r>
+        <r>  0.0256  0.1132  0.0003  0.0001  0.0002  0.0002  0.0011  0.0000  0.0019 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0081  0.0910  0.0012  0.0296  0.0384  0.0006  0.0007  0.0001  0.0037 </r>
+        <r>  0.0065  0.1163  0.0002  0.0040  0.0250  0.0001  0.0008  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0086  0.0936  0.0012  0.0276  0.0241  0.0010  0.0010  0.0000  0.0091 </r>
+        <r>  0.0047  0.1996  0.0001  0.0071  0.0195  0.0001  0.0005  0.0000  0.0045 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0044  0.0000  0.0061  0.1966  0.0038  0.0001  0.0002  0.0019  0.0024 </r>
+        <r>  0.0017  0.0002  0.0029  0.3361  0.0085  0.0000  0.0006  0.0001  0.0012 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0059  0.0016  0.3453  0.0038  0.0000  0.0049  0.0074  0.0003  0.0001 </r>
+        <r>  0.0087  0.0047  0.2549  0.0071  0.0001  0.0000  0.0033  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0002  0.0077  0.0026  0.0007  0.0000  0.0783  0.0128  0.0000  0.0010 </r>
+        <r>  0.0087  0.0095  0.1049  0.0003  0.0000  0.0261  0.0000  0.0003  0.0003 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0169  0.0003  0.0016  0.0103  0.0000  0.0119  0.0218  0.0028  0.1317 </r>
+        <r>  0.0337  0.0022  0.0041  0.0094  0.0000  0.0012  0.0050  0.0015  0.0603 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0014  0.0058  0.0042  0.0006  0.0003  0.0205  0.0031  0.1647  0.0645 </r>
+        <r>  0.0004  0.0005  0.0122  0.0096  0.0000  0.0000  0.0009  0.0018  0.0230 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0038  0.0296  0.0132  0.0018  0.0017  0.0465  0.0410  0.0732  0.0514 </r>
+        <r>  0.0299  0.0017  0.0048  0.0127  0.0001  0.0006  0.0000  0.0013  0.0185 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0360  0.0157  0.0060  0.0024  0.0017  0.0008  0.0154  0.0063  0.0000 </r>
+        <r>  0.0318  0.0103  0.0144  0.0252  0.0001  0.0001  0.0167  0.0256  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0395  0.0001  0.0112  0.0011  0.0000  0.0131  0.0166  0.0054  0.0332 </r>
+        <r>  0.0003  0.0711  0.0231  0.0004  0.0000  0.0169  0.0470  0.0024  0.0177 </r>
+       </set>
+      </set>
+      <set comment="kpoint 97">
+       <set comment="band 1">
+        <r>  0.0044  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0031  0.0001  0.9566  0.0000  0.0075 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0060  0.0024  0.0069  0.0005  0.9614 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9677  0.0001  0.0038  0.0005  0.0053 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0003  0.9303  0.0001  0.0471  0.0019 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0003  0.0467  0.0000  0.9321  0.0012 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6436  0.0000  0.0001  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0272  0.0032  0.0004  0.0010  0.0000  0.0000  0.0146  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0347  0.0125  0.0011  0.0043  0.0000  0.0000  0.0030  0.0000  0.0001 </r>
+        <r>  0.6373  0.0011  0.0000  0.0006  0.0001  0.0000  0.0002  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0008  0.0002  0.2314  0.0001  0.0000  0.0003  0.0002  0.0001  0.0000 </r>
+        <r>  0.0030  0.0000  0.1238  0.0000  0.0000  0.0008  0.0004  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0030  0.0023  0.0000  0.2777  0.0006  0.0000  0.0003  0.0000  0.0003 </r>
+        <r>  0.0094  0.0004  0.0000  0.1204  0.0014  0.0000  0.0004  0.0001  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0098  0.3100  0.0000  0.0002  0.0003  0.0000  0.0014  0.0000  0.0007 </r>
+        <r>  0.0379  0.1038  0.0001  0.0003  0.0006  0.0001  0.0019  0.0000  0.0032 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0220  0.1670  0.0005  0.0031  0.0053  0.0004  0.0021  0.0000  0.0129 </r>
+        <r>  0.0159  0.2822  0.0000  0.0000  0.0013  0.0001  0.0012  0.0000  0.0056 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0001  0.0015  0.0001  0.1445  0.0440  0.0000  0.0000  0.0001  0.0062 </r>
+        <r>  0.0010  0.0298  0.0000  0.0722  0.0249  0.0000  0.0002  0.0000  0.0029 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0104  0.0001  0.0024  0.1004  0.0184  0.0001  0.0017  0.0005  0.0041 </r>
+        <r>  0.0058  0.0051  0.0007  0.2650  0.0254  0.0000  0.0006  0.0000  0.0020 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0011  0.0003  0.3589  0.0012  0.0000  0.0110  0.0025  0.0023  0.0000 </r>
+        <r>  0.0031  0.0015  0.2328  0.0030  0.0001  0.0002  0.0010  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0009  0.0017  0.0006  0.0001  0.0000  0.0784  0.0026  0.0001  0.0001 </r>
+        <r>  0.0012  0.0018  0.1352  0.0000  0.0000  0.0349  0.0004  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0002  0.0026  0.0033  0.0000  0.0124  0.0062  0.1149  0.0019 </r>
+        <r>  0.0041  0.0001  0.0457  0.0049  0.0000  0.0004  0.0001  0.0186  0.0012 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0093  0.0005  0.0019  0.0329  0.0014  0.0003  0.0526  0.0305  0.1390 </r>
+        <r>  0.0504  0.0010  0.0043  0.0070  0.0001  0.0000  0.0005  0.0000  0.0551 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0197  0.0196  0.0104  0.0001  0.0019  0.0070  0.0884  0.0043  0.0805 </r>
+        <r>  0.0212  0.0000  0.0098  0.0179  0.0001  0.0002  0.0363  0.0003  0.0254 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0005  0.0082  0.0044  0.0017  0.0018  0.0013  0.0438  0.1059  0.0012 </r>
+        <r>  0.0230  0.0000  0.0096  0.0366  0.0001  0.0002  0.0005  0.0173  0.0020 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0644  0.0470  0.0010  0.0003  0.0000  0.0238  0.0018  0.0343  0.0494 </r>
+        <r>  0.0092  0.0436  0.0056  0.0106  0.0001  0.0006  0.0590  0.0002  0.0165 </r>
+       </set>
+      </set>
+      <set comment="kpoint 98">
+       <set comment="band 1">
+        <r>  0.0039  0.0001  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0092  0.0000  0.9420  0.0000  0.0173 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0040  0.0000  0.0159  0.0000  0.9568 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9645  0.0000  0.0107  0.0000  0.0025 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9103  0.0000  0.0690  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0691  0.0000  0.9110  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6651  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0067  0.0046  0.0000  0.0022  0.0000  0.0000  0.0130  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0072  0.0152  0.0000  0.0080  0.0000  0.0000  0.0026  0.0000  0.0001 </r>
+        <r>  0.6435  0.0006  0.0000  0.0007  0.0001  0.0000  0.0000  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2373  0.0000  0.0000  0.0005  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.1243  0.0000  0.0000  0.0012  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0055  0.0045  0.0000  0.2714  0.0008  0.0000  0.0006  0.0000  0.0008 </r>
+        <r>  0.0173  0.0006  0.0000  0.1155  0.0016  0.0000  0.0007  0.0000  0.0025 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0108  0.3183  0.0000  0.0001  0.0006  0.0000  0.0018  0.0000  0.0008 </r>
+        <r>  0.0496  0.0897  0.0000  0.0006  0.0012  0.0000  0.0027  0.0000  0.0047 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0280  0.1467  0.0000  0.0014  0.0035  0.0000  0.0025  0.0000  0.0147 </r>
+        <r>  0.0174  0.2959  0.0000  0.0002  0.0002  0.0000  0.0009  0.0000  0.0053 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0074  0.0000  0.0000  0.2294  0.0174  0.0000  0.0005  0.0000  0.0123 </r>
+        <r>  0.0098  0.0108  0.0000  0.2090  0.0037  0.0000  0.0011  0.0000  0.0053 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0095  0.0019  0.0000  0.0059  0.0490  0.0000  0.0028  0.0000  0.0013 </r>
+        <r>  0.0033  0.0172  0.0000  0.1170  0.0458  0.0000  0.0001  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.3478  0.0000  0.0000  0.0167  0.0000  0.0049  0.0000 </r>
+        <r>  0.0000  0.0000  0.2061  0.0000  0.0000  0.0009  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0056  0.0000  0.0000  0.0683  0.0000  0.0007  0.0000 </r>
+        <r>  0.0000  0.0000  0.1617  0.0000  0.0000  0.0392  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0005  0.0000  0.0000  0.0106  0.0000  0.1128  0.0000 </r>
+        <r>  0.0000  0.0000  0.0628  0.0000  0.0000  0.0005  0.0000  0.0273  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0150  0.0084  0.0000  0.0100  0.0042  0.0000  0.1565  0.0000  0.0005 </r>
+        <r>  0.0609  0.0015  0.0000  0.0018  0.0003  0.0000  0.0405  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0252  0.0012  0.0000  0.0519  0.0012  0.0000  0.0000  0.0000  0.2116 </r>
+        <r>  0.0080  0.0000  0.0000  0.0346  0.0000  0.0000  0.0205  0.0000  0.0638 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0006  0.0010  0.0296  0.0006  0.0007  0.0305  0.0014  0.2471  0.0014 </r>
+        <r>  0.0002  0.0009  0.0006  0.0009  0.0000  0.0010  0.0009  0.0206  0.0007 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0100  0.0425  0.0002  0.0013  0.0009  0.0007  0.0291  0.0010  0.0052 </r>
+        <r>  0.0243  0.0064  0.0000  0.0759  0.0007  0.0001  0.0059  0.0001  0.0009 </r>
+       </set>
+      </set>
+      <set comment="kpoint 99">
+       <set comment="band 1">
+        <r>  0.0052  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.9650  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9767  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0002 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0009  0.0006  0.0000  0.9765 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9793  0.0000  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000  0.9803  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6110  0.0000  0.0002  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000 </r>
+        <r>  0.0573  0.0009  0.0004  0.0000  0.0000  0.0000  0.0168  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0805  0.0047  0.0013  0.0000  0.0000  0.0000  0.0039  0.0000  0.0000 </r>
+        <r>  0.6384  0.0008  0.0000  0.0000  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0006  0.0001  0.2252  0.0000  0.0000  0.0001  0.0002  0.0000  0.0000 </r>
+        <r>  0.0040  0.0000  0.1242  0.0000  0.0000  0.0002  0.0004  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.2938  0.0002  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1257  0.0006  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0039  0.3034  0.0000  0.0000  0.0000  0.0000  0.0005  0.0000  0.0002 </r>
+        <r>  0.0128  0.1209  0.0000  0.0000  0.0000  0.0001  0.0006  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0000  0.0000  0.0000  0.0202  0.0646  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0015  0.0515  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0093  0.2173  0.0006  0.0000  0.0000  0.0005  0.0012  0.0000  0.0084 </r>
+        <r>  0.0073  0.3372  0.0001  0.0000  0.0000  0.0000  0.0008  0.0000  0.0043 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.2436  0.0008  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3660  0.0028  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0025  0.0005  0.3911  0.0000  0.0000  0.0033  0.0020  0.0000  0.0001 </r>
+        <r>  0.0018  0.0011  0.2646  0.0000  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0007  0.0027  0.0009  0.0000  0.0000  0.0877  0.0107  0.0000  0.0011 </r>
+        <r>  0.0100  0.0035  0.1201  0.0000  0.0000  0.0201  0.0001  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0143  0.0028  0.0000  0.0000  0.0000  0.0035  0.0097  0.0000  0.2282 </r>
+        <r>  0.0198  0.0036  0.0002  0.0000  0.0000  0.0007  0.0044  0.0000  0.1021 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0271  0.0248  0.0032  0.0000  0.0000  0.0465  0.0620  0.0000  0.0551 </r>
+        <r>  0.0722  0.0085  0.0034  0.0000  0.0000  0.0010  0.0063  0.0000  0.0214 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0001  0.0002  0.0000  0.0000  0.3519  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0098  0.0000  0.0000  0.0000  0.0075  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0306  0.0055  0.0077  0.0000  0.0000  0.0095  0.0107  0.0000  0.0001 </r>
+        <r>  0.0262  0.0065  0.0601  0.0000  0.0000  0.0001  0.0120  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0527  0.0020  0.0066  0.0001  0.0000  0.0147  0.0905  0.0001  0.0055 </r>
+        <r>  0.0087  0.0387  0.0111  0.0002  0.0000  0.0039  0.0674  0.0002  0.0038 </r>
+       </set>
+      </set>
+      <set comment="kpoint 100">
+       <set comment="band 1">
+        <r>  0.0050  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.0000  0.9629  0.0000  0.0028 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9760  0.0000  0.0004  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.0000  0.0029  0.0000  0.9743 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9643  0.0000  0.0157  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0157  0.0000  0.9646  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6286  0.0001  0.0000  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0433  0.0019  0.0000  0.0002  0.0000  0.0000  0.0165  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0578  0.0089  0.0000  0.0013  0.0000  0.0000  0.0036  0.0000  0.0000 </r>
+        <r>  0.6425  0.0012  0.0000  0.0002  0.0000  0.0000  0.0007  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2280  0.0000  0.0000  0.0002  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.1247  0.0000  0.0000  0.0005  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0009  0.0007  0.0000  0.2853  0.0005  0.0000  0.0001  0.0000  0.0001 </r>
+        <r>  0.0027  0.0002  0.0000  0.1242  0.0010  0.0000  0.0001  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0073  0.3055  0.0000  0.0001  0.0001  0.0000  0.0009  0.0000  0.0005 </r>
+        <r>  0.0249  0.1143  0.0000  0.0001  0.0002  0.0000  0.0012  0.0000  0.0019 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0034  0.0461  0.0000  0.0391  0.0536  0.0000  0.0003  0.0000  0.0013 </r>
+        <r>  0.0037  0.0459  0.0000  0.0045  0.0369  0.0000  0.0003  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0121  0.1472  0.0000  0.0123  0.0097  0.0000  0.0016  0.0000  0.0120 </r>
+        <r>  0.0084  0.2786  0.0000  0.0035  0.0089  0.0000  0.0006  0.0000  0.0058 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0033  0.0000  0.0000  0.2126  0.0029  0.0000  0.0005  0.0000  0.0023 </r>
+        <r>  0.0027  0.0006  0.0000  0.3522  0.0075  0.0000  0.0003  0.0000  0.0012 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.3897  0.0000  0.0000  0.0080  0.0000  0.0008  0.0000 </r>
+        <r>  0.0000  0.0000  0.2481  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0006  0.0000  0.0000  0.0916  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.1346  0.0000  0.0000  0.0301  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0225  0.0010  0.0000  0.0101  0.0000  0.0000  0.0176  0.0000  0.2209 </r>
+        <r>  0.0331  0.0015  0.0000  0.0077  0.0000  0.0000  0.0071  0.0000  0.0933 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0000  0.0023  0.0000  0.0000  0.0112  0.0000  0.1359  0.0000 </r>
+        <r>  0.0000  0.0000  0.0534  0.0000  0.0000  0.0003  0.0000  0.0130  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0007  0.0433  0.0000  0.0020  0.0005  0.0000  0.1717  0.0000  0.0392 </r>
+        <r>  0.1002  0.0051  0.0000  0.0004  0.0000  0.0000  0.0045  0.0000  0.0122 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0001  0.0097  0.0002  0.0000  0.0180  0.0001  0.2316  0.0001 </r>
+        <r>  0.0001  0.0003  0.0243  0.0005  0.0000  0.0000  0.0004  0.0006  0.0001 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.1015  0.0156  0.0001  0.0002  0.0005  0.0003  0.0246  0.0011  0.0283 </r>
+        <r>  0.0020  0.0513  0.0001  0.0100  0.0000  0.0000  0.0944  0.0000  0.0128 </r>
+       </set>
+      </set>
+      <set comment="kpoint 101">
+       <set comment="band 1">
+        <r>  0.0013  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0088  0.9535  0.0000  0.0106 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0602  0.0154  0.0000  0.9012 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9495  0.0000  0.0000  0.0281  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0282  0.0004  0.0000  0.9505  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9095  0.0042  0.0004  0.0650 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5113  0.0006  0.0023  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.1056  0.0022  0.0050  0.0000  0.0000  0.0000  0.0031  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1609  0.0116  0.0169  0.0000  0.0000  0.0000  0.0008  0.0000  0.0001 </r>
+        <r>  0.5234  0.0022  0.0009  0.0000  0.0000  0.0002  0.0013  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.3031  0.0006  0.0000  0.0000  0.0007  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1195  0.0015  0.0000  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0117  0.0809  0.2454  0.0000  0.0000  0.0006  0.0023  0.0000  0.0001 </r>
+        <r>  0.0188  0.0140  0.0614  0.0000  0.0000  0.0000  0.0128  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0023  0.2847  0.0427  0.0000  0.0000  0.0002  0.0032  0.0000  0.0003 </r>
+        <r>  0.0778  0.0677  0.0231  0.0000  0.0000  0.0025  0.0000  0.0000  0.0032 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0612  0.0365  0.1079  0.0000  0.0000  0.0071  0.0028  0.0000  0.0044 </r>
+        <r>  0.0007  0.1183  0.1479  0.0000  0.0000  0.0001  0.0046  0.0000  0.0021 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0004  0.0588  0.0672  0.0000  0.0000  0.0003  0.0178  0.0000  0.0087 </r>
+        <r>  0.0309  0.1925  0.1448  0.0000  0.0000  0.0008  0.0001  0.0000  0.0033 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.1955  0.0310  0.0000  0.0000  0.0065  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1491  0.0125  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0394  0.0388  0.0000  0.0000  0.0039  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1917  0.0383  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0000  0.0013  0.0078  0.0000  0.0000  0.0984  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0615  0.0017  0.0000  0.0000  0.0465  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0262  0.0087  0.0115  0.0000  0.0000  0.0012  0.0345  0.0000  0.0792 </r>
+        <r>  0.0529  0.0024  0.0094  0.0000  0.0000  0.0032  0.0135  0.0000  0.0418 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0026  0.0195  0.0122  0.0000  0.0000  0.1397  0.0008  0.0000  0.0237 </r>
+        <r>  0.0001  0.0237  0.0159  0.0000  0.0000  0.0368  0.0000  0.0000  0.0066 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0003  0.0507  0.0196  0.0000  0.0000  0.0400  0.0067  0.0000  0.0407 </r>
+        <r>  0.0030  0.0783  0.0280  0.0000  0.0000  0.0158  0.0005  0.0000  0.0236 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0179  0.0009  0.0119  0.0000  0.0000  0.0195  0.0362  0.0000  0.0803 </r>
+        <r>  0.0214  0.0344  0.0073  0.0000  0.0000  0.0514  0.0176  0.0000  0.0304 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0000  0.0001  0.0422  0.0000  0.0000  0.0374  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0127  0.0099  0.0000  0.0000  0.0034  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 102">
+       <set comment="band 1">
+        <r>  0.0017  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0020  0.0118  0.9228  0.0001  0.0355 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0007  0.0530  0.0432  0.0033  0.8763 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9356  0.0043  0.0016  0.0358  0.0005 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0189  0.7607  0.0048  0.1538  0.0409 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0207  0.1493  0.0000  0.7863  0.0232 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5514  0.0007  0.0020  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0777  0.0035  0.0052  0.0002  0.0000  0.0000  0.0042  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1153  0.0141  0.0152  0.0011  0.0000  0.0000  0.0009  0.0000  0.0002 </r>
+        <r>  0.5455  0.0018  0.0003  0.0002  0.0000  0.0002  0.0010  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0013  0.0003  0.0013  0.2854  0.0008  0.0000  0.0000  0.0006  0.0001 </r>
+        <r>  0.0014  0.0000  0.0002  0.1196  0.0018  0.0000  0.0002  0.0015  0.0003 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0101  0.0183  0.2621  0.0006  0.0000  0.0006  0.0033  0.0000  0.0001 </r>
+        <r>  0.0350  0.0013  0.0918  0.0004  0.0000  0.0006  0.0103  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0047  0.3659  0.0033  0.0000  0.0001  0.0002  0.0021  0.0000  0.0004 </r>
+        <r>  0.0666  0.0591  0.0070  0.0001  0.0002  0.0021  0.0013  0.0000  0.0059 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0421  0.0624  0.0141  0.0002  0.0003  0.0058  0.0015  0.0000  0.0128 </r>
+        <r>  0.0052  0.2985  0.0060  0.0000  0.0000  0.0002  0.0019  0.0000  0.0040 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0205  0.0053  0.1868  0.0007  0.0000  0.0021  0.0190  0.0004  0.0018 </r>
+        <r>  0.0265  0.0249  0.2661  0.0003  0.0000  0.0008  0.0042  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0003  0.0001  0.0008  0.2231  0.0271  0.0001  0.0006  0.0059  0.0018 </r>
+        <r>  0.0029  0.0013  0.0020  0.1604  0.0081  0.0000  0.0001  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0018  0.0008  0.0001  0.0228  0.0428  0.0000  0.0009  0.0028  0.0010 </r>
+        <r>  0.0013  0.0008  0.0003  0.1721  0.0414  0.0000  0.0001  0.0001  0.0006 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0020  0.0012  0.0047  0.0047  0.0087  0.0003  0.0015  0.0951  0.0065 </r>
+        <r>  0.0027  0.0010  0.0000  0.0398  0.0017  0.0007  0.0007  0.0391  0.0024 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0041  0.0180  0.0173  0.0052  0.0003  0.0226  0.0276  0.0069  0.0481 </r>
+        <r>  0.0286  0.0227  0.0413  0.0263  0.0000  0.0122  0.0057  0.0018  0.0211 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0223  0.0019  0.0001  0.0034  0.0000  0.1069  0.0042  0.0009  0.0264 </r>
+        <r>  0.0136  0.0294  0.0186  0.0083  0.0000  0.0054  0.0045  0.0001  0.0186 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0491  0.0363  0.0002  0.0005  0.0661  0.0001  0.0009  0.0429 </r>
+        <r>  0.0001  0.0024  0.0040  0.0000  0.0001  0.0558  0.0004  0.0000  0.0130 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0065  0.0090  0.0001  0.0017  0.0000  0.0012  0.0465  0.0022  0.1296 </r>
+        <r>  0.0172  0.0830  0.0007  0.0001  0.0000  0.0324  0.0094  0.0030  0.0451 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0098  0.0066  0.0077  0.0078  0.0199  0.0016  0.0035  0.1260  0.0018 </r>
+        <r>  0.0058  0.0031  0.0129  0.0114  0.0033  0.0003  0.0056  0.0183  0.0002 </r>
+       </set>
+      </set>
+      <set comment="kpoint 103">
+       <set comment="band 1">
+        <r>  0.0021  0.0000  0.0004  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0069  0.0141  0.8623  0.0001  0.0882 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0039  0.0388  0.0960  0.0083  0.8292 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8905  0.0282  0.0059  0.0506  0.0027 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0508  0.8244  0.0065  0.0638  0.0335 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0259  0.0734  0.0015  0.8567  0.0221 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6040  0.0004  0.0013  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0400  0.0048  0.0049  0.0009  0.0000  0.0000  0.0052  0.0000  0.0011 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0577  0.0159  0.0130  0.0038  0.0000  0.0000  0.0010  0.0000  0.0003 </r>
+        <r>  0.5782  0.0010  0.0000  0.0006  0.0001  0.0002  0.0005  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0052  0.0007  0.0073  0.2677  0.0008  0.0000  0.0001  0.0005  0.0003 </r>
+        <r>  0.0042  0.0001  0.0016  0.1153  0.0019  0.0001  0.0009  0.0010  0.0011 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0081  0.0098  0.2502  0.0044  0.0000  0.0007  0.0030  0.0000  0.0001 </r>
+        <r>  0.0358  0.0002  0.1019  0.0030  0.0000  0.0011  0.0072  0.0004  0.0002 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0032  0.4015  0.0003  0.0000  0.0002  0.0000  0.0017  0.0000  0.0001 </r>
+        <r>  0.0719  0.0313  0.0036  0.0003  0.0006  0.0017  0.0027  0.0000  0.0084 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0425  0.0336  0.0052  0.0006  0.0011  0.0045  0.0032  0.0000  0.0143 </r>
+        <r>  0.0042  0.3341  0.0004  0.0000  0.0000  0.0003  0.0006  0.0000  0.0023 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0218  0.0013  0.2067  0.0067  0.0001  0.0038  0.0159  0.0018  0.0017 </r>
+        <r>  0.0193  0.0124  0.2493  0.0035  0.0000  0.0005  0.0065  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0013  0.0004  0.0057  0.2359  0.0166  0.0004  0.0028  0.0043  0.0059 </r>
+        <r>  0.0130  0.0024  0.0118  0.2007  0.0021  0.0000  0.0002  0.0002  0.0029 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0041  0.0041  0.0006  0.0016  0.0537  0.0002  0.0023  0.0010  0.0018 </r>
+        <r>  0.0017  0.0036  0.0006  0.1139  0.0450  0.0001  0.0001  0.0003  0.0010 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0027  0.0179  0.0189  0.0033  0.0011  0.0697  0.0052  0.0040  0.0054 </r>
+        <r>  0.0019  0.0308  0.0464  0.0005  0.0006  0.0342  0.0000  0.0019  0.0010 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0046  0.0001  0.0031  0.0074  0.0092  0.0062  0.0000  0.1006  0.0042 </r>
+        <r>  0.0010  0.0009  0.0161  0.0326  0.0012  0.0015  0.0004  0.0314  0.0012 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0127  0.0032  0.0100  0.0300  0.0002  0.0226  0.0243  0.0170  0.0511 </r>
+        <r>  0.0296  0.0003  0.0023  0.0626  0.0001  0.0000  0.0061  0.0002  0.0276 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0006  0.0356  0.0419  0.0007  0.0023  0.0829  0.0002  0.0068  0.0638 </r>
+        <r>  0.0010  0.0066  0.0112  0.0009  0.0002  0.0345  0.0029  0.0006  0.0156 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0122  0.0116  0.0035  0.0052  0.0002  0.0068  0.0001  0.0673  0.0383 </r>
+        <r>  0.0058  0.0019  0.0217  0.0005  0.0003  0.0122  0.0044  0.0506  0.0120 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0047  0.0147  0.0043  0.0026  0.0179  0.0003  0.0954  0.0272  0.0865 </r>
+        <r>  0.0180  0.0717  0.0046  0.0036  0.0019  0.0136  0.0055  0.0014  0.0214 </r>
+       </set>
+      </set>
+      <set comment="kpoint 104">
+       <set comment="band 1">
+        <r>  0.0023  0.0000  0.0002  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0120  0.0145  0.7670  0.0000  0.1779 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0113  0.0235  0.1800  0.0114  0.7497 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.7032  0.1768  0.0085  0.0802  0.0095 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.2183  0.7169  0.0124  0.0137  0.0176 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0336  0.0469  0.0045  0.8743  0.0205 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6506  0.0001  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0057  0.0059  0.0038  0.0022  0.0000  0.0000  0.0058  0.0000  0.0017 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0081  0.0169  0.0105  0.0073  0.0000  0.0000  0.0011  0.0000  0.0003 </r>
+        <r>  0.6095  0.0001  0.0002  0.0006  0.0002  0.0002  0.0000  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0120  0.0005  0.0459  0.2251  0.0007  0.0001  0.0000  0.0005  0.0005 </r>
+        <r>  0.0030  0.0000  0.0157  0.0950  0.0016  0.0003  0.0028  0.0003  0.0020 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0028  0.0081  0.2112  0.0371  0.0001  0.0007  0.0025  0.0000  0.0003 </r>
+        <r>  0.0383  0.0000  0.0946  0.0199  0.0002  0.0012  0.0033  0.0009  0.0006 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0005  0.4305  0.0000  0.0000  0.0001  0.0000  0.0010  0.0000  0.0000 </r>
+        <r>  0.0781  0.0046  0.0018  0.0008  0.0011  0.0014  0.0036  0.0000  0.0105 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0458  0.0049  0.0026  0.0013  0.0022  0.0034  0.0043  0.0000  0.0147 </r>
+        <r>  0.0007  0.3600  0.0000  0.0001  0.0001  0.0002  0.0000  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0221  0.0002  0.1852  0.0453  0.0012  0.0046  0.0093  0.0045  0.0043 </r>
+        <r>  0.0058  0.0119  0.1919  0.0347  0.0000  0.0001  0.0079  0.0001  0.0009 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0010  0.0007  0.0413  0.1928  0.0086  0.0018  0.0085  0.0012  0.0076 </r>
+        <r>  0.0295  0.0010  0.0582  0.1994  0.0001  0.0000  0.0000  0.0005  0.0037 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0036  0.0115  0.0022  0.0026  0.0598  0.0027  0.0040  0.0003  0.0017 </r>
+        <r>  0.0012  0.0057  0.0024  0.0714  0.0425  0.0016  0.0000  0.0005  0.0008 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0078  0.0085  0.0083  0.0007  0.0034  0.0666  0.0020  0.0008  0.0012 </r>
+        <r>  0.0004  0.0256  0.0554  0.0046  0.0025  0.0401  0.0002  0.0003  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0029  0.0002  0.0092  0.0104  0.0108  0.0006  0.0001  0.1248  0.0063 </r>
+        <r>  0.0012  0.0000  0.0255  0.0269  0.0007  0.0002  0.0001  0.0198  0.0008 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0001  0.0033  0.0302  0.0397  0.0036  0.0217  0.0157  0.0458  0.0051 </r>
+        <r>  0.0099  0.0001  0.0052  0.0366  0.0003  0.0001  0.0000  0.0215  0.0042 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0136  0.0042  0.0288  0.0154  0.0001  0.0219  0.0000  0.0087  0.1388 </r>
+        <r>  0.0070  0.0050  0.0146  0.0360  0.0007  0.0092  0.0204  0.0051  0.0334 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0028  0.0491  0.0076  0.0004  0.0063  0.0398  0.0146  0.0066  0.0072 </r>
+        <r>  0.0157  0.0015  0.0389  0.0172  0.0017  0.0186  0.0000  0.0393  0.0043 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0033  0.0238  0.0087  0.0046  0.0401  0.0194  0.2112  0.0001  0.0066 </r>
+        <r>  0.0224  0.0016  0.0311  0.0008  0.0107  0.0039  0.0289  0.0041  0.0092 </r>
+       </set>
+      </set>
+      <set comment="kpoint 105">
+       <set comment="band 1">
+        <r>  0.0026  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0039  0.9541  0.0000  0.0124 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0442  0.0151  0.0000  0.9177 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9675  0.0000  0.0000  0.0099  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9312  0.0013  0.0000  0.0469 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0100  0.0000  0.0000  0.9697  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5565  0.0004  0.0021  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0782  0.0025  0.0047  0.0000  0.0000  0.0000  0.0070  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.1171  0.0117  0.0137  0.0000  0.0000  0.0000  0.0015  0.0000  0.0001 </r>
+        <r>  0.5588  0.0019  0.0001  0.0000  0.0000  0.0002  0.0015  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.0000  0.2894  0.0007  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1222  0.0015  0.0000  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0094  0.0084  0.2413  0.0000  0.0000  0.0004  0.0030  0.0000  0.0000 </r>
+        <r>  0.0357  0.0009  0.1070  0.0000  0.0000  0.0005  0.0074  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0069  0.3350  0.0013  0.0000  0.0000  0.0003  0.0017  0.0000  0.0006 </r>
+        <r>  0.0453  0.0922  0.0036  0.0000  0.0000  0.0014  0.0011  0.0000  0.0036 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0318  0.1148  0.0152  0.0000  0.0000  0.0055  0.0011  0.0000  0.0123 </r>
+        <r>  0.0078  0.2848  0.0058  0.0000  0.0000  0.0003  0.0024  0.0000  0.0055 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0187  0.0069  0.2333  0.0000  0.0000  0.0020  0.0182  0.0000  0.0015 </r>
+        <r>  0.0266  0.0222  0.2614  0.0000  0.0000  0.0006  0.0053  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.1425  0.0505  0.0000  0.0000  0.0022  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0620  0.0274  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.1139  0.0181  0.0000  0.0000  0.0059  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.2843  0.0243  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0121  0.0132  0.0154  0.0000  0.0000  0.0095  0.0377  0.0000  0.0670 </r>
+        <r>  0.0460  0.0122  0.0364  0.0000  0.0000  0.0077  0.0076  0.0000  0.0315 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0000  0.0026  0.0063  0.0000  0.0000  0.1221  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0628  0.0009  0.0000  0.0000  0.0356  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0149  0.0108  0.0029  0.0000  0.0000  0.0943  0.0004  0.0000  0.0326 </r>
+        <r>  0.0053  0.0374  0.0250  0.0000  0.0000  0.0125  0.0025  0.0000  0.0200 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0019  0.0456  0.0278  0.0000  0.0000  0.0997  0.0021  0.0000  0.0518 </r>
+        <r>  0.0017  0.0027  0.0048  0.0000  0.0000  0.0339  0.0000  0.0000  0.0162 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0145  0.0043  0.0032  0.0000  0.0000  0.0002  0.0336  0.0000  0.0978 </r>
+        <r>  0.0254  0.0804  0.0007  0.0000  0.0000  0.0487  0.0128  0.0000  0.0396 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0129  0.0038  0.0147  0.0111  0.0120  0.0001  0.0001  0.1109  0.0108 </r>
+        <r>  0.0049  0.0017  0.0128  0.0066  0.0016  0.0003  0.0073  0.0240  0.0022 </r>
+       </set>
+      </set>
+      <set comment="kpoint 106">
+       <set comment="band 1">
+        <r>  0.0030  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0014  0.0046  0.9288  0.0000  0.0351 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0012  0.0358  0.0385  0.0016  0.8996 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9626  0.0013  0.0016  0.0111  0.0009 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0031  0.9182  0.0011  0.0208  0.0361 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0094  0.0192  0.0002  0.9462  0.0049 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6015  0.0003  0.0013  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0474  0.0039  0.0039  0.0002  0.0000  0.0000  0.0085  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0686  0.0147  0.0107  0.0011  0.0000  0.0000  0.0017  0.0000  0.0002 </r>
+        <r>  0.5886  0.0014  0.0000  0.0002  0.0000  0.0002  0.0008  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0086  0.0022  0.1828  0.0695  0.0002  0.0004  0.0014  0.0002  0.0000 </r>
+        <r>  0.0149  0.0001  0.0848  0.0293  0.0005  0.0007  0.0045  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0003  0.0026  0.0563  0.2056  0.0006  0.0001  0.0009  0.0002  0.0001 </r>
+        <r>  0.0160  0.0001  0.0287  0.0928  0.0013  0.0002  0.0007  0.0008  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0076  0.3560  0.0002  0.0000  0.0001  0.0001  0.0018  0.0000  0.0006 </r>
+        <r>  0.0537  0.0749  0.0018  0.0000  0.0002  0.0010  0.0023  0.0000  0.0055 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0329  0.0948  0.0050  0.0002  0.0004  0.0037  0.0025  0.0000  0.0143 </r>
+        <r>  0.0105  0.3087  0.0004  0.0000  0.0000  0.0004  0.0012  0.0000  0.0049 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0164  0.0015  0.2296  0.0254  0.0038  0.0041  0.0129  0.0012  0.0018 </r>
+        <r>  0.0149  0.0114  0.2225  0.0128  0.0016  0.0003  0.0062  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0008  0.0006  0.0322  0.1667  0.0394  0.0009  0.0025  0.0014  0.0006 </r>
+        <r>  0.0067  0.0002  0.0334  0.0796  0.0169  0.0000  0.0003  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0019  0.0004  0.0001  0.0745  0.0260  0.0000  0.0012  0.0035  0.0015 </r>
+        <r>  0.0023  0.0007  0.0013  0.2501  0.0320  0.0000  0.0001  0.0001  0.0008 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0016  0.0167  0.0115  0.0011  0.0001  0.0712  0.0095  0.0004  0.0053 </r>
+        <r>  0.0049  0.0237  0.0674  0.0004  0.0001  0.0336  0.0000  0.0003  0.0016 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0112  0.0001  0.0035  0.0112  0.0053  0.0082  0.0077  0.0808  0.0345 </r>
+        <r>  0.0144  0.0005  0.0015  0.0161  0.0007  0.0008  0.0029  0.0207  0.0153 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0126  0.0004  0.0015  0.0031  0.0016  0.0100  0.0189  0.0560  0.0539 </r>
+        <r>  0.0269  0.0003  0.0045  0.0541  0.0001  0.0005  0.0052  0.0054  0.0279 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0002  0.0397  0.0456  0.0000  0.0007  0.0930  0.0055  0.0043  0.0687 </r>
+        <r>  0.0009  0.0028  0.0075  0.0000  0.0001  0.0215  0.0021  0.0010  0.0175 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0106  0.0097  0.0021  0.0090  0.0011  0.0073  0.0002  0.0709  0.0229 </r>
+        <r>  0.0047  0.0021  0.0250  0.0001  0.0002  0.0111  0.0031  0.0446  0.0083 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0110  0.0103  0.0012  0.0015  0.0025  0.0008  0.0395  0.0330  0.0958 </r>
+        <r>  0.0206  0.0964  0.0030  0.0004  0.0003  0.0275  0.0110  0.0057  0.0333 </r>
+       </set>
+      </set>
+      <set comment="kpoint 107">
+       <set comment="band 1">
+        <r>  0.0032  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0054  0.0045  0.8807  0.0001  0.0791 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0051  0.0224  0.0804  0.0034  0.8651 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9447  0.0092  0.0073  0.0135  0.0032 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0140  0.9182  0.0012  0.0241  0.0214 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0087  0.0246  0.0008  0.9389  0.0071 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6469  0.0001  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0148  0.0053  0.0026  0.0010  0.0000  0.0000  0.0093  0.0000  0.0012 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0203  0.0167  0.0073  0.0040  0.0000  0.0000  0.0018  0.0000  0.0003 </r>
+        <r>  0.6195  0.0005  0.0002  0.0005  0.0001  0.0001  0.0001  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0076  0.0017  0.2328  0.0128  0.0000  0.0006  0.0011  0.0002  0.0000 </r>
+        <r>  0.0131  0.0000  0.1121  0.0046  0.0001  0.0013  0.0035  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0016  0.0022  0.0088  0.2508  0.0008  0.0000  0.0006  0.0001  0.0004 </r>
+        <r>  0.0148  0.0001  0.0056  0.1153  0.0018  0.0000  0.0000  0.0006  0.0012 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0058  0.3848  0.0000  0.0000  0.0002  0.0000  0.0018  0.0000  0.0004 </r>
+        <r>  0.0633  0.0482  0.0009  0.0002  0.0006  0.0007  0.0032  0.0000  0.0078 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0377  0.0635  0.0022  0.0005  0.0012  0.0024  0.0033  0.0000  0.0154 </r>
+        <r>  0.0086  0.3332  0.0000  0.0001  0.0000  0.0004  0.0005  0.0000  0.0032 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0102  0.0000  0.0700  0.1863  0.0171  0.0017  0.0013  0.0034  0.0064 </r>
+        <r>  0.0001  0.0099  0.0542  0.1262  0.0037  0.0000  0.0038  0.0000  0.0023 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0038  0.0014  0.2098  0.0616  0.0085  0.0077  0.0109  0.0001  0.0003 </r>
+        <r>  0.0212  0.0008  0.1860  0.0446  0.0020  0.0000  0.0027  0.0002  0.0004 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0047  0.0027  0.0000  0.0148  0.0447  0.0001  0.0028  0.0011  0.0023 </r>
+        <r>  0.0032  0.0041  0.0019  0.1596  0.0428  0.0001  0.0001  0.0002  0.0012 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0050  0.0088  0.0025  0.0007  0.0003  0.0689  0.0047  0.0004  0.0011 </r>
+        <r>  0.0016  0.0133  0.0842  0.0006  0.0003  0.0410  0.0005  0.0002  0.0002 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0037  0.0006  0.0071  0.0137  0.0078  0.0008  0.0043  0.1323  0.0160 </r>
+        <r>  0.0064  0.0000  0.0138  0.0207  0.0005  0.0001  0.0002  0.0141  0.0047 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0028  0.0023  0.0155  0.0253  0.0004  0.0153  0.0267  0.0500  0.0266 </r>
+        <r>  0.0231  0.0001  0.0111  0.0365  0.0001  0.0002  0.0007  0.0075  0.0145 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0226  0.0047  0.0329  0.0020  0.0014  0.0179  0.0032  0.0097  0.1340 </r>
+        <r>  0.0028  0.0016  0.0060  0.0230  0.0002  0.0023  0.0249  0.0142  0.0377 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0002  0.0282  0.0110  0.0014  0.0000  0.0208  0.0647  0.0056  0.0008 </r>
+        <r>  0.0290  0.0017  0.0562  0.0082  0.0001  0.0094  0.0045  0.0378  0.0027 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0225  0.0271  0.0001  0.0002  0.0025  0.0841  0.1413  0.0219  0.0080 </r>
+        <r>  0.0141  0.0001  0.0228  0.0015  0.0002  0.0225  0.0484  0.0001  0.0043 </r>
+       </set>
+      </set>
+      <set comment="kpoint 108">
+       <set comment="band 1">
+        <r>  0.0031  0.0000  0.0001  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0106  0.0034  0.8010  0.0000  0.1551 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0126  0.0100  0.1498  0.0032  0.8006 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.8318  0.1019  0.0149  0.0220  0.0078 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.1154  0.8373  0.0041  0.0157  0.0063 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0079  0.0261  0.0013  0.9391  0.0056 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6655  0.0000  0.0001  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0061  0.0012  0.0024  0.0000  0.0000  0.0088  0.0000  0.0017 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0001  0.0177  0.0039  0.0075  0.0000  0.0000  0.0017  0.0000  0.0003 </r>
+        <r>  0.6323  0.0000  0.0003  0.0004  0.0002  0.0001  0.0001  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0044  0.0008  0.2455  0.0045  0.0000  0.0008  0.0005  0.0002  0.0000 </r>
+        <r>  0.0065  0.0000  0.1187  0.0013  0.0000  0.0017  0.0017  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0049  0.0033  0.0026  0.2512  0.0008  0.0000  0.0007  0.0001  0.0008 </r>
+        <r>  0.0207  0.0001  0.0020  0.1152  0.0018  0.0000  0.0005  0.0003  0.0025 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0021  0.4225  0.0000  0.0001  0.0002  0.0000  0.0014  0.0000  0.0000 </r>
+        <r>  0.0726  0.0153  0.0004  0.0006  0.0011  0.0004  0.0039  0.0000  0.0101 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0432  0.0232  0.0008  0.0009  0.0022  0.0012  0.0041  0.0000  0.0159 </r>
+        <r>  0.0034  0.3643  0.0000  0.0003  0.0000  0.0002  0.0000  0.0000  0.0010 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0122  0.0003  0.0149  0.2425  0.0116  0.0005  0.0002  0.0020  0.0116 </r>
+        <r>  0.0087  0.0075  0.0081  0.2129  0.0005  0.0000  0.0026  0.0001  0.0043 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0019  0.0008  0.2734  0.0137  0.0012  0.0166  0.0077  0.0020  0.0001 </r>
+        <r>  0.0132  0.0018  0.2000  0.0153  0.0001  0.0010  0.0024  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0040  0.0082  0.0000  0.0001  0.0568  0.0022  0.0048  0.0002  0.0016 </r>
+        <r>  0.0024  0.0086  0.0068  0.0905  0.0434  0.0017  0.0000  0.0002  0.0008 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0065  0.0020  0.0013  0.0001  0.0032  0.0567  0.0024  0.0009  0.0001 </r>
+        <r>  0.0010  0.0083  0.1189  0.0032  0.0023  0.0422  0.0010  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0015  0.0005  0.0094  0.0071  0.0002  0.0107  0.0101  0.1194  0.0000 </r>
+        <r>  0.0038  0.0000  0.0295  0.0130  0.0001  0.0005  0.0013  0.0194  0.0003 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0014  0.0042  0.0288  0.0211  0.0111  0.0020  0.0567  0.0472  0.0063 </r>
+        <r>  0.0270  0.0001  0.0352  0.0067  0.0003  0.0001  0.0114  0.0068  0.0026 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0336  0.0001  0.0044  0.0321  0.0038  0.0000  0.0541  0.0196  0.0858 </r>
+        <r>  0.0016  0.0022  0.0221  0.0109  0.0003  0.0005  0.0568  0.0089  0.0137 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0016  0.0091  0.0012  0.0079  0.0005  0.0002  0.0556  0.0114  0.0718 </r>
+        <r>  0.0386  0.0002  0.0053  0.0746  0.0012  0.0001  0.0000  0.0384  0.0270 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0021  0.0522  0.0175  0.0015  0.0100  0.0845  0.0177  0.0562  0.0317 </r>
+        <r>  0.0007  0.0002  0.0003  0.0065  0.0031  0.0159  0.0058  0.0001  0.0054 </r>
+       </set>
+      </set>
+      <set comment="kpoint 109">
+       <set comment="band 1">
+        <r>  0.0028  0.0000  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0142  0.0013  0.6853  0.0000  0.2697 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0246  0.0021  0.2525  0.0014  0.6955 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0218  0.9198  0.0003  0.0325  0.0038 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9127  0.0270  0.0329  0.0027  0.0035 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0053  0.0281  0.0010  0.9432  0.0022 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6410  0.0003  0.0000  0.0007  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0163  0.0058  0.0003  0.0039  0.0000  0.0000  0.0070  0.0000  0.0021 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0246  0.0175  0.0011  0.0108  0.0000  0.0000  0.0015  0.0000  0.0004 </r>
+        <r>  0.6135  0.0003  0.0002  0.0001  0.0002  0.0000  0.0007  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0013  0.0002  0.2572  0.0011  0.0000  0.0008  0.0001  0.0003  0.0000 </r>
+        <r>  0.0017  0.0000  0.1220  0.0002  0.0000  0.0020  0.0005  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0078  0.0049  0.0006  0.2512  0.0008  0.0000  0.0009  0.0000  0.0013 </r>
+        <r>  0.0274  0.0000  0.0005  0.1114  0.0015  0.0000  0.0010  0.0001  0.0042 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0000  0.4431  0.0000  0.0000  0.0001  0.0000  0.0006  0.0000  0.0003 </r>
+        <r>  0.0767  0.0004  0.0001  0.0015  0.0015  0.0001  0.0038  0.0000  0.0109 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0457  0.0000  0.0002  0.0020  0.0034  0.0003  0.0051  0.0000  0.0153 </r>
+        <r>  0.0000  0.3777  0.0000  0.0001  0.0001  0.0000  0.0002  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0169  0.0006  0.0023  0.2399  0.0071  0.0001  0.0011  0.0005  0.0148 </r>
+        <r>  0.0179  0.0068  0.0009  0.2483  0.0000  0.0000  0.0022  0.0000  0.0048 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0003  0.0003  0.2705  0.0021  0.0002  0.0279  0.0022  0.0040  0.0000 </r>
+        <r>  0.0035  0.0009  0.1576  0.0032  0.0000  0.0054  0.0008  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0013  0.0014  0.0206  0.0001  0.0003  0.0453  0.0024  0.0021  0.0001 </r>
+        <r>  0.0013  0.0004  0.1846  0.0010  0.0002  0.0419  0.0007  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0054  0.0115  0.0005  0.0059  0.0677  0.0004  0.0052  0.0003  0.0009 </r>
+        <r>  0.0012  0.0210  0.0012  0.0659  0.0425  0.0004  0.0001  0.0001  0.0004 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0019  0.0001  0.0041  0.0020  0.0005  0.0093  0.0054  0.1096  0.0001 </r>
+        <r>  0.0019  0.0000  0.0458  0.0024  0.0001  0.0008  0.0018  0.0297  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0188  0.0032  0.0104  0.0064  0.0086  0.0000  0.1172  0.0085  0.0000 </r>
+        <r>  0.0434  0.0001  0.0269  0.0036  0.0004  0.0000  0.0459  0.0001  0.0005 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0078  0.0198  0.0006  0.0709  0.0604  0.0011  0.0322  0.0182  0.0532 </r>
+        <r>  0.0001  0.0045  0.0001  0.0107  0.0117  0.0001  0.0257  0.0051  0.0025 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0035  0.0254  0.0096  0.0014  0.0204  0.0009  0.0089  0.0804  0.0007 </r>
+        <r>  0.0075  0.0025  0.0000  0.0460  0.0141  0.0001  0.0017  0.0378  0.0004 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0011  0.0000  0.0143  0.0014  0.0135  0.0059  0.0535  0.1047  0.0219 </r>
+        <r>  0.0125  0.0002  0.0007  0.0642  0.0008  0.0002  0.0003  0.0076  0.0173 </r>
+       </set>
+      </set>
+      <set comment="kpoint 110">
+       <set comment="band 1">
+        <r>  0.0023  0.0000  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0144  0.0000  0.5465  0.0000  0.4104 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0401  0.0000  0.3779  0.0000  0.5582 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9467  0.0000  0.0312  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9243  0.0000  0.0489  0.0000  0.0058 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0313  0.0000  0.9483  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.5948  0.0006  0.0000  0.0014  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0482  0.0048  0.0000  0.0049  0.0000  0.0000  0.0049  0.0000  0.0021 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0715  0.0162  0.0000  0.0133  0.0000  0.0000  0.0012  0.0000  0.0004 </r>
+        <r>  0.5784  0.0011  0.0000  0.0000  0.0002  0.0000  0.0012  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2702  0.0000  0.0000  0.0009  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.1226  0.0000  0.0000  0.0020  0.0000  0.0012  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0096  0.0080  0.0000  0.2549  0.0007  0.0000  0.0011  0.0000  0.0018 </r>
+        <r>  0.0331  0.0001  0.0000  0.1046  0.0011  0.0000  0.0014  0.0000  0.0063 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0024  0.4157  0.0000  0.0002  0.0000  0.0000  0.0001  0.0000  0.0014 </r>
+        <r>  0.0716  0.0256  0.0000  0.0033  0.0018  0.0000  0.0030  0.0000  0.0087 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0427  0.0239  0.0000  0.0045  0.0045  0.0000  0.0057  0.0000  0.0128 </r>
+        <r>  0.0030  0.3494  0.0000  0.0001  0.0002  0.0000  0.0009  0.0000  0.0017 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0211  0.0014  0.0000  0.2213  0.0044  0.0000  0.0015  0.0000  0.0168 </r>
+        <r>  0.0233  0.0093  0.0000  0.2629  0.0004  0.0000  0.0022  0.0000  0.0041 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2417  0.0000  0.0000  0.0340  0.0000  0.0050  0.0000 </r>
+        <r>  0.0000  0.0000  0.1303  0.0000  0.0000  0.0099  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0414  0.0000  0.0000  0.0378  0.0000  0.0039  0.0000 </r>
+        <r>  0.0000  0.0000  0.2168  0.0000  0.0000  0.0393  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0016  0.0194  0.0000  0.0150  0.0694  0.0000  0.0163  0.0000  0.0009 </r>
+        <r>  0.0044  0.0303  0.0000  0.0584  0.0354  0.0000  0.0026  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0013  0.0000  0.0000  0.0089  0.0000  0.1056  0.0000 </r>
+        <r>  0.0000  0.0000  0.0630  0.0000  0.0000  0.0010  0.0000  0.0368  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0292  0.0008  0.0000  0.0030  0.0182  0.0000  0.1159  0.0000  0.0001 </r>
+        <r>  0.0455  0.0005  0.0000  0.0002  0.0016  0.0000  0.0546  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0001  0.0450  0.0000  0.0503  0.1047  0.0000  0.0262  0.0000  0.0154 </r>
+        <r>  0.0001  0.0069  0.0000  0.0135  0.0374  0.0000  0.0095  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0037  0.0013  0.0023  0.0118  0.0022  0.0005  0.0335  0.0147  0.1123 </r>
+        <r>  0.0008  0.0286  0.0005  0.0143  0.0208  0.0000  0.0231  0.0041  0.0021 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0003  0.0008  0.0285  0.0000  0.0001  0.0144  0.0037  0.2165  0.0161 </r>
+        <r>  0.0014  0.0101  0.0101  0.0004  0.0028  0.0004  0.0018  0.0516  0.0023 </r>
+       </set>
+      </set>
+      <set comment="kpoint 111">
+       <set comment="band 1">
+        <r>  0.0039  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0012  0.9544  0.0000  0.0125 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0206  0.0136  0.0000  0.9430 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9744  0.0000  0.0000  0.0029  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9577  0.0003  0.0000  0.0216 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0029  0.0000  0.0000  0.9772  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6043  0.0002  0.0011  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0514  0.0029  0.0027  0.0000  0.0000  0.0000  0.0118  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0737  0.0122  0.0076  0.0000  0.0000  0.0000  0.0025  0.0000  0.0001 </r>
+        <r>  0.6038  0.0015  0.0001  0.0000  0.0000  0.0001  0.0010  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0051  0.0020  0.2300  0.0000  0.0000  0.0004  0.0015  0.0000  0.0000 </r>
+        <r>  0.0218  0.0001  0.1190  0.0000  0.0000  0.0007  0.0030  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.2807  0.0007  0.0000  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1240  0.0015  0.0000  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0085  0.3268  0.0001  0.0000  0.0000  0.0001  0.0015  0.0000  0.0007 </r>
+        <r>  0.0388  0.0998  0.0008  0.0000  0.0000  0.0006  0.0017  0.0000  0.0034 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0249  0.1421  0.0041  0.0000  0.0000  0.0028  0.0021  0.0000  0.0140 </r>
+        <r>  0.0124  0.3053  0.0004  0.0000  0.0000  0.0004  0.0014  0.0000  0.0062 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0000  0.0000  0.0989  0.0599  0.0000  0.0000  0.0004  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0227  0.0371  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0123  0.0021  0.3085  0.0000  0.0000  0.0055  0.0119  0.0000  0.0007 </r>
+        <r>  0.0145  0.0076  0.2563  0.0000  0.0000  0.0001  0.0055  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.1756  0.0078  0.0000  0.0000  0.0036  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3361  0.0152  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0006  0.0128  0.0058  0.0000  0.0000  0.0728  0.0128  0.0000  0.0041 </r>
+        <r>  0.0081  0.0163  0.0865  0.0000  0.0000  0.0306  0.0000  0.0000  0.0014 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0255  0.0000  0.0019  0.0000  0.0000  0.0146  0.0255  0.0000  0.1149 </r>
+        <r>  0.0436  0.0014  0.0015  0.0000  0.0000  0.0015  0.0079  0.0000  0.0545 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0000  0.0000  0.0029  0.0048  0.0000  0.0000  0.1808  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0544  0.0004  0.0000  0.0000  0.0146  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0408  0.0357  0.0000  0.0000  0.0881  0.0237  0.0000  0.0867 </r>
+        <r>  0.0097  0.0000  0.0020  0.0000  0.0000  0.0078  0.0012  0.0000  0.0257 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0132  0.0108  0.0035  0.0000  0.0000  0.0087  0.0005  0.0002  0.0321 </r>
+        <r>  0.0064  0.0089  0.0489  0.0000  0.0000  0.0149  0.0042  0.0001  0.0123 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0000  0.0000  0.0252  0.0051  0.0001  0.0003  0.1677  0.0003 </r>
+        <r>  0.0001  0.0004  0.0000  0.0004  0.0004  0.0002  0.0001  0.0768  0.0001 </r>
+       </set>
+      </set>
+      <set comment="kpoint 112">
+       <set comment="band 1">
+        <r>  0.0041  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0011  0.0010  0.9323  0.0000  0.0337 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0020  0.0119  0.0343  0.0004  0.9283 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9719  0.0002  0.0016  0.0023  0.0015 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0005  0.9597  0.0002  0.0068  0.0122 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0021  0.0065  0.0001  0.9706  0.0010 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6416  0.0001  0.0004  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0252  0.0043  0.0013  0.0003  0.0000  0.0000  0.0126  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0341  0.0155  0.0040  0.0012  0.0000  0.0000  0.0026  0.0000  0.0002 </r>
+        <r>  0.6307  0.0010  0.0001  0.0002  0.0000  0.0001  0.0003  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0030  0.0009  0.2334  0.0003  0.0000  0.0005  0.0007  0.0000  0.0000 </r>
+        <r>  0.0105  0.0000  0.1216  0.0001  0.0000  0.0011  0.0015  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0008  0.0004  0.0001  0.2686  0.0008  0.0000  0.0001  0.0001  0.0001 </r>
+        <r>  0.0030  0.0000  0.0001  0.1232  0.0019  0.0000  0.0001  0.0002  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0090  0.3452  0.0000  0.0000  0.0001  0.0000  0.0018  0.0000  0.0007 </r>
+        <r>  0.0495  0.0831  0.0004  0.0000  0.0002  0.0003  0.0026  0.0000  0.0052 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0300  0.1174  0.0014  0.0002  0.0005  0.0013  0.0027  0.0000  0.0155 </r>
+        <r>  0.0136  0.3175  0.0000  0.0000  0.0000  0.0002  0.0008  0.0000  0.0055 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0002  0.0001  0.0004  0.1559  0.0530  0.0000  0.0000  0.0004  0.0011 </r>
+        <r>  0.0005  0.0037  0.0003  0.0506  0.0268  0.0000  0.0002  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0070  0.0010  0.3214  0.0011  0.0009  0.0119  0.0061  0.0007  0.0007 </r>
+        <r>  0.0068  0.0032  0.2274  0.0039  0.0008  0.0002  0.0037  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0017  0.0001  0.0064  0.1255  0.0147  0.0002  0.0015  0.0013  0.0016 </r>
+        <r>  0.0034  0.0009  0.0066  0.3016  0.0235  0.0000  0.0000  0.0001  0.0009 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0028  0.0052  0.0000  0.0001  0.0000  0.0710  0.0051  0.0001  0.0005 </r>
+        <r>  0.0023  0.0061  0.1168  0.0000  0.0000  0.0391  0.0006  0.0001  0.0002 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0174  0.0012  0.0053  0.0123  0.0003  0.0072  0.0361  0.0023  0.1065 </r>
+        <r>  0.0476  0.0001  0.0067  0.0083  0.0001  0.0003  0.0045  0.0021  0.0470 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0017  0.0000  0.0000  0.0026  0.0034  0.0011  0.0003  0.2182  0.0092 </r>
+        <r>  0.0012  0.0000  0.0123  0.0292  0.0002  0.0000  0.0003  0.0009  0.0026 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0188  0.0116  0.0370  0.0006  0.0019  0.0245  0.0380  0.0000  0.0806 </r>
+        <r>  0.0036  0.0006  0.0014  0.0115  0.0001  0.0008  0.0263  0.0100  0.0217 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0005  0.0126  0.0021  0.0037  0.0015  0.0016  0.0891  0.0011  0.0017 </r>
+        <r>  0.0356  0.0013  0.0583  0.0100  0.0001  0.0018  0.0103  0.0279  0.0028 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0017  0.0015  0.0035  0.0144  0.0040  0.0107  0.0054  0.1376  0.0143 </r>
+        <r>  0.0012  0.0016  0.0218  0.0036  0.0001  0.0002  0.0043  0.0212  0.0041 </r>
+       </set>
+      </set>
+      <set comment="kpoint 113">
+       <set comment="band 1">
+        <r>  0.0039  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0048  0.0005  0.8889  0.0000  0.0745 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0062  0.0033  0.0725  0.0004  0.8942 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9646  0.0009  0.0077  0.0013  0.0033 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0014  0.9607  0.0001  0.0136  0.0032 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0009  0.0136  0.0001  0.9649  0.0008 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6674  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0046  0.0056  0.0003  0.0011  0.0000  0.0000  0.0121  0.0000  0.0013 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0053  0.0175  0.0011  0.0041  0.0000  0.0000  0.0024  0.0000  0.0003 </r>
+        <r>  0.6468  0.0003  0.0001  0.0004  0.0001  0.0000  0.0000  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0010  0.0002  0.2396  0.0003  0.0000  0.0006  0.0002  0.0001  0.0000 </r>
+        <r>  0.0025  0.0000  0.1234  0.0001  0.0000  0.0015  0.0004  0.0002  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0031  0.0014  0.0001  0.2591  0.0009  0.0000  0.0003  0.0000  0.0004 </r>
+        <r>  0.0099  0.0001  0.0001  0.1207  0.0019  0.0000  0.0003  0.0001  0.0011 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0071  0.3745  0.0000  0.0000  0.0002  0.0000  0.0019  0.0000  0.0005 </r>
+        <r>  0.0602  0.0566  0.0001  0.0001  0.0006  0.0001  0.0034  0.0000  0.0075 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0360  0.0823  0.0003  0.0004  0.0013  0.0003  0.0032  0.0000  0.0163 </r>
+        <r>  0.0111  0.3377  0.0000  0.0002  0.0000  0.0001  0.0003  0.0000  0.0038 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0030  0.0005  0.0011  0.2418  0.0319  0.0000  0.0001  0.0003  0.0058 </r>
+        <r>  0.0049  0.0064  0.0005  0.1437  0.0089  0.0000  0.0009  0.0000  0.0024 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0014  0.0004  0.3229  0.0004  0.0007  0.0223  0.0017  0.0017  0.0001 </r>
+        <r>  0.0023  0.0008  0.1894  0.0000  0.0003  0.0021  0.0010  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0064  0.0017  0.0012  0.0331  0.0375  0.0000  0.0024  0.0001  0.0028 </r>
+        <r>  0.0038  0.0045  0.0016  0.1983  0.0400  0.0000  0.0001  0.0000  0.0014 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0016  0.0011  0.0110  0.0000  0.0000  0.0581  0.0019  0.0007  0.0001 </r>
+        <r>  0.0009  0.0012  0.1703  0.0000  0.0000  0.0418  0.0005  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0003  0.0007  0.0056  0.0036  0.0001  0.0095  0.0125  0.1245  0.0015 </r>
+        <r>  0.0066  0.0000  0.0390  0.0048  0.0000  0.0002  0.0009  0.0154  0.0013 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0026  0.0065  0.0088  0.0156  0.0050  0.0005  0.1218  0.0354  0.0137 </r>
+        <r>  0.0586  0.0006  0.0174  0.0019  0.0002  0.0000  0.0182  0.0002  0.0081 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0500  0.0003  0.0019  0.0224  0.0003  0.0001  0.0113  0.0069  0.1593 </r>
+        <r>  0.0024  0.0011  0.0038  0.0239  0.0000  0.0000  0.0496  0.0000  0.0448 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0030  0.0039  0.0016  0.0035  0.0023  0.0535  0.0611  0.0118 </r>
+        <r>  0.0237  0.0002  0.0087  0.0434  0.0001  0.0001  0.0032  0.0268  0.0087 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0004  0.0046  0.0137  0.0105  0.0049  0.0146  0.0063  0.1463  0.0052 </r>
+        <r>  0.0019  0.0005  0.0033  0.0176  0.0001  0.0006  0.0005  0.0001  0.0003 </r>
+       </set>
+      </set>
+      <set comment="kpoint 114">
+       <set comment="band 1">
+        <r>  0.0035  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0101  0.0000  0.8108  0.0000  0.1485 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0133  0.0000  0.1408  0.0000  0.8222 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9549  0.0000  0.0189  0.0000  0.0045 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9578  0.0000  0.0208  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0208  0.0000  0.9592  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6671  0.0001  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0012  0.0062  0.0000  0.0025  0.0000  0.0000  0.0100  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0023  0.0181  0.0000  0.0077  0.0000  0.0000  0.0021  0.0000  0.0003 </r>
+        <r>  0.6408  0.0000  0.0000  0.0003  0.0002  0.0000  0.0003  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2476  0.0000  0.0000  0.0008  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.1240  0.0000  0.0000  0.0018  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0058  0.0028  0.0000  0.2534  0.0009  0.0000  0.0006  0.0000  0.0008 </r>
+        <r>  0.0184  0.0001  0.0000  0.1170  0.0018  0.0000  0.0007  0.0000  0.0025 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0028  0.4176  0.0000  0.0001  0.0003  0.0000  0.0015  0.0000  0.0001 </r>
+        <r>  0.0708  0.0200  0.0000  0.0005  0.0011  0.0000  0.0040  0.0000  0.0100 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0424  0.0325  0.0000  0.0008  0.0022  0.0000  0.0040  0.0000  0.0165 </r>
+        <r>  0.0048  0.3671  0.0000  0.0003  0.0000  0.0000  0.0000  0.0000  0.0013 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0099  0.0006  0.0000  0.2627  0.0141  0.0000  0.0007  0.0000  0.0114 </r>
+        <r>  0.0129  0.0058  0.0000  0.2251  0.0008  0.0000  0.0016  0.0000  0.0044 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2983  0.0000  0.0000  0.0302  0.0000  0.0031  0.0000 </r>
+        <r>  0.0000  0.0000  0.1538  0.0000  0.0000  0.0052  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0067  0.0059  0.0000  0.0001  0.0584  0.0000  0.0034  0.0000  0.0015 </r>
+        <r>  0.0020  0.0121  0.0000  0.1029  0.0460  0.0000  0.0000  0.0000  0.0008 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0296  0.0000  0.0000  0.0468  0.0000  0.0019  0.0000 </r>
+        <r>  0.0000  0.0000  0.2087  0.0000  0.0000  0.0414  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0000  0.0000  0.0017  0.0000  0.0000  0.0085  0.0000  0.1255  0.0000 </r>
+        <r>  0.0000  0.0000  0.0598  0.0000  0.0000  0.0004  0.0000  0.0245  0.0000 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0209  0.0050  0.0000  0.0070  0.0052  0.0000  0.1480  0.0000  0.0001 </r>
+        <r>  0.0549  0.0007  0.0000  0.0031  0.0003  0.0000  0.0495  0.0000  0.0009 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0275  0.0031  0.0000  0.0688  0.0127  0.0000  0.0021  0.0000  0.1547 </r>
+        <r>  0.0080  0.0016  0.0000  0.0244  0.0007  0.0000  0.0304  0.0000  0.0317 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0268  0.0000  0.0000  0.0111  0.0001  0.2402  0.0000 </r>
+        <r>  0.0000  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0408  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0071  0.0000  0.0019  0.0028  0.0000  0.0552  0.0001  0.0114 </r>
+        <r>  0.0229  0.0000  0.0000  0.0952  0.0006  0.0000  0.0014  0.0000  0.0115 </r>
+       </set>
+      </set>
+      <set comment="kpoint 115">
+       <set comment="band 1">
+        <r>  0.0047  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.9543  0.0000  0.0124 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0026  0.0127  0.0000  0.9621 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9769  0.0000  0.0000  0.0003  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9769  0.0000  0.0000  0.0027 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0003  0.0000  0.0000  0.9801  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6357  0.0001  0.0001  0.0000  0.0000  0.0000  0.0002  0.0000  0.0000 </r>
+        <r>  0.0351  0.0031  0.0004  0.0000  0.0000  0.0000  0.0152  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0468  0.0128  0.0012  0.0000  0.0000  0.0000  0.0033  0.0000  0.0001 </r>
+        <r>  0.6400  0.0013  0.0000  0.0000  0.0000  0.0000  0.0005  0.0000  0.0002 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0007  0.0002  0.2298  0.0000  0.0000  0.0003  0.0002  0.0000  0.0000 </r>
+        <r>  0.0033  0.0000  0.1240  0.0000  0.0000  0.0008  0.0004  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.2766  0.0007  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1249  0.0015  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0092  0.3214  0.0000  0.0000  0.0000  0.0000  0.0014  0.0000  0.0007 </r>
+        <r>  0.0368  0.1031  0.0001  0.0000  0.0000  0.0001  0.0019  0.0000  0.0033 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0230  0.1579  0.0005  0.0000  0.0000  0.0004  0.0024  0.0000  0.0150 </r>
+        <r>  0.0144  0.3180  0.0000  0.0000  0.0000  0.0001  0.0010  0.0000  0.0066 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0000  0.0000  0.0818  0.0625  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0123  0.0407  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.0000  0.2041  0.0048  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3573  0.0119  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0019  0.0004  0.3674  0.0000  0.0000  0.0121  0.0020  0.0000  0.0002 </r>
+        <r>  0.0021  0.0013  0.2359  0.0000  0.0000  0.0003  0.0011  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0008  0.0016  0.0016  0.0000  0.0000  0.0788  0.0024  0.0000  0.0001 </r>
+        <r>  0.0012  0.0017  0.1374  0.0000  0.0000  0.0355  0.0003  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0288  0.0000  0.0005  0.0000  0.0000  0.0018  0.0274  0.0000  0.1702 </r>
+        <r>  0.0485  0.0002  0.0043  0.0000  0.0000  0.0001  0.0088  0.0000  0.0729 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0072  0.0154  0.0195  0.0001  0.0001  0.0246  0.0589  0.0122  0.0505 </r>
+        <r>  0.0173  0.0001  0.0143  0.0008  0.0000  0.0000  0.0137  0.0001  0.0140 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0002  0.0007  0.0008  0.0006  0.0010  0.0010  0.0023  0.3199  0.0022 </r>
+        <r>  0.0008  0.0000  0.0006  0.0145  0.0000  0.0000  0.0004  0.0018  0.0006 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0021  0.0155  0.0000  0.0002  0.0001  0.0007  0.1116  0.0004  0.0015 </r>
+        <r>  0.0479  0.0009  0.0639  0.0003  0.0000  0.0004  0.0138  0.0006  0.0005 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0227  0.0125  0.0002  0.0176  0.0062  0.0018  0.0015  0.0264  0.0192 </r>
+        <r>  0.0022  0.0187  0.0006  0.0292  0.0002  0.0000  0.0206  0.0192  0.0078 </r>
+       </set>
+      </set>
+      <set comment="kpoint 116">
+       <set comment="band 1">
+        <r>  0.0045  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0010  0.0000  0.9333  0.0000  0.0331 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0004  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0024  0.0000  0.0329  0.0000  0.9418 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9741  0.0000  0.0017  0.0000  0.0018 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9749  0.0000  0.0045  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0045  0.0000  0.9759  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6562  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0178  0.0045  0.0000  0.0003  0.0000  0.0000  0.0144  0.0000  0.0008 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0225  0.0159  0.0000  0.0012  0.0000  0.0000  0.0030  0.0000  0.0002 </r>
+        <r>  0.6497  0.0009  0.0000  0.0002  0.0000  0.0000  0.0001  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2342  0.0000  0.0000  0.0005  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.1245  0.0000  0.0000  0.0012  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0009  0.0004  0.0000  0.2669  0.0008  0.0000  0.0001  0.0000  0.0001 </r>
+        <r>  0.0027  0.0000  0.0000  0.1237  0.0019  0.0000  0.0001  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0095  0.3415  0.0000  0.0000  0.0001  0.0000  0.0018  0.0000  0.0008 </r>
+        <r>  0.0484  0.0856  0.0000  0.0000  0.0002  0.0000  0.0027  0.0000  0.0052 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0292  0.1264  0.0000  0.0002  0.0006  0.0000  0.0028  0.0000  0.0161 </r>
+        <r>  0.0147  0.3230  0.0000  0.0000  0.0001  0.0000  0.0007  0.0000  0.0058 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0001  0.0001  0.0000  0.1427  0.0560  0.0000  0.0000  0.0000  0.0010 </r>
+        <r>  0.0005  0.0039  0.0000  0.0391  0.0297  0.0000  0.0001  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0031  0.0001  0.0000  0.1463  0.0123  0.0000  0.0006  0.0000  0.0020 </r>
+        <r>  0.0021  0.0005  0.0000  0.3234  0.0217  0.0000  0.0002  0.0000  0.0010 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.3546  0.0000  0.0000  0.0202  0.0000  0.0006  0.0000 </r>
+        <r>  0.0000  0.0000  0.2040  0.0000  0.0000  0.0015  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0115  0.0000  0.0000  0.0659  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.1741  0.0000  0.0000  0.0396  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0275  0.0008  0.0000  0.0123  0.0003  0.0000  0.0351  0.0000  0.1780 </r>
+        <r>  0.0551  0.0000  0.0000  0.0069  0.0000  0.0000  0.0078  0.0000  0.0709 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0000  0.0037  0.0000  0.0000  0.0083  0.0000  0.1595  0.0000 </r>
+        <r>  0.0000  0.0000  0.0479  0.0000  0.0000  0.0001  0.0000  0.0100  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0304  0.0119  0.0000  0.0005  0.0010  0.0000  0.1669  0.0000  0.0183 </r>
+        <r>  0.0461  0.0013  0.0000  0.0045  0.0001  0.0000  0.0585  0.0000  0.0024 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0000  0.0000  0.0121  0.0000  0.0000  0.0112  0.0000  0.2189  0.0000 </r>
+        <r>  0.0000  0.0000  0.0218  0.0000  0.0000  0.0000  0.0000  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0007  0.0015  0.0000  0.0203  0.0114  0.0000  0.0190  0.0000  0.0004 </r>
+        <r>  0.0063  0.0005  0.0000  0.0577  0.0002  0.0000  0.0022  0.0001  0.0008 </r>
+       </set>
+      </set>
+      <set comment="kpoint 117">
+       <set comment="band 1">
+        <r>  0.0035  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0046  0.8733  0.0000  0.0915 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0236  0.0966  0.0000  0.8564 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9700  0.0000  0.0000  0.0079  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9508  0.0003  0.0000  0.0280 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0080  0.0000  0.0000  0.9721  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6405  0.0002  0.0006  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0216  0.0052  0.0026  0.0000  0.0000  0.0000  0.0098  0.0000  0.0015 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0310  0.0171  0.0075  0.0000  0.0000  0.0000  0.0019  0.0000  0.0004 </r>
+        <r>  0.6221  0.0007  0.0001  0.0000  0.0000  0.0001  0.0003  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0057  0.0023  0.2396  0.0000  0.0000  0.0007  0.0014  0.0000  0.0000 </r>
+        <r>  0.0196  0.0000  0.1181  0.0000  0.0000  0.0014  0.0031  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.2624  0.0009  0.0000  0.0000  0.0002  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1238  0.0020  0.0000  0.0000  0.0005  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0050  0.3991  0.0000  0.0000  0.0000  0.0000  0.0017  0.0000  0.0003 </r>
+        <r>  0.0639  0.0429  0.0009  0.0000  0.0000  0.0007  0.0034  0.0000  0.0081 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0386  0.0520  0.0020  0.0000  0.0000  0.0024  0.0036  0.0000  0.0159 </r>
+        <r>  0.0070  0.3478  0.0000  0.0000  0.0000  0.0003  0.0003  0.0000  0.0032 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0000  0.0000  0.2094  0.0470  0.0000  0.0000  0.0015  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0802  0.0182  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0112  0.0010  0.2875  0.0000  0.0000  0.0101  0.0116  0.0000  0.0008 </r>
+        <r>  0.0142  0.0058  0.2412  0.0000  0.0000  0.0000  0.0058  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.0917  0.0244  0.0000  0.0000  0.0030  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.2804  0.0319  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0042  0.0091  0.0013  0.0000  0.0000  0.0682  0.0055  0.0000  0.0015 </r>
+        <r>  0.0023  0.0125  0.0917  0.0000  0.0000  0.0416  0.0004  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0244  0.0021  0.0048  0.0000  0.0000  0.0071  0.0342  0.0000  0.1095 </r>
+        <r>  0.0516  0.0000  0.0038  0.0000  0.0000  0.0004  0.0080  0.0000  0.0487 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0000  0.0000  0.0000  0.0027  0.0071  0.0000  0.0000  0.1470  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0558  0.0004  0.0000  0.0000  0.0202  0.0000 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0119  0.0196  0.0665  0.0000  0.0000  0.0481  0.0432  0.0000  0.0722 </r>
+        <r>  0.0044  0.0021  0.0091  0.0000  0.0000  0.0052  0.0229  0.0000  0.0133 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0008  0.0071  0.0000  0.0120  0.0031  0.0006  0.0177  0.0989  0.0087 </r>
+        <r>  0.0107  0.0008  0.0507  0.0000  0.0001  0.0026  0.0010  0.0285  0.0039 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0038  0.0133  0.0001  0.0128  0.0032  0.0066  0.0030  0.1068  0.0058 </r>
+        <r>  0.0060  0.0008  0.0353  0.0001  0.0001  0.0061  0.0004  0.0297  0.0022 </r>
+       </set>
+      </set>
+      <set comment="kpoint 118">
+       <set comment="band 1">
+        <r>  0.0038  0.0000  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0011  0.0032  0.7813  0.0000  0.1834 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0025  0.0109  0.1864  0.0004  0.7763 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9610  0.0070  0.0026  0.0062  0.0016 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0083  0.9551  0.0001  0.0020  0.0131 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0053  0.0024  0.0002  0.9717  0.0006 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6679  0.0000  0.0002  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0028  0.0061  0.0013  0.0003  0.0000  0.0000  0.0101  0.0000  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0040  0.0185  0.0040  0.0011  0.0000  0.0000  0.0020  0.0000  0.0006 </r>
+        <r>  0.6457  0.0001  0.0002  0.0001  0.0000  0.0001  0.0000  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0037  0.0001  0.1225  0.1286  0.0004  0.0004  0.0001  0.0001  0.0000 </r>
+        <r>  0.0011  0.0000  0.0596  0.0618  0.0010  0.0009  0.0011  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0003  0.0013  0.1219  0.1236  0.0004  0.0004  0.0006  0.0000  0.0001 </r>
+        <r>  0.0116  0.0000  0.0616  0.0615  0.0010  0.0009  0.0004  0.0003  0.0002 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0008  0.4435  0.0000  0.0000  0.0000  0.0000  0.0011  0.0000  0.0000 </r>
+        <r>  0.0733  0.0069  0.0003  0.0001  0.0001  0.0004  0.0039  0.0000  0.0108 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0446  0.0081  0.0007  0.0001  0.0003  0.0012  0.0048  0.0000  0.0165 </r>
+        <r>  0.0012  0.3863  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000  0.0008 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0041  0.0000  0.1100  0.1649  0.0221  0.0070  0.0018  0.0014  0.0021 </r>
+        <r>  0.0004  0.0050  0.0729  0.0792  0.0057  0.0006  0.0024  0.0000  0.0005 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0015  0.0010  0.1860  0.0957  0.0152  0.0137  0.0044  0.0000  0.0000 </r>
+        <r>  0.0084  0.0006  0.1253  0.0457  0.0041  0.0013  0.0014  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0017  0.0008  0.0002  0.0487  0.0359  0.0001  0.0011  0.0011  0.0014 </r>
+        <r>  0.0017  0.0006  0.0015  0.2332  0.0385  0.0001  0.0000  0.0001  0.0007 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0050  0.0033  0.0056  0.0002  0.0002  0.0552  0.0040  0.0002  0.0003 </r>
+        <r>  0.0019  0.0050  0.1456  0.0005  0.0002  0.0437  0.0010  0.0000  0.0001 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0104  0.0037  0.0092  0.0161  0.0042  0.0037  0.0409  0.0256  0.0774 </r>
+        <r>  0.0456  0.0001  0.0001  0.0008  0.0002  0.0002  0.0014  0.0074  0.0311 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0023  0.0006  0.0009  0.0001  0.0029  0.0026  0.0076  0.1577  0.0159 </r>
+        <r>  0.0087  0.0000  0.0133  0.0495  0.0001  0.0000  0.0011  0.0026  0.0077 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0409  0.0023  0.0363  0.0000  0.0004  0.0067  0.0697  0.0118  0.0732 </r>
+        <r>  0.0043  0.0018  0.0088  0.0047  0.0000  0.0001  0.0602  0.0035  0.0122 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0005  0.0044  0.0000  0.0036  0.0020  0.0015  0.0805  0.0171  0.0100 </r>
+        <r>  0.0323  0.0002  0.0592  0.0080  0.0001  0.0002  0.0106  0.0301  0.0076 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0001  0.0001  0.0093  0.0151  0.0062  0.0102  0.0014  0.1607  0.0103 </r>
+        <r>  0.0015  0.0000  0.0153  0.0030  0.0000  0.0002  0.0001  0.0071  0.0018 </r>
+       </set>
+      </set>
+      <set comment="kpoint 119">
+       <set comment="band 1">
+        <r>  0.0042  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0005  0.8811  0.0000  0.0865 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0001 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0035  0.0879  0.0000  0.8854 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9771  0.0000  0.0000  0.0008  0.0000 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9750  0.0000  0.0000  0.0039 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0008  0.0000  0.0000  0.9796  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6646  0.0000  0.0001  0.0000  0.0000  0.0000  0.0001  0.0000  0.0000 </r>
+        <r>  0.0092  0.0055  0.0004  0.0000  0.0000  0.0000  0.0127  0.0000  0.0016 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0120  0.0179  0.0011  0.0000  0.0000  0.0000  0.0027  0.0000  0.0004 </r>
+        <r>  0.6525  0.0004  0.0001  0.0000  0.0000  0.0000  0.0000  0.0000  0.0004 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0008  0.0003  0.2380  0.0000  0.0000  0.0006  0.0002  0.0000  0.0000 </r>
+        <r>  0.0030  0.0000  0.1237  0.0000  0.0000  0.0015  0.0004  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0000  0.0000  0.0000  0.2586  0.0009  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.1244  0.0021  0.0000  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0063  0.3885  0.0000  0.0000  0.0000  0.0000  0.0018  0.0000  0.0004 </r>
+        <r>  0.0609  0.0517  0.0001  0.0000  0.0000  0.0001  0.0035  0.0000  0.0078 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0371  0.0703  0.0003  0.0000  0.0000  0.0003  0.0035  0.0000  0.0168 </r>
+        <r>  0.0095  0.3524  0.0000  0.0000  0.0000  0.0001  0.0002  0.0000  0.0038 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0000  0.0000  0.0000  0.1847  0.0536  0.0000  0.0000  0.0001  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0549  0.0234  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0013  0.0003  0.3266  0.0000  0.0000  0.0247  0.0018  0.0000  0.0002 </r>
+        <r>  0.0020  0.0014  0.1857  0.0000  0.0000  0.0027  0.0011  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0000  0.0000  0.0000  0.1279  0.0174  0.0000  0.0000  0.0005  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.3174  0.0272  0.0000  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0016  0.0011  0.0162  0.0000  0.0000  0.0558  0.0020  0.0000  0.0001 </r>
+        <r>  0.0010  0.0011  0.1835  0.0000  0.0000  0.0415  0.0005  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0273  0.0022  0.0014  0.0000  0.0000  0.0018  0.0375  0.0000  0.1522 </r>
+        <r>  0.0586  0.0001  0.0037  0.0000  0.0000  0.0001  0.0079  0.0000  0.0609 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0363  0.0077  0.0179  0.0000  0.0000  0.0052  0.1440  0.0000  0.0282 </r>
+        <r>  0.0308  0.0016  0.0014  0.0000  0.0000  0.0000  0.0632  0.0000  0.0030 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0000  0.0023  0.0034  0.0000  0.0000  0.2762  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0255  0.0001  0.0000  0.0000  0.0004  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0001  0.0014  0.0082  0.0000  0.0000  0.0121  0.0323  0.0000  0.0094 </r>
+        <r>  0.0159  0.0001  0.0734  0.0000  0.0000  0.0000  0.0036  0.0000  0.0047 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0000  0.0199  0.0102  0.0000  0.0000  0.0986  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0301  0.0002  0.0000  0.0000  0.0215  0.0000 </r>
+       </set>
+      </set>
+      <set comment="kpoint 120">
+       <set comment="band 1">
+        <r>  0.0041  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0011  0.0000  0.7912  0.0000  0.1761 </r>
+       </set>
+       <set comment="band 2">
+        <r>  0.0000  0.0005  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0027  0.0000  0.1760  0.0000  0.7978 </r>
+       </set>
+       <set comment="band 3">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.9744  0.0000  0.0027  0.0000  0.0011 </r>
+       </set>
+       <set comment="band 4">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.9768  0.0000  0.0018  0.0000 </r>
+       </set>
+       <set comment="band 5">
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.0000  0.0000  0.0000  0.0018  0.0000  0.9785  0.0000 </r>
+       </set>
+       <set comment="band 6">
+        <r>  0.6748  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000 </r>
+        <r>  0.0005  0.0062  0.0000  0.0003  0.0000  0.0000  0.0114  0.0000  0.0027 </r>
+       </set>
+       <set comment="band 7">
+        <r>  0.0006  0.0190  0.0000  0.0011  0.0000  0.0000  0.0024  0.0000  0.0006 </r>
+        <r>  0.6586  0.0000  0.0000  0.0001  0.0000  0.0000  0.0001  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 8">
+        <r>  0.0000  0.0000  0.2443  0.0000  0.0000  0.0008  0.0000  0.0000  0.0000 </r>
+        <r>  0.0000  0.0000  0.1244  0.0000  0.0000  0.0019  0.0000  0.0001  0.0000 </r>
+       </set>
+       <set comment="band 9">
+        <r>  0.0009  0.0003  0.0000  0.2504  0.0008  0.0000  0.0001  0.0000  0.0001 </r>
+        <r>  0.0028  0.0000  0.0000  0.1236  0.0020  0.0000  0.0001  0.0000  0.0003 </r>
+       </set>
+       <set comment="band 10">
+        <r>  0.0014  0.4407  0.0000  0.0000  0.0000  0.0000  0.0012  0.0000  0.0000 </r>
+        <r>  0.0721  0.0106  0.0000  0.0000  0.0001  0.0000  0.0040  0.0000  0.0106 </r>
+       </set>
+       <set comment="band 11">
+        <r>  0.0442  0.0147  0.0000  0.0001  0.0003  0.0000  0.0047  0.0000  0.0171 </r>
+        <r>  0.0021  0.3904  0.0000  0.0000  0.0000  0.0000  0.0000  0.0000  0.0011 </r>
+       </set>
+       <set comment="band 12">
+        <r>  0.0007  0.0003  0.0000  0.2527  0.0410  0.0000  0.0000  0.0000  0.0015 </r>
+        <r>  0.0014  0.0018  0.0000  0.1112  0.0118  0.0000  0.0003  0.0000  0.0006 </r>
+       </set>
+       <set comment="band 13">
+        <r>  0.0000  0.0000  0.2898  0.0000  0.0000  0.0366  0.0000  0.0003  0.0000 </r>
+        <r>  0.0000  0.0000  0.1336  0.0000  0.0000  0.0079  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 14">
+        <r>  0.0024  0.0006  0.0000  0.0633  0.0323  0.0000  0.0007  0.0000  0.0015 </r>
+        <r>  0.0014  0.0007  0.0000  0.2544  0.0369  0.0000  0.0001  0.0000  0.0007 </r>
+       </set>
+       <set comment="band 15">
+        <r>  0.0000  0.0000  0.0498  0.0000  0.0000  0.0403  0.0000  0.0003  0.0000 </r>
+        <r>  0.0000  0.0000  0.2417  0.0000  0.0000  0.0393  0.0000  0.0000  0.0000 </r>
+       </set>
+       <set comment="band 16">
+        <r>  0.0057  0.0079  0.0000  0.0063  0.0020  0.0000  0.1906  0.0000  0.0158 </r>
+        <r>  0.0890  0.0003  0.0000  0.0004  0.0001  0.0000  0.0299  0.0000  0.0133 </r>
+       </set>
+       <set comment="band 17">
+        <r>  0.0613  0.0003  0.0000  0.0085  0.0002  0.0000  0.0053  0.0000  0.1664 </r>
+        <r>  0.0077  0.0016  0.0000  0.0098  0.0000  0.0000  0.0535  0.0000  0.0451 </r>
+       </set>
+       <set comment="band 18">
+        <r>  0.0000  0.0000  0.0038  0.0000  0.0000  0.0063  0.0000  0.2066  0.0000 </r>
+        <r>  0.0000  0.0000  0.0373  0.0000  0.0000  0.0001  0.0000  0.0051  0.0000 </r>
+       </set>
+       <set comment="band 19">
+        <r>  0.0004  0.0007  0.0000  0.0162  0.0139  0.0000  0.0236  0.0000  0.0009 </r>
+        <r>  0.0082  0.0000  0.0000  0.0623  0.0001  0.0000  0.0025  0.0000  0.0021 </r>
+       </set>
+       <set comment="band 20">
+        <r>  0.0000  0.0000  0.0157  0.0000  0.0000  0.0104  0.0000  0.1740  0.0000 </r>
+        <r>  0.0000  0.0000  0.0234  0.0000  0.0000  0.0000  0.0000  0.0078  0.0000 </r>
+       </set>
+      </set>
+     </set>
+    </set>
+   </array>
+  </projected>
+ </calculation>
+ <structure name="finalpos" >
+  <crystal>
+   <varray name="basis" >
+    <v>       0.00000000       3.28312200       3.28312200 </v>
+    <v>       3.28312200       0.00000000       3.28312200 </v>
+    <v>       3.28312200       3.28312200       0.00000000 </v>
+   </varray>
+   <i name="volume">     70.77682223 </i>
+   <varray name="rec_basis" >
+    <v>      -0.15229407       0.15229407       0.15229407 </v>
+    <v>       0.15229407      -0.15229407       0.15229407 </v>
+    <v>       0.15229407       0.15229407      -0.15229407 </v>
+   </varray>
+  </crystal>
+  <varray name="positions" >
+   <v>       0.00000000       0.00000000       0.00000000 </v>
+   <v>       0.50000000       0.50000000       0.50000000 </v>
+  </varray>
+ </structure>
+</modeling>


### PR DESCRIPTION
I implemented and tested (for PbTe case) a function that
calculate the DOS using the interpolator.
I guess a grid of energies is calculated somewhere else
for the transport properties, hence it could be faster to
pass directly energies and kpoints to perform just the sum.