### PR TITLE
fix mfp bug

### DIFF
--- a/amset/scattering/basic.py
+++ b/amset/scattering/basic.py
@@ -108,8 +108,8 @@ class MeanFreePathScattering(AbstractBasicScattering):
                 v, (len(amset_data.doping), len(amset_data.temperatures), 1, 1)
             )
 
-            rates2 = velocities * s_to_au / mfp
-            rates[spin] = rates2[..., amset_data.ir_to_full_kpoint_mapping]
+            spin_rates = velocities * s_to_au / mfp
+            rates[spin] = spin_rates[..., amset_data.ir_to_full_kpoint_mapping]
         return cls(
             cls.get_properties(materials_properties),
             amset_data.doping,

--- a/amset/scattering/basic.py
+++ b/amset/scattering/basic.py
@@ -108,8 +108,8 @@ class MeanFreePathScattering(AbstractBasicScattering):
                 v, (len(amset_data.doping), len(amset_data.temperatures), 1, 1)
             )
 
-            rates = velocities * s_to_au / mfp
-            rates[spin] = rates[..., amset_data.ir_to_full_kpoint_mapping]
+            rates2 = velocities * s_to_au / mfp
+            rates[spin] = rates2[..., amset_data.ir_to_full_kpoint_mapping]
         return cls(
             cls.get_properties(materials_properties),
             amset_data.doping,


### PR DESCRIPTION
when running with MFP scattering, this error occurs:
```
  File "/home/kieran/.local/lib/python3.7/site-
packages/amset/scattering/basic.py", line 113, in from_amset_data
    rates[spin] = rates[..., amset_data.ir_to_full_kpoint_mapping]
IndexError: only integers, slices (`:`), ellipsis (`...`),
numpy.newaxis (`None`) and integer or boolean arrays are valid
indices
```
resulting from rates not being a dictionary. I think this should fix that.