### PR TITLE
refactor: do not use deprecated `numpy.float`

### DIFF
--- a/amset/util.py
+++ b/amset/util.py
@@ -71,7 +71,7 @@ def validate_settings(user_settings: Dict[str, Any]) -> Dict[str, Any]:
             settings["piezoelectric_constant"]
         )
 
-    settings["doping"] = np.asarray(settings["doping"], dtype=np.float)
+    settings["doping"] = np.asarray(settings["doping"], dtype=float)
     settings["temperatures"] = np.asarray(settings["temperatures"])
 
     for charge_setting in ("donor_charge", "acceptor_charge"):


### PR DESCRIPTION
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

NumPy 1.24.3 raises error:

```
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```